### PR TITLE
refactor: rename `select_sound_mode` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Changed
+- Rename media-player `select_sound_mode` command parameter from `sound_mode` to `mode`.
+
 ---
 
 ## 0.8.0-alpha - 2023-07-15

--- a/doc/entities/entity_media_player.md
+++ b/doc/entities/entity_media_player.md
@@ -162,7 +162,7 @@ requests in `msg_data.cmd_id`.
 | menu              | -              | Menu                                                                     |
 | back              | -              | Back / exit function for menu navigation.                                |
 | select_source     | source         | Select an input source from the available sources.                       |
-| select_sound_mode | sound_mode     | Select a sound mode from the available modes.                            |
+| select_sound_mode | mode           | Select a sound mode from the available modes.                            |
 | 🚧 search         |                |                                                                          |
 
 ### Events
@@ -321,6 +321,26 @@ The integration may return other values, but the UI will most likely handle them
     "cmd_id": "shuffle",
     "params": {
       "shuffle": true
+    }
+  }
+}
+```
+
+### select_sound_mode
+
+Specify a sound mode value contained in the `sound_mode_list` attribute array.
+
+```json
+{
+  "kind": "req",
+  "id": 123,
+  "msg": "entity_command",
+  "msg_data": {
+    "entity_type": "media_player",
+    "entity_id": "media-1",
+    "cmd_id": "select_sound_mode",
+    "params": {
+      "mode": "MOVIE"
     }
   }
 }


### PR DESCRIPTION
The Core command metadata used `mode` instead of `sound_mode`. To avoid invalid user configurations and risky data migrations, we change the specification.

Caused by: unfoldedcircle/feature-and-bug-tracker#165