### PR TITLE
(fix) repeat is a integer not string

### DIFF
--- a/dock-api/UCD2-asyncapi.yaml
+++ b/dock-api/UCD2-asyncapi.yaml
@@ -628,7 +628,7 @@ components:
           command: ir_send
           code: "4;0x10;12;1"
           format: "hex"
-          repeat: "3"
+          repeat: 3
           int_side: true
         - type: dock
           id: 4


### PR DESCRIPTION
AsyncAPI Studio gave me an error because repeat is an integer and not a string