### PR TITLE
Migrate Core-API specification from core-simulator

### DIFF
--- a/.github/workflows/asyncapi.yml
+++ b/.github/workflows/asyncapi.yml
@@ -4,14 +4,14 @@ on:
   push:
     paths:
       - 'dock-api/**'
-      - 'websocket-api/**'
+      - 'core-api/websocket/**'
       - 'integration-api/**'
       - '.github/workflows/asyncapi.yml'
   pull_request:
     types: [ opened, synchronize, reopened ]
     paths:
       - 'dock-api/**'
-      - 'websocket-api/**'
+      - 'core-api/websocket/**'
       - 'integration-api/**'
       - '.github/workflows/asyncapi.yml'
 
@@ -21,20 +21,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-#      - name: Validate websocket-api
-#        uses: WaleedAshraf/asyncapi-github-action@v0.0.9
-#        with:
-#          filepath: './websocket-api/asyncapi.yaml'
+      - name: Validate websocket-api
+        uses: WaleedAshraf/asyncapi-github-action@v0.0.10
+        with:
+          filepath: './core-api/websocket/UCR2-asyncapi.yaml'
 
       - name: Validate integration-api
-        uses: WaleedAshraf/asyncapi-github-action@v0.0.9
+        uses: WaleedAshraf/asyncapi-github-action@v0.0.10
         with:
           filepath: './integration-api/asyncapi.yaml'
 
       - name: Validate dock-api
-        uses: WaleedAshraf/asyncapi-github-action@v0.0.9
+        uses: WaleedAshraf/asyncapi-github-action@v0.0.10
         with:
           filepath: './dock-api/UCD2-asyncapi.yaml'
 
@@ -51,6 +51,10 @@ jobs:
           fi;
           ag --version
 
+      - name: Generate core AsyncAPI HTML doc
+        run: |
+          ag ./core-api/websocket/UCR2-asyncapi.yaml @asyncapi/html-template -o ./static/api/ws --force-write
+
       - name: Generate integration AsyncAPI HTML doc
         run: |
           ag ./integration-api/asyncapi.yaml @asyncapi/html-template -o ./static/api/integration --force-write
@@ -59,15 +63,22 @@ jobs:
         run: |
           ag ./dock-api/UCD2-asyncapi.yaml @asyncapi/html-template -o ./static/api/dock --force-write
 
+      - name: Deploy core API GH page
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          branch: gh-pages
+          folder: ./static/api/ws
+          target-folder: ./ws
+
       - name: Deploy integration API GH page
-        uses: JamesIves/github-pages-deploy-action@v4.3.0
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           branch: gh-pages
           folder: ./static/api/integration
           target-folder: ./integration
 
       - name: Deploy dock API GH page
-        uses: JamesIves/github-pages-deploy-action@v4.3.0
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           branch: gh-pages
           folder: ./static/api/dock

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -3,13 +3,13 @@ name: OpenAPI
 on:
   push:
     paths:
-      - 'rest-api/**'
-#      - '.github/workflows/openapi.yml'
+      - 'core-api/rest/**'
+      - '.github/workflows/openapi.yml'
   pull_request:
     types: [ opened, synchronize, reopened ]
     paths:
-      - 'rest-api/**'
-#      - '.github/workflows/openapi.yml'
+      - 'core-api/rest/**'
+      - '.github/workflows/openapi.yml'
 
 jobs:
   validate:
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Validate
         uses: mbowman100/swagger-validator-action@master
         with:
           files: |
-            ./rest-api/openapi.yaml
+            ./core-api/rest/UCR2-openapi.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _Changes in the next release_
 ### Changed
 - Rename media-player `select_sound_mode` command parameter from `sound_mode` to `mode`.
 - Integration API: add `reconfigure` flag in `setup_driver` request message to reconfigure a driver.
+- Migrated REST- & WebSocket Core-APIs from the core-simulator repository to the `core-api` directory. 
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,9 @@ This repository contains API specifications of [Unfolded Circle Remote Two](http
 API definitions:
 
 - [WebSocket Integration API](./integration-api/README.md) defined with [AsyncAPI](https://www.asyncapi.com/).
-- [WebSocket Core API](https://github.com/unfoldedcircle/core-simulator/tree/main/core-api) defined with [AsyncAPI](https://www.asyncapi.com/)
-- [REST Core API](https://github.com/unfoldedcircle/core-simulator/tree/main/core-api) defined with [OpenAPI](https://www.openapis.org/)
+- [WebSocket Core API](./core-api/websocket/README.md) defined with [AsyncAPI](https://www.asyncapi.com/)
+- [REST Core API](./core-api/rest/README.md) defined with [OpenAPI](https://www.openapis.org/)
 - [WebSocket Dock API](./dock-api/README.md) defined with [AsyncAPI](https://www.asyncapi.com/)
-
-ℹ️  The Core-APIs will be migrated to this repository soon.
 
 Integration driver documentation:
 
@@ -68,16 +66,9 @@ We plan to release more examples in the future.
 ## Core APIs
 
 The Remote Two WebSockets & REST core APIs allow you to interact with the Unfolded Circle remote-core application and
-take full control of its features. The APIs are specialized for certain features, but otherwise contain the same
-functionality.
+take full control of its features.
 
-- The REST API adds:
-  - custom resource handling for uploading icons, images etc.
-  - user management and authentication handling.
-- The WebSockets API adds event subscription with asynchronous notifications. 
-
-The Remote Two acts as server. Whenever the remote enters standby it may choose to disconnect open WebSocket sessions.
-It is up to the client to reconnect again.
+See [core-api](./core-api) directory for more information.
 
 ## Other resources
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![AsyncAPI Validation](https://github.com/unfoldedcircle/core-api/actions/workflows/asyncapi.yml/badge.svg)](https://github.com/unfoldedcircle/core-api/actions/workflows/asyncapi.yml)
+[![AsyncAPI Validation](https://github.com/unfoldedcircle/core-api/actions/workflows/asyncapi.yml/badge.svg)](https://github.com/unfoldedcircle/core-api/actions/workflows/asyncapi.yml) 
+[![OpenAPI Validation](https://github.com/unfoldedcircle/core-api/actions/workflows/openapi.yml/badge.svg)](https://github.com/unfoldedcircle/core-api/actions/workflows/asyncapi.yml)
 
 # Unfolded Circle Core APIs
 

--- a/core-api/README.md
+++ b/core-api/README.md
@@ -1,0 +1,17 @@
+# Remote Two Core-APIs
+
+The Remote Two WebSockets & REST Core-APIs allow you to interact with the Unfolded Circle remote-core application and
+take full control of its features. The APIs are specialized for certain tasks, but otherwise contain the same
+functionality.
+
+- The REST API adds:
+    - Custom resource handling for uploading icons, images etc.
+    - User management and authentication handling.
+- The WebSockets API adds:
+    - Event subscription with asynchronous notifications.
+
+The API specifications are defined with [OpenAPI](https://swagger.io/specification/) & [AsyncAPI](https://www.asyncapi.com/)
+in YAML format.
+
+- [REST Core-API](rest)
+- [WebSocket Core-API](websocket)

--- a/core-api/rest/README.md
+++ b/core-api/rest/README.md
@@ -1,0 +1,29 @@
+# Core REST API
+
+The Core-API is defined with [OpenAPI](https://www.openapis.org/).
+
+You can use the online [Swagger Editor](https://editor.swagger.io/) to load and browse the specification or use your
+favorite IDE with OpenAPI support (e.g. IntelliJ or Visual Studio Code).
+
+- [OpenAPI YAML definition](UCR2-openapi.yaml).
+  - ℹ️ This is a bundled YAML file generated from individual definitions.
+  - Most OpenAPI tools only work with a single file.
+  - We might publish the original definitions at a later time.
+- See [/doc folder](../../doc/README.md) for further API documentation and information.
+
+## Postman Collection
+
+For explorative API testing the `remote-core_rest-api.postman_collection.json` collection can be imported into
+[Postman](https://www.postman.com/). It contains pre-defined requests and some helper scripts to propagate generated
+identifier keys to simplify common tasks.
+
+Postman also supports [importing OpenAPI definitions](https://learning.postman.com/docs/integrations/available-integrations/working-with-openAPI/).  
+
+### Configuration
+
+The admin user account password needs to be configured in the Postman collection:
+
+1. Open the `Remote Two Core-API` collection
+2. Select the `Variables` tab.
+3. Set the `apiPassword` and `apiKeyId` in the **CURRENT VALUE** column.  
+   This will keep the passwords local and won't save them in the collection or Postman cloud.

--- a/core-api/rest/README.md
+++ b/core-api/rest/README.md
@@ -1,4 +1,4 @@
-# Core REST API
+# Remote Two REST Core-API
 
 The Core-API is defined with [OpenAPI](https://www.openapis.org/).
 

--- a/core-api/rest/UCR2-openapi.yaml
+++ b/core-api/rest/UCR2-openapi.yaml
@@ -1,0 +1,13882 @@
+openapi: 3.0.3
+info:
+  title: Remote Two REST API
+  version: 0.30.2
+  contact:
+    name: API Support
+    url: 'https://github.com/unfoldedcircle/core-api/issues'
+  license:
+    name: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
+    url: 'https://creativecommons.org/licenses/by-sa/4.0/'
+  description: "The Unfolded Circle Remote Two REST API allows to configure the remote and manage custom resource files.\nFurthermore, API-keys for the WebSocket & REST APIs can be created.\n\n## Overview\n\nThe Remote Two WebSockets Core-API allows you to interact with the Unfolded Circle remote-core application and take\nfull control of its features.\n\nThe focus of the Core-API is to provide all functionality for the UI application and the web-configurator.  \nIt may also be used by other external systems and integration drivers, if specific configuration or interaction\nfeatures are required, which are not present in the Integration API.\n\n## Authentication\n\nAll API endpoints besides `/api/pub` are secured. Available authentication methods are:\n- `Basic Auth` for every request.  \n  This should only be used for simple testing. At the moment there's only a single user account available for the\n  web-configurator.\n  - User: `web-configurator`\n  - Password: generated pin shown in the remote UI\n- `Bearer Token` for ever request.  \n  This is the preferred authentication method for external systems communicating with the Remote Two.\n  - See `/auth/api_keys` endpoints on how to create and manage API keys.\n  - Only the `admin` role is supported at the moment. More roles will be added in the future.\n  - Example for a curl request:  \n    `curl 'http://$IP/api/system' --header 'Authorization: Bearer $API_KEY'`\n- `Cookie` based session login with the `/api/pub/login` endpoint.  \n  This is the preferred method for web frontends like the web-configurator.\n\n## \U0001F6A7 Missing Features\n\n**This API is a preview version and does not yet contain all functionality.**\n\nThe following features will be continuously added (in no particular order):\n\n- Upload of custom certificate\n- Static network configuration\n\nPlease check the [core-api GitHub issues](https://github.com/unfoldedcircle/core-api/issues) for the current state. \n\n## API Versioning\n\nThe API is versioned according to [SemVer](https://semver.org/).  \nThe initial public release will be `1.0.0` once it is considered stable enough with some initial integration\nimplementations and developer examples.\n\n**Any major version zero (`0.y.z`) is for initial development and may change at any time!**  \nI.e. backward compatibility for minor releases is not yet established, anything MAY change at any time!\nWe try avoiding it, but it might still happen...\n"
+externalDocs:
+  description: Find out more about the Remote Two
+  url: 'https://www.unfoldedcircle.com/'
+servers:
+  - url: /api
+  - url: 'http://localhost:8080/api'
+  - url: 'https://localhost:8443/api'
+  - url: 'http://unfolded-simulator.local:8080/api'
+  - url: 'https://unfolded-simulator.local:8443/api'
+security:
+  - basicAuth: []
+  - cookieAuth: []
+tags:
+  - name: info
+    description: "\U0001F481 Public status information and health checks"
+  - name: auth
+    description: "\U0001F510 Session authentication"
+  - name: api-keys
+    description: "\U0001F511 API keys for authentication."
+  - name: external-token
+    description: "\U0001F48E Access token handling for external systems."
+  - name: resources
+    description: "\U0001F508 Media files handling, e.g. manage background images, icons or sound effects."
+  - name: integrations
+    description: "\U0001F9E9 Integration handling"
+  - name: entities
+    description: "\U0001F4FA Common handling of configured entities like sending commands and modifying editable properties.  \nEntities are usually provided by integrations, except the special activity, macro and infrared-remote entities.\n"
+  - name: activities
+    description: "\U0001F39B️ Combine multiple entities into an activity with optional on- & off-sequences, physical button mappings and a\ncustom user interface.\n"
+  - name: macros
+    description: "\U0001F522 Macros execute a sequence of commands which is exposed as an entity command. Macros don't have a custom user\ninterface.\n"
+  - name: infrared
+    description: "\U0001F308 Infrared code set lookup, custom IR code management and IR emitter devices.\n"
+  - name: remotes
+    description: "\U0001F3AE Customizable user interface and button mappings for remote-entities\ncontrolling single IR- and the like devices.\n"
+  - name: profiles
+    description: "\U0001F464 User profile configuration with profiles, groups, pages"
+  - name: cfg
+    description: "\U0001F4DD Configuration settings"
+  - name: dock
+    description: "\U0001F6F0 Docking station management, discovery and infrared testing functions"
+  - name: system
+    description: ⚙️ System information and commands
+paths:
+  /pub/version:
+    get:
+      tags:
+        - info
+      summary: Get version information about installed components.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionInfo'
+      security: []
+  /pub/status:
+    get:
+      tags:
+        - info
+      summary: Get status information about the system.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  memory:
+                    type: object
+                    description: Memory status
+                    properties:
+                      total_memory:
+                        type: integer
+                        description: Amount of available RAM in KB
+                      available_memory:
+                        type: integer
+                        description: Amount of available RAM in KB for (re)use
+                      used_memory:
+                        type: integer
+                        description: Amount of used RAM in KB
+                      total_swap:
+                        type: integer
+                        description: SWAP size in KB
+                      used_swap:
+                        type: integer
+                        description: Free SWAP in KB
+                  load_avg:
+                    type: object
+                    description: System load average
+                    properties:
+                      one:
+                        type: number
+                        description: Average load within one minute
+                      five:
+                        type: number
+                        description: Average load within five minutes
+                      fifteen:
+                        type: number
+                        description: Average load within fifteen minutes
+                  filesystem:
+                    type: object
+                    description: Filesystem status
+                    properties:
+                      user_data:
+                        type: object
+                        properties:
+                          available:
+                            type: integer
+                            description: Amount of available disk space in KB
+                          used:
+                            type: integer
+                            description: Amount of used disk space in KB
+      security: []
+  /pub/health_check:
+    get:
+      tags:
+        - info
+      summary: Retrieve health check information about the system and running services.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  db:
+                    $ref: '#/components/schemas/HealthStatus'
+                  ui:
+                    $ref: '#/components/schemas/HealthStatus'
+                  storage:
+                    $ref: '#/components/schemas/HealthStatus'
+        '500':
+          $ref: '#/components/responses/Err500InternalServerError'
+      security: []
+  /pub/login:
+    post:
+      tags:
+        - auth
+      summary: Log in and create session.
+      description: |
+        A successful login returns a session authentication cookie which need to be submitted in subsequent requests.  
+        The session ID is returned in a cookie named `id`.
+      operationId: login
+      requestBody:
+        required: true
+        description: A JSON object containing the username and password.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      security: []
+      responses:
+        '200':
+          description: Successfully authenticated.
+          headers:
+            Set-Cookie:
+              schema:
+                type: string
+                example: id=abcde12345; Path=/; HttpOnly
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '500':
+          $ref: '#/components/responses/Err500InternalServerError'
+  /pub/logout:
+    post:
+      tags:
+        - auth
+      summary: Log out from session.
+      description: |
+        The session is removed and the session cookie named `id` is cleared.
+      operationId: logout
+      parameters:
+        - name: id
+          in: cookie
+          description: Session cookie
+          schema:
+            type: string
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          description: Successfully logged out.
+          headers:
+            Set-Cookie:
+              schema:
+                type: string
+                example: 'id=; HttpOnly; Path=/; Max-Age=0; Expires=Sat, 26 Jun 2021 12:05:09 GMT'
+        '500':
+          $ref: '#/components/responses/Err500InternalServerError'
+  /auth/api_keys:
+    head:
+      tags:
+        - api-keys
+      summary: Get total number of available API keys.
+      operationId: getApiKeyCount
+      parameters:
+        - $ref: '#/components/parameters/active'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    get:
+      tags:
+        - api-keys
+      summary: List available API keys.
+      description: |
+        This endpoint is only intended for a management UI and not for client access. The response contains a key
+        identifier in `key_id` which is required for further operations on the API key, like disabling or revoking it or
+        adding a description.
+      operationId: getApiKeys
+      parameters:
+        - $ref: '#/components/parameters/active'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiKeys'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    post:
+      tags:
+        - api-keys
+      summary: Create an API key for the Remote Two APIs.
+      description: |
+        The returned API key in `api_key` is only visible in this response. Afterwards it cannot be retrieved anymore!
+
+        The newly created API key is usually not yet enabled for use and must first be approved by the user on the remote.
+
+        The required scopes must be provided. They let you specify what exactly a client needs to access.
+        When the access token request is displayed to the remote user for approval, the requested scopes will be
+        displayed to them.
+
+        An error is returned if an API key already exists for the provided `name`. To issue a new API key for the same
+        name, the old token needs to be revoked first.
+      operationId: createApiKey
+      requestBody:
+        description: Client information requesting access
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiKeyRequest'
+            example:
+              name: My integration
+              scopes:
+                - admin
+        required: true
+      responses:
+        '201':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiKeyResponse'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+    delete:
+      tags:
+        - api-keys
+      summary: Delete all API keys.
+      description: |
+        This endpoint is only intended for a management UI and not for client access. The required `key_id` parameter is
+        returned in the `GET /auth/api_keys` response.
+      operationId: deleteAllApiKeys
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/auth/api_keys/{apiKeyId}':
+    get:
+      tags:
+        - api-keys
+      summary: Get information about an API key.
+      description: |
+        The API key itself is non-retrievable. This function provides the access rights and validity of a defined API key.
+
+        This endpoint is only intended for a management UI and not for client access. The required `key_id` parameter is
+        returned in the `GET /auth/api_keys` response.
+      operationId: getApiKey
+      parameters:
+        - $ref: '#/components/parameters/api_key_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiKey'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - api-keys
+      summary: Update properties of an API key.
+      operationId: updateApiKey
+      description: |
+        Activate, deactivate, rename or set validity periods of an existing API key.
+
+        Note: access scopes cannot be changed. This requires to revoke the API key and request a new one.
+
+        This endpoint is only intended for a management UI and not for client access. The required `key_id` parameter is
+        returned in the `GET /auth/api_keys` response.
+      parameters:
+        - $ref: '#/components/parameters/api_key_id'
+      requestBody:
+        description: Properties to update in the existing token.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiKeyUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiKey'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - api-keys
+      summary: Revoke an API key.
+      description: |
+        The API key will be deleted, no further access is possible.
+
+        This endpoint is only intended for a management UI and not for client access. The required `key_id` parameter is
+        returned in the `GET /auth/api_keys` response.
+      operationId: deleteApiKey
+      parameters:
+        - $ref: '#/components/parameters/api_key_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  /auth/scopes:
+    get:
+      tags:
+        - api-keys
+      summary: Get available access scopes.
+      description: |
+        Access scopes are used to create tokens for the WebSocket API.
+      operationId: getAccessScopes
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Scopes'
+  /auth/external:
+    get:
+      tags:
+        - external-token
+      summary: Get registered external systems.
+      description: |
+        External systems are handled with the R2 integrations. Before an access token for such a system can be provided,
+        the corresponding system needs to be registered.
+
+        _TODO: reference to WebSocket API for integration registration._
+
+        If the expected system name is not returned by this call, any operations on that system name will fail:
+        `/auth/external/{system}`.
+        Therefore, it's advisable to either call this method first or react on the 404 error while providing or updating an
+        external system token, to inform the client user, that the integration is not available on the remote.
+      operationId: getExternalSystems
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalSystems'
+    delete:
+      tags:
+        - external-token
+      summary: Remove all external access tokens.
+      description: |
+        Management operation to delete all external access tokens. Attention: this cannot be reverted!
+      operationId: deleteAllExternalAccessTokens
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+  '/auth/external/{system}':
+    post:
+      tags:
+        - external-token
+      summary: Provide an access token of an external system.
+      description: |
+        An access token is usually required to connect to external systems like Home Assistant.
+        This method allows the external system to automatically provide the access token for the corresponding R2
+        integration instead of forcing the user to type it in. If the token name already exists for the given system,
+        error `422` is returned.
+        Use the put method to update an existing token.
+
+        The format of the access token depends on the external system and the involved R2 integration.
+        It could be a UUID, a JWT or any other representation required for the integration to communicate with the
+        external system.
+
+        The `system` parameter is determined by the registered R2 integration. Only registered system name identifiers are
+        valid, otherwise error `404` will be returned.
+        E.g. a "FooBar" integration might register the system identifier name "foobar".
+        Use the `GET /auth/external` method the retrieve the registered systems.
+      operationId: addExternalAccessToken
+      parameters:
+        - $ref: '#/components/parameters/system'
+      requestBody:
+        description: Access token that needs to be added to the remote
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExternalAccessTokenRequest'
+        required: true
+      responses:
+        '201':
+          description: Successful operation returning the token identifier in the response.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token_id:
+                    type: string
+                    format: '^[a-zA-Z0-9\-_]+$'
+                    minLength: 1
+                    maxLength: 36
+                    description: |
+                      Unique token identifier, used for later token management through the external system or management ui.
+                      If the token identifier has been provided in the request, then then same identifier is returned, otherwise a
+                      UUID is generated.
+                required:
+                  - token_it
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+      x-codegen-request-body-name: body
+    head:
+      tags:
+        - external-token
+      summary: Get total number of available tokens for an external system.
+      operationId: getExternalAccessTokenCount
+      parameters:
+        - $ref: '#/components/parameters/system'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    get:
+      tags:
+        - external-token
+      summary: List available tokens for an external system.
+      operationId: getExternalAccessTokens
+      parameters:
+        - $ref: '#/components/parameters/system'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalAccessTokens'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - external-token
+      summary: Remove all access tokens of an external system.
+      operationId: deleteExternalAccessTokensBySystem
+      parameters:
+        - $ref: '#/components/parameters/system'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/auth/external/{system}/{tokenId}':
+    get:
+      tags:
+        - external-token
+      summary: Get external access token.
+      operationId: getExternalAccessToken
+      parameters:
+        - $ref: '#/components/parameters/system'
+        - $ref: '#/components/parameters/token_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalAccessToken'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    put:
+      tags:
+        - external-token
+      summary: Replace an existing access token of an external system.
+      description: |
+        This methods allows an already provided token of an external system to be updated. The token is identified by
+        the system name and the token identification.
+      operationId: replaceExternalAccessToken
+      parameters:
+        - $ref: '#/components/parameters/system'
+        - $ref: '#/components/parameters/token_id'
+      requestBody:
+        description: Access token to update
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExternalAccessTokenRequest'
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - external-token
+      summary: Remove an external access token.
+      description: |
+        No error is returned if the `tokenId` doesn't exist. `404` is only returned it the `system` is not found.
+      operationId: deleteExternalAccessToken
+      parameters:
+        - $ref: '#/components/parameters/system'
+        - $ref: '#/components/parameters/token_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  /resources:
+    get:
+      tags:
+        - resources
+      summary: Get supported media resource types.
+      operationId: getResourceTypes
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SupportedResources'
+              example:
+                - type: Icon
+                  name:
+                    en: Icon
+                    de: Icon
+                  description:
+                    en: User interface icons for entities and integrations. Icons must be of size 90x90 pixels and either in PNG or JPG format. Maximum size is 32 KB.
+                    de: Icons für die Benutzeroberfläche von Objekten und Integrationen. Die Icons müssen 90x90 Pixel gross und im PNG oder JPG Format sein. Maximale Grösse ist 32 KB.
+                  file_formats:
+                    - png
+                    - jpg
+                  max_file_size: 32768
+                  max_count: 100
+                  image:
+                    sizes:
+                      - width: 90
+                        height: 90
+                - type: TvChannelIcon
+                  name:
+                    en: TV channel icon
+                    de: TV Sender Icon
+                  description:
+                    en: User interface icons for TV channels. Icons must be of size 90x90 pixels and either in PNG or JPG format. Maximum size is 32 KB.
+                    de: TV Sender Icons für die Benutzeroberfläche. Die Icons müssen 90x90 Pixel gross und im PNG oder JPG Format sein. Maximale Grösse ist 32 KB.
+                  file_formats:
+                    - png
+                    - jpg
+                  max_file_size: 32768
+                  max_count: 256
+                  image:
+                    sizes:
+                      - width: 90
+                        height: 90
+                - type: BackgroundImage
+                  name:
+                    en: Background image
+                    de: Hintergrund Bild
+                  description:
+                    en: Background image for user interface profile pages. Images must be of size 275x480 pixels and either in PNG or JPG format. Maximum size is 1 MB.
+                    de: Hintergrund Bild für Profil Seiten. Die Bilder müssen 275x480 Pixel gross und im PNG oder JPG Format sein. Maximale Grösse ist 1 MB.
+                  file_formats:
+                    - png
+                    - jpg
+                  max_file_size: 1048576
+                  max_count: 30
+                  image:
+                    sizes:
+                      - width: 275
+                        height: 480
+                - type: Sound
+                  name:
+                    en: Sound effect
+                    de: Klangeffekt
+                  description:
+                    en: User interface sound effects. Maximum size is 1 MB.
+                    de: Klangeffekte für die Benutzeroberfläche. Maximale Grösse ist 1 MB.
+                  file_formats:
+                    - wav
+                  max_file_size: 1048576
+                  max_count: 50
+                  sound:
+                    bits:
+                      - 8
+                      - 16
+                    channels:
+                      - 1
+                      - 2
+                    sampling_rates:
+                      - 11025
+                      - 22050
+                      - 44100
+    delete:
+      tags:
+        - resources
+      summary: Delete all resources.
+      operationId: deleteAllResources
+      parameters:
+        - $ref: '#/components/parameters/resource_type_query'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+  '/resources/{type}':
+    head:
+      tags:
+        - resources
+      summary: Get total number of available resources of a given type.
+      operationId: getResourceTypeItemsCount
+      parameters:
+        - $ref: '#/components/parameters/resource_type'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    get:
+      tags:
+        - resources
+      summary: List available media resources of a given type.
+      operationId: getResourceTypeItems
+      parameters:
+        - $ref: '#/components/parameters/resource_type'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceItems'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    post:
+      tags:
+        - resources
+      summary: Upload media resource files.
+      description: |
+        Upload one or more binary resource files as form-data. Files must conform to the given type according to the metadata
+        returned in `GET /api/resources`. E.g. an icon resource has other image size restrictions than a background image.
+
+        The file names are normalized (e.g. spaces replaced with underscores) and returned as resource identifiers.
+
+        Uploaded resources are verified, if they match expected formats. Status codes: 
+        - `400`: resource doesn't confirm to the expected parameters.
+        - `422`: resource already exists with the same name. Already existing resource files are NOT overwritten.
+        - `507`: insufficient storage to save a new resource.
+      operationId: uploadFile
+      parameters:
+        - $ref: '#/components/parameters/resource_type'
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '201':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceItems'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+        '507':
+          $ref: '#/components/responses/Err507InsufficientStorage'
+    delete:
+      tags:
+        - resources
+      summary: Delete all resources of a given type.
+      operationId: deleteResources
+      parameters:
+        - $ref: '#/components/parameters/resource_type'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/resources/{type}/{id}':
+    get:
+      tags:
+        - resources
+      summary: Download a media resource.
+      operationId: getResource
+      parameters:
+        - $ref: '#/components/parameters/resource_type'
+        - $ref: '#/components/parameters/resource_id'
+      responses:
+        '200':
+          description: A resource file
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+            image/jpg:
+              schema:
+                type: string
+                format: binary
+            audio/wav:
+              schema:
+                type: string
+                format: binary
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - resources
+      summary: Delete a media resource.
+      operationId: deleteResource
+      parameters:
+        - $ref: '#/components/parameters/resource_type'
+        - $ref: '#/components/parameters/resource_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  /intg:
+    head:
+      tags:
+        - integrations
+      summary: Get total number of configured and external integrations.
+      operationId: getIntegrationStatusCount
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    get:
+      tags:
+        - integrations
+      summary: Get overview of configured and external integrations.
+      description: |
+        Retrieve an overview of the configured integrations and their current connection state and all external
+        integrations which are ready to be configured. This overview is meant for an integration management frontend like
+        the web-configurator to avoid calling multiple API endpoints to gather integration driver and instance data.
+      operationId: getIntegrationStatus
+      parameters:
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/IntegrationStatus'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /intg/discover:
+    get:
+      tags:
+        - integrations
+      summary: Get external integration driver discovery status.
+      description: |
+        Returns the current discovery status and the discovered integration drivers.
+
+        Use the DELETE operation to stop an active discovery and PUT to start a new discovery.
+      operationId: getIntegrationDiscoveryStatus
+      responses:
+        '200':
+          description: Integration discovery status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationDiscoveryStatus'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    put:
+      tags:
+        - integrations
+      summary: Start discovery of external integration drivers.
+      description: |
+        Start integration driver discovery on the network with mDNS. By default the discovery automatically stops after
+        30 seconds. Use the GET status request to check on discovered devices or DELETE to stop discovery.
+
+        By default only new integration drivers are returned. If a driver is already configured it will be omitted from the
+        results, unless the query parameter `new=false` is set.
+
+        - Previously discovered integrations are removed, only newly discovered integrations will be returned.
+        - Emits the WebSocket event `integration_discovery` with `event_type: START` when discovery starts.
+        - For each discovered driver the WebSocket event `integration_discovery` with `event_type: DISCOVER` is emitted.
+      operationId: startIntegrationDiscovery
+      parameters:
+        - name: timeout
+          in: query
+          description: Timeout in seconds.
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
+            minimum: 1
+            maximum: 300
+        - name: new
+          in: query
+          description: 'Only return new devices, filter out already configured integrations.'
+          required: false
+          schema:
+            type: boolean
+            default: true
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    delete:
+      tags:
+        - integrations
+      summary: Stop discovery of external integration drivers.
+      description: |
+        Stops the driver discovery and returns the current discovery status in the response.
+
+        Emits the WebSocket event `integration_discovery` with `event_type: STOP`.
+      operationId: stopIntegrationDiscovery
+      responses:
+        '200':
+          description: Integration discovery status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationDiscoveryStatus'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/intg/discover/{driverId}':
+    get:
+      tags:
+        - integrations
+      summary: Get integration driver discovery information.
+      description: |
+        Returns the discovered integration driver.
+      operationId: getDiscoveredIntegrationDriver
+      parameters:
+        - $ref: '#/components/parameters/driver_id'
+      responses:
+        '200':
+          description: Integration discovery status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationDiscovery'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    put:
+      tags:
+        - integrations
+      summary: "\U0001F477 Execute connection test and fetch metadata from discovered integration driver."
+      description: |
+        Perform a driver connection test with a discovered driver. If the driver requires a token, it must be specified in
+        the request body.
+
+        Response status codes:
+        - `200`: successful operation: the connection test was successful and driver metadata could be retrieved.
+        - `401` / `403`: driver authentication failed. Either the driver requires a token and it was not provided, or the 
+                 provided token was not valid.
+        - `404`: discovered driver with `driver_id` not found. Check if the discovery result is still available and has not
+                 been deleted. This can happen after a timeout since the discovery, or if the discovery result has been
+                 cleared with starting a new discovery.
+        - `503`: integration driver connection could not be established.
+      operationId: getDiscoveredIntgDriverMetadata
+      parameters:
+        - $ref: '#/components/parameters/driver_id'
+        - name: timeout
+          in: query
+          description: Timeout in seconds.
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 5
+            minimum: 3
+            maximum: 60
+      requestBody:
+        required: false
+        description: Command payload
+        content:
+          application/json:
+            schema:
+              description: Driver connection parameters.
+              type: object
+              properties:
+                connection:
+                  type: object
+                  properties:
+                    driver_url:
+                      description: |
+                        Custom URL to connect to driver. If not specified the mDNS connection information is used.
+                      type: string
+                    token:
+                      description: |
+                        Optional driver authentication token.
+                      type: string
+                      maxLength: 2048
+            examples:
+              Connection test without token and discovered driver url:
+                value: {}
+              Connection test with token:
+                value:
+                  connection:
+                    token: '0000'
+              Connection test with custom driver url:
+                value:
+                  connection:
+                    driver_url: 'ws://my-integration.local:8080'
+      responses:
+        '200':
+          description: Command response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  driver:
+                    $ref: '#/components/schemas/IntegrationDriver'
+                required:
+                  - driver
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    post:
+      tags:
+        - integrations
+      summary: Register a discovered integration driver.
+      description: |
+        Register a discovered integration driver:
+        - establish communication with the driver.
+          - if the driver requires a password, it must be provided in the request.
+          - the discovered driver name and url can be overridden.
+        - fetch metadata from the driver.
+        - check compatability.
+        - register the driver and connection parameters in the remote.
+
+        After a successful registration the setup process of the driver can be started to configure the integration.
+        The required setup data is described in the returned `setup_data_schema` and the provided values by the user must
+        be passed to the `POST /intg/setup` operation.
+
+        Response status codes:
+        - `400`: invalid data in request body.
+        - `401` / `403`: driver authentication failed. Either the driver requires a token and it was not provided, or the 
+                 provided token was not valid.
+        - `404`: no discovered driver found for given `driver_id`.
+        - `409`: integration driver is already registered.
+        - `503`: integration driver communication error. Either driver is not reachable or communication failed.
+      operationId: configureDiscoveredIntgDriver
+      parameters:
+        - $ref: '#/components/parameters/driver_id'
+      requestBody:
+        description: Command payload
+        content:
+          application/json:
+            schema:
+              description: Driver connection parameters.
+              type: object
+              properties:
+                name:
+                  $ref: '#/components/schemas/LanguageText'
+                driver_url:
+                  description: 'Custom WebSocket URL of the driver, otherwise the discovered driver address is used.'
+                  type: string
+                  format: uri
+                  maxLength: 2048
+                token:
+                  description: |
+                    Optional driver authentication token.
+                  type: string
+                  maxLength: 2048
+            examples:
+              Default:
+                value: {}
+              Configure driver with custom url:
+                value:
+                  driver_url: 'ws://my-integration.local:8080'
+              Configure driver with default name & url and custom token:
+                value:
+                  token: '0000'
+              Configure driver with custom name:
+                value:
+                  name:
+                    en: My integration
+                    de: Meine Integration
+      responses:
+        '201':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationDriver'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '409':
+          $ref: '#/components/responses/Err409Conflict'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+  /intg/setup:
+    get:
+      tags:
+        - integrations
+      summary: Get current integration setup processes.
+      description: |
+        Return a list of all active setup process identifiers. The returned ids can be used with the
+        `/intg/setup/:id` endpoints to continue or abort a setup process.
+      operationId: getIntegrationSetupProcesses
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    post:
+      tags:
+        - integrations
+      summary: Start setting up a new integration driver.
+      description: |
+        Start a new setup process for the given integration driver and provided setup data, or reconfigure an existing
+        driver.
+
+        - This operation immediately starts the driver communication and setup process.
+        - There may only be one active setup process per driver, otherwise status code `409` is returned.
+
+        The returned `id` in the `IntegrationSetupInfo` response will be the identifier for the further setup operations
+        with the `/intg/setup/:driver_id` endpoints. Once the setup process is successfully finished, an integration instance is
+        created. A setup process can be simple and fully automatic, but may also require user interaction and further
+        communication with the `/intg/setup/:driver_id` endpoint.
+
+        Emits the WebSocket event `integration_setup_change` with `event_type: START`.
+
+        Request body:
+        - `name`: optional integration name. If not specified the name of the integration driver is used.
+        - `setup_data`: optional driver setting values corresponding to the driver's `setup_data_schema` object.
+        - `reconfigure`: set to true to reconfigure an already configured driver. The configuration options and behaviour
+          is driver dependent.
+
+        Response status codes:
+        - `400`: invalid data in request body. E.g. setting the reconfigure flag for a new driver which is not yet configured.
+        - `404`: specified `driver_id` in request body does not exist.
+        - `409`: a setup process for the given `driver_id` already exists. Either continue or abort existing process.
+        - `422`: the setup process cannot be used: either the integration is already configured or doesn't allow to be
+                 set up again.  
+        - `503`: integration driver communication error. Either driver is not reachable or communication failed.
+      operationId: setupIntegration
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateIntegrationSetup'
+        required: true
+      responses:
+        '201':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationSetupInfo'
+              example:
+                id: sim-test
+                state: SETUP
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '409':
+          $ref: '#/components/responses/Err409Conflict'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    delete:
+      tags:
+        - integrations
+      summary: Abort and remove all setup processes.
+      description: |
+        Stop all setup processes at the next possible operation and remove all setup process information.  
+        Depending on the integration driver, a started setup process cannot be aborted.
+
+        ⚠️ This stops all setup processes, not just for the current session!
+      operationId: stopAllIntegrationSetups
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/intg/setup/{driverId}':
+    get:
+      tags:
+        - integrations
+      summary: Get integration driver setup status.
+      description: |
+        Poll operation to retrieve the current integration driver setup state. See the `state` and `error` fields in the
+        response message. There are also WebSocket `integration_setup_change` event messages for state changes to avoid
+        polling.
+
+        Defined setup states:
+        - `SETUP`: setup is running and configuring the integration. 
+        - `WAIT_USER_ACTION`: user input is required to continue the setup process. See `require_user_action` in response
+           for the required user input. Provide the requested data with the `PUT` operation.
+        - `OK`: setup process has been completed successfully, the integration driver can now be used.
+        - `ERROR`: the setup process failed. Check the `error` field for more information.
+      operationId: getIntegrationSetupStatus
+      parameters:
+        - $ref: '#/components/parameters/driver_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationSetupInfo'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    put:
+      tags:
+        - integrations
+      summary: Provide requested integration setup data.
+      description: |
+        Set required data to configure the integration driver or continue the setup process.
+
+        Defined user actions to set in the request body `action` field:
+        - `input_values`: if the user was requested to enter settings, e.g. connection or credential parameters to a device
+          or service.
+        - `confirm`: response to the user action `confirmation`. Set to `true` if the user had to perform an action like
+          pressing a button on a device and then confirms the action with continuing the setup process.  
+          The `false` value is prepared for yes / no choices.
+
+        The `state` field in the response message indicate the current state of the setup process. Use the `GET` operation
+        to poll for state updates or listen to the corresponding WebSocket `integration_setup_change` event messages with
+        `event_type: SETUP`.
+      operationId: setIntegrationUserData
+      parameters:
+        - $ref: '#/components/parameters/driver_id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - type: object
+                  properties:
+                    input_values:
+                      $ref: '#/components/schemas/SettingsValues'
+                  required:
+                    - input_values
+                - type: object
+                  properties:
+                    confirm:
+                      type: boolean
+                  required:
+                    - confirm
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationSetupInfo'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    delete:
+      tags:
+        - integrations
+      summary: Abort the integration driver setup process.
+      description: |
+        Stop the setup process at the next possible operation and remove the setup process information.  
+        To start a new setup process, use the `POST /intg/setup` operation again.
+
+        Depending on the integration driver, a started setup process cannot be aborted.
+
+        Emits the WebSocket event `integration_setup_change` with `event_type: STOP`.
+      operationId: stopIntegrationSetup
+      parameters:
+        - $ref: '#/components/parameters/driver_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  /intg/drivers:
+    head:
+      tags:
+        - integrations
+      summary: Get total number of registered integration drivers.
+      operationId: getIntegrationDriversCount
+      parameters:
+        - name: driver_type
+          in: query
+          description: Filter by driver type.
+          schema:
+            type: string
+            enum:
+              - LOCAL
+              - EXTERNAL
+        - $ref: '#/components/parameters/enabled'
+        - $ref: '#/components/parameters/instantiable'
+        - $ref: '#/components/parameters/single_device'
+        - $ref: '#/components/parameters/has_instances'
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    get:
+      tags:
+        - integrations
+      summary: Get all registered integration drivers.
+      description: |
+        Returns an overview of all registered drivers. To retrieve all driver data use `/intg/drivers/{driverId}`.
+      operationId: getIntegrationDrivers
+      parameters:
+        - name: driver_type
+          in: query
+          description: Filter by driver type.
+          schema:
+            type: string
+            enum:
+              - LOCAL
+              - EXTERNAL
+        - $ref: '#/components/parameters/enabled'
+        - $ref: '#/components/parameters/instantiable'
+        - $ref: '#/components/parameters/single_device'
+        - $ref: '#/components/parameters/has_instances'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationDrivers'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    post:
+      tags:
+        - integrations
+      summary: "\U0001F477 Manually register a new integration driver."
+      description: |
+        A driver provides the connection parameters and optional setup configuration for an integration driver.
+
+        Registering a driver requires that the driver is running and responding to requests on the given URL. The driver
+        details will be fetched and stored in the Remote.
+
+        Depending on the driver capabilities it either provides a single access point to the provided entities, or exposes
+        multiple devices, each with its own unique set of entities. The former could for example be used to provide GPIO
+        access of a Raspberry Pi or gather all supported devices it is able to interact with (e.g. network sensors, light
+        switches etc.). The more capable multi-device mode is suited to bridge home automation hubs where multiple
+        instances should be supported.
+
+        Once a driver is registered, one or more integration instances must be configured to interact with the driver.  
+        For simple integration drivers there's a 1:1 relationship between an instance and driver. For multi-device drivers, 
+        each device corresponds to an integration instance.
+
+        It is recommended to manually set a unique and human-readable driver identifier in `driver_id`. Otherwise a UUID
+        will be assigned. The `driver_id` is required for all further interactions with the driver, like creating a runtime
+        instance to connect to the driver and fetch available entities.
+      operationId: registerIntegrationDriver
+      requestBody:
+        description: Integration driver data
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IntegrationDriverRequest'
+        required: true
+      responses:
+        '201':
+          description: Successful operation returning the created integration driver in the response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationDriver'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/intg/drivers/{driverId}':
+    get:
+      tags:
+        - integrations
+      summary: Get integration driver metadata.
+      description: |
+        Returns the full data of an integration driver, except the authentication token for external clients.
+      operationId: getIntegrationDriver
+      parameters:
+        - $ref: '#/components/parameters/driver_id'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationDriver'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - integrations
+      summary: Modify connection parameters of an external integration driver.
+      description: |
+        Update connection settings of an external integration driver if the URL or access token has changed. The new
+        settings are immediately applied and the driver communication verified. This might take a few seconds.  
+        The driver's own optional configuration settings cannot be applied with this operation and are configured during
+        the setup process, or through the integration instance.
+
+        - Only external integration drivers can be modified. Otherwise `400` (Bad Request) is returned.
+        - Connection settings are tested and applied against the driver.
+          - `503` (Service Unavailable) is returned if the driver communication fails.
+          - If the driver is not active, the settings are only applied and not tested! This is for development use only.
+        - See request description on how to update or remove an existing setting.
+      operationId: updateIntegrationDriver
+      parameters:
+        - $ref: '#/components/parameters/driver_id'
+      requestBody:
+        description: Entity data
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IntegrationDriverUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful operation returning the updated integration driver in the response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationDriver'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    put:
+      tags:
+        - integrations
+      summary: Execute a command on an integration driver.
+      description: |
+        Available driver commands:
+        - `CONNECTION_TEST`: perform a driver connection test with the connection parameters in the payload.
+        - `START`: Manually start an integration driver.
+        - `STOP`: Manually stop a driver to disable all integration instances processing.
+
+        Response status codes:
+        - `200`: successful operation, e.g. the connection test was successful.
+        - `400`: bad request, e.g. connection parameters missing for connection test command.
+        - `503`: integration driver connection could not be established.
+
+        If a driver is enabled it will start automatically. Manually starting and stopping a driver is for testing purposes
+        and setting up new drivers in the web-configurator.
+      operationId: integrationDriverCommand
+      parameters:
+        - $ref: '#/components/parameters/driver_id'
+        - name: cmd
+          in: query
+          description: Command to execute.
+          required: true
+          schema:
+            type: string
+            enum:
+              - CONNECTION_TEST
+              - START
+              - STOP
+      requestBody:
+        required: false
+        description: Command payload
+        content:
+          application/json:
+            schema:
+              description: Driver connection parameters for `CONNECTION_TEST` command only.
+              type: object
+              properties:
+                driver_url:
+                  description: WebSocket URL of the driver.
+                  type: string
+                  format: uri
+                  maxLength: 2048
+                token:
+                  description: |
+                    Optional driver authentication token.
+                  type: string
+                  maxLength: 2048
+              required:
+                - driver_url
+            examples:
+              Connection test:
+                value:
+                  driver_url: 'ws://192.168.1.200:8000/ws'
+                  token: '0000'
+              Other:
+                value: null
+      responses:
+        '200':
+          description: |
+            Successful operation, returns the `IntegrationDriver` object for the `CONNECTION_TEST` command, otherwise the
+            common `ApiResponse` object.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/IntegrationDriver'
+                  - $ref: '#/components/schemas/ApiResponse'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    post:
+      tags:
+        - integrations
+      summary: Create a new integration instance from driver.
+      description: |
+        Create an integration driver instance and associate it with the driver.  
+        For simple integration drivers there's a 1:1 relationship only between an instance and driver.
+        For multi-device drivers, each device corresponds to an integration instance.
+
+        - the `integration_id` is automatically created by the system to make it unique over all integrations.
+        - for multi-device drivers the `device_id` must be specified and may not already exist in another instance of the
+          same driver.
+        - the driver's name is used by default if `name` isn't specified.
+        - the instance is active by default if `enabled` isn't specified.
+      operationId: createIntegration
+      parameters:
+        - $ref: '#/components/parameters/driver_id'
+      requestBody:
+        description: Integration instance data.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IntegrationUpdate'
+        required: true
+      responses:
+        '201':
+          description: Successful operation returning the created integration instance in the response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Integration'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - integrations
+      summary: Remove an integration driver.
+      description: |
+        Unloads and deletes an integration driver with all instances and provided entities.
+
+        ⚠️ **Attention: all references to the integration driver will be removed! This includes all driver instances,
+        provided entities and their references in profile pages and groups.**
+      operationId: deleteIntegrationDriver
+      parameters:
+        - $ref: '#/components/parameters/driver_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  /intg/instances:
+    head:
+      tags:
+        - integrations
+      summary: Get total number of integration instances.
+      operationId: getIntegrationsCount
+      parameters:
+        - $ref: '#/components/parameters/enabled'
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    get:
+      tags:
+        - integrations
+      summary: Get all integration instances.
+      operationId: getIntegrations
+      parameters:
+        - $ref: '#/components/parameters/enabled'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Integrations'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    put:
+      tags:
+        - integrations
+      summary: Connect or disconnect all integration instances.
+      description: |
+        Execute a command on all active integration instances:
+
+        - `connect`: requests all enabled integrations to establish a session to the integration driver and start processing
+          events.  
+          Use `GET /intg/instances` or `GET /intg/instances/{intgId}` to check on the connection status.
+        - `disconnect`: disconnects all active integration driver sessions.
+      operationId: executeCommandOnAllIntegrations
+      parameters:
+        - name: cmd
+          in: query
+          description: Command to execute.
+          required: true
+          schema:
+            type: string
+            enum:
+              - CONNECT
+              - DISCONNECT
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/intg/instances/{intgId}':
+    get:
+      tags:
+        - integrations
+      summary: Get an integration instance.
+      operationId: getIntegration
+      parameters:
+        - $ref: '#/components/parameters/integration_id'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Integration'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - integrations
+      summary: Modify a configured integration instance.
+      description: |
+        Modify one or several properties of an integration instance.  
+        See update model description on how to update or delete an existing property.
+
+        The integration driver of an instance cannot be changed and will be ignored if provided in the request.
+      operationId: updateIntegration
+      parameters:
+        - $ref: '#/components/parameters/integration_id'
+      requestBody:
+        description: Integration instance data.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IntegrationUpdate'
+        required: true
+      responses:
+        '201':
+          description: Successful operation returning the updated integration instance in the response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Integration'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+    delete:
+      tags:
+        - integrations
+      summary: Remove an integration instance.
+      description: |
+        Unloads and deletes an integration instance.
+
+        **Attention: all references to the integration instance will be removed! This includes configured entities and 
+        their references in profile pages and groups.**
+      operationId: deleteIntegration
+      parameters:
+        - $ref: '#/components/parameters/integration_id'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    put:
+      tags:
+        - integrations
+      summary: Connect or disconnect an integration instance.
+      description: |
+        Exectue a command on the integration instance:
+
+        - `connect`: establish a session to the integration driver and start processing events.  
+          Use `GET /intg` or `GET /intg/instances/{intgId}` to check on the connection status.
+        - `disconnect`: disconnect from the driver and stop processing events.
+      operationId: executeIntegrationCommand
+      parameters:
+        - $ref: '#/components/parameters/integration_id'
+        - name: cmd
+          in: query
+          description: Command to execute.
+          required: true
+          schema:
+            type: string
+            enum:
+              - CONNECT
+              - DISCONNECT
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/intg/instances/{intgId}/entities':
+    get:
+      tags:
+        - integrations
+      summary: Get available entities from integration instance.
+      description: |
+        Retrieve the available entities provided by the integration instance.
+
+        By default only the entities are returned which are not yet configured. Use the `filter` query to include all or
+        only the already configured entities.
+
+        Available entities can be searched and filtered by one or multiple entity types. The text search searches in the
+        entity name, entity identifier and area.
+      operationId: getAvailableEntitiesFromInstance
+      parameters:
+        - $ref: '#/components/parameters/integration_id'
+        - name: reload
+          in: query
+          description: Force reload available entities from driver.
+          required: false
+          schema:
+            type: boolean
+            default: false
+        - name: filter
+          in: query
+          description: Filter available entities.
+          required: false
+          schema:
+            type: string
+            default: NEW
+            enum:
+              - NEW
+              - CONFIGURED
+              - ALL
+        - $ref: '#/components/parameters/entity_types'
+        - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AvailableEntity'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    post:
+      tags:
+        - integrations
+      summary: Configure multiple available entities.
+      description: |
+        Configure multiple new Remote Two entities from available integration entities. Once configured, the entities will
+        no longer show up as an available entity (unless the `filter=ALL` query parameter is set).
+
+        An empty request body array will configure all available entities.
+
+        Use endpoint `/intg/instances/{intgId}/entities/{entityId}` to configure a single entity and optionally rename it
+        or change its icon.
+
+        This is a best effort operation:
+        - if an entity is already configured, it is ignored and not returned in the response.
+        - unknown entity identifiers are ignored, no error is returned
+
+        Every newly configured entity will trigger an `entity_change` event.
+      operationId: configureEntitiesFromIntegration
+      parameters:
+        - $ref: '#/components/parameters/integration_id'
+      requestBody:
+        description: Entity identifiers.
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
+        required: true
+      responses:
+        '201':
+          description: Successful operation returning the configured entity identifiers in the response.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/intg/instances/{intgId}/entities/{entityId}':
+    post:
+      tags:
+        - integrations
+      summary: Configure an available entity.
+      description: |
+        Configure a new Remote Two entity from an available integration entity. Once configured, the entity will no longer
+        show up as available entity (unless the `filter=ALL` query parameter is set).
+
+        The entity `name`, `icon` and `description` fields may be changed. If not specified in the request the values from
+        the available entity are used.
+      operationId: configureEntityFromIntegration
+      parameters:
+        - $ref: '#/components/parameters/integration_id'
+        - $ref: '#/components/parameters/entity_id'
+      requestBody:
+        description: Entity data.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityUpdateRequest'
+        required: true
+      responses:
+        '201':
+          description: Successful operation returning the configured entity in the response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entity'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+  /entities:
+    head:
+      tags:
+        - entities
+      summary: Get total number of configured entities.
+      operationId: getEntityCount
+      parameters:
+        - $ref: '#/components/parameters/entity_types'
+        - $ref: '#/components/parameters/intg_ids'
+        - $ref: '#/components/parameters/query'
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    get:
+      tags:
+        - entities
+      summary: Search and retrieve configured entities.
+      description: |
+        Returns all configured and loaded entities.
+
+        Entities can be searched and filtered by one or multiple types and integrations. The text search searches in the
+        entity name, entity identifier and integration name.
+      operationId: getEntities
+      parameters:
+        - $ref: '#/components/parameters/entity_types'
+        - $ref: '#/components/parameters/intg_ids'
+        - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entities'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    delete:
+      tags:
+        - entities
+      summary: Remove configured entities.
+      description: |
+        Unloads and deletes multiple configured entities, either by integration identifier or by entity identifiers.
+        If a deleted entity is still provided from an integration, it can be reused and will show up again as
+        available entity from its integration.
+
+        ⚠️ An empty `entity_ids` array will delete all configured entities!
+
+        All references to the configured entities will be removed from profile pages and groups.
+
+        This is a best effort operation:
+        - unknown entity identifiers are ignored, no error is returned
+
+        Deleted entities will trigger an `entity_change` event with `event_type: DELETE`. If a large amount of entities
+        are deleted, a single, generic `entity_change` event might be sent instead (without an `entity_id` field).
+      operationId: deleteEntities
+      requestBody:
+        description: Integration or entity identifiers.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityDeleteRequest'
+            examples:
+              by integration:
+                value:
+                  integration_id: hass.main
+              by entity identifiers:
+                value:
+                  entity_ids:
+                    - hass.main.sensor.1
+                    - hass.main.sensor.2
+                    - hass.main.light.1
+              all entities:
+                value:
+                  entity_ids: []
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/entities/{entityId}':
+    get:
+      tags:
+        - entities
+      summary: Get a configured entity.
+      operationId: getEntity
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entity'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - entities
+      summary: Modify a configured entity.
+      operationId: updateEntity
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      requestBody:
+        description: Entity data
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityUpdateRequest'
+        required: true
+      responses:
+        '201':
+          description: Successful operation returning the configured entity in the response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entity'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+    delete:
+      tags:
+        - entities
+      summary: Remove a configured entity.
+      description: |
+        Unloads and deletes a configured entity. If the entity is still provided from an integration it can be reused and
+        will show up again as available entity from its integration.
+
+        All references to the configured entity will be removed from profile pages and groups.
+      operationId: deleteEntity
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/entities/{entityId}/command':
+    put:
+      tags:
+        - entities
+      summary: Execute an entity command.
+      operationId: executeEntityCommand
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      requestBody:
+        description: Command data
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityCommand'
+        required: true
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+  /activities:
+    head:
+      tags:
+        - activities
+      summary: Get total number of activity entities.
+      description: |
+        The total number of available activities are returned in the `Pagination-Count` header. This allows to prepare the
+        retrieval of the activities with the `GET` operation and paging parameters.
+
+        The optional text search query searches in the activity name and activity identifier.
+      operationId: getActivityCount
+      parameters:
+        - name: in_group
+          in: query
+          description: Only activities in any activity group
+          required: false
+          schema:
+            type: boolean
+        - name: group_id
+          in: query
+          description: Only activities in this activity group
+          required: false
+          schema:
+            $ref: '#/components/schemas/SimpleId'
+        - $ref: '#/components/parameters/query'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    get:
+      tags:
+        - activities
+      summary: Get activity entities overview with paging.
+      description: |
+        Returns an overview of all defined activities with the given paging parameters. Use the `HEAD` operation to retrieve
+        the total number of defined activities.
+
+        The optional text search query searches in the activity name and activity identifier.
+            
+        The overview information doesn't include all details of an activity. The full activity information is retrievable
+        with `/activities/{entityId}`.
+      operationId: getActivities
+      parameters:
+        - name: in_group
+          in: query
+          description: Only activities in any activity group
+          required: false
+          schema:
+            type: boolean
+        - name: group_id
+          in: query
+          description: Only activities in this activity group
+          required: false
+          schema:
+            $ref: '#/components/schemas/SimpleId'
+        - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Activities'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    post:
+      tags:
+        - activities
+      summary: Create a new activity entity.
+      description: |
+        Create a new entity of type `activity`. An activity entity is a special internal entity without association to an
+        integration driver.
+
+        To create a new activity at least a name must be provided. The `icon`, `description` and `options.entity_ids`
+        are optional and can be set later with the `PUT` update operation.
+
+        When setting a text in a multilingual field, like name or description, the default `en` identifier should always be
+        included.
+
+        An activity can be cloned from another activity-, macro- or remote-entity identifier in `clone_from`. 
+        All applicable configuration will be copied, except a new activity name must be specified. The `icon` and
+        `description` fields can still be specified and will override the copied data. The `options.entity_ids` is
+        not allowed when cloning data, additional entities can be added later with the `PUT` update operation.
+
+        The `entity_ids` may be omitted when creating a new activity and specified later when updating the activity.
+      operationId: createActivity
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ActivityRequest'
+            examples:
+              simple:
+                value:
+                  name:
+                    en: My new activity
+              activity with icon and description:
+                value:
+                  name:
+                    en: My new activity
+                  icon: 'uc:bell'
+                  description:
+                    en: Testing the activity feature
+              clone:
+                value:
+                  name:
+                    en: My cloned activity
+                  clone_from: uc.main.activity.watch-tv
+        required: true
+      responses:
+        '201':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Activity'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+    delete:
+      tags:
+        - activities
+      summary: Delete all activity entities.
+      description: |
+        ⚠️ All defined activities will be irrevocably deleted!
+      operationId: deleteAllActivities
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/activities/{entityId}':
+    get:
+      tags:
+        - activities
+      summary: Get an activity by its entity_id.
+      description: "Returns all the information required to manage an existing activity. The included entities are enriched with `name`,\n`icon`, `entity_type`, available commands and if the entity is still available or has been removed since the\nactivity was defined.\n\nThe available entity commands are divided into:\n- `entity_commands`: regular entity commands as defined in the [entity documentation](https://github.com/unfoldedcircle/core-api/tree/main/doc/entities).\n   The identifier refers to the common entity command definitions, which describe all required parameters for \n   defining a command. This includes the mandatory `cmd_id` name and optional parameters.\n\n   \U0001F477 TODO endpoint to retrieve entity command definitions.\n- `simple_commands`: additional, simple dynamic commands of an entity. Like infrared code commands of a\n   remote-entity. A simple command relates directly to the `cmd_id` attribute when executing a command and there's\n   no further mapping as for _entity_commands_.\n"
+      operationId: getActivity
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Activity'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - activities
+      summary: Update an activity entity.
+      operationId: updateActivity
+      description: |
+        Update one or multiple properties of an activity. The omitted properties are ignored and not deleted. To clear an
+        array simply provide an empty array.
+
+        - Button mappings are configured with the dedicated `/activities/{entityId}/buttons` and
+        `/activities/{entityId}/buttons/{button}` endpoints.
+        - The user interface is configured with the dedicated `/activities/{entityId}/ui`, `/activities/{entityId}/ui/pages`
+          and `/activities/{entityId}/ui/pages/{pageId}` endpoints.
+        - Sequence-commands are composed of command definitions (see description of `entity_commands` and
+          `simple_commands` in GET operation). The `entity_id` and `cmd_id` attributes are always required. The `params`
+          object is only required for `entity_commands` having parameters. 
+        - The special `"type": "delay"` command is not described in the entity command definitions and can only be used in
+          sequences.
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      requestBody:
+        description: Properties to update in the existing activity.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ActivityUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Activity'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - activities
+      summary: Delete an activity entity.
+      description: |
+        ⚠️ The given activity is irrevocably deleted.
+      operationId: deleteActivity
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/activities/{entityId}/buttons':
+    get:
+      tags:
+        - activities
+      summary: Get the physical button mappings.
+      operationId: getActivityButtonMappings
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceButtonMappings'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - activities
+      summary: Reset the physical button mappings to their default state.
+      description: |
+        An automatic mapping of common functions to the physical buttons is performed. This depends on the chosen entities,
+        e.g. an audio device will map the volume up & down keys and a TV or set-top box will map the channel up & down
+        commands.
+
+        ⚠️ The previous customization of the physical button mapping is irrevocably deleted.
+      operationId: resetActivityButtonMappings
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceButtonMappings'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/activities/{entityId}/buttons/{buttonId}':
+    get:
+      tags:
+        - activities
+      summary: Get a physical button mapping.
+      operationId: getActivityButtonMapping
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - $ref: '#/components/parameters/button_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceButtonMapping'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - activities
+      summary: Update a physical button mapping.
+      description: |
+        Update the button mapping for either a short- or a long-press.
+      operationId: updateActivityButtonMapping
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - $ref: '#/components/parameters/button_id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - type: object
+                  properties:
+                    short_press:
+                      $ref: '#/components/schemas/EntityCommand'
+                  required:
+                    - short_press
+                - type: object
+                  properties:
+                    long_press:
+                      $ref: '#/components/schemas/EntityCommand'
+                  required:
+                    - long_press
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceButtonMapping'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - activities
+      summary: Remove a physical button mapping.
+      description: |
+        ⚠️ The previous customization of the physical button mapping is irrevocably deleted.
+      operationId: deleteActivityButtonMapping
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - $ref: '#/components/parameters/button_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceButtonMappings'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/activities/{entityId}/ui':
+    get:
+      tags:
+        - activities
+      summary: Get the user interface definition of an activity.
+      description: |
+        Returns all the information required to manage an existing activity user interface.
+
+        At the moment a user interface only consists of pages.
+      operationId: getActivityUi
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityUserInterface'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - activities
+      summary: Reset an activity user interface to its default state.
+      description: |
+        ⚠️ The customization of the activity user interface is irrevocably deleted.
+      operationId: deleteActivityUi
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityUserInterface'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/activities/{entityId}/ui/pages':
+    post:
+      tags:
+        - activities
+      summary: Create a new user interface page
+      description: |
+        Append a new empty page to the user interface pages. The new page identifier is returned in the response.
+
+        The payload fields are optional. A page name and the items of the page can be specified, or later be added with 
+        `PATCH /activities/{entityId}/ui/pages/{pageId}`. If `grid` is not specified, the default grid size is used from
+        the screen metadata layout in `GET /cfg/device/screen_layout`
+      operationId: createActivityUiPage
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ActivityUserInterfacePageUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  page_id:
+                    $ref: '#/components/schemas/SimpleId'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    get:
+      tags:
+        - activities
+      summary: Get the user interface pages of an activity.
+      operationId: getActivityUiPages
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ActivityUserInterfacePage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - activities
+      summary: Update the activity user interface page order.
+      operationId: updateActivityUiPageOrder
+      description: |
+        Reorder the pages in the user interface according to the page identifiers in the `page_order` array.
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                page_order:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/SimpleId'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ActivityUserInterfacePage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - activities
+      summary: Reset the activity user interface pages to the default state.
+      description: |
+        The default page(s) is created and the page array returned.
+
+        ⚠️ The customization of the activity user interface is irrevocably deleted.
+      operationId: resetActivityUiPages
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ActivityUserInterfacePage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/activities/{entityId}/ui/pages/{pageId}':
+    get:
+      tags:
+        - activities
+      summary: Get the user interface page definition of a remote-entity.
+      operationId: getActivityUiPage
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - $ref: '#/components/parameters/page_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityUserInterfacePage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - activities
+      summary: Update an activity user interface page.
+      operationId: updateActivityUiPage
+      description: |
+        Update one or multiple properties of an activity user interface page. The omitted properties are ignored and not
+        deleted. To clear an array simply provide an empty array.
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - $ref: '#/components/parameters/page_id'
+      requestBody:
+        description: Properties to update in the existing activity user interface page.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ActivityUserInterfacePageUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityUserInterfacePage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - activities
+      summary: Delete an activity user interface page.
+      description: |
+        The given page is removed and the array of remaining pages is returned.
+
+        ⚠️ The customization of the activity user interface page is irrevocably deleted.
+      operationId: deleteActivityUiPage
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - $ref: '#/components/parameters/page_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ActivityUserInterfacePage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  /activity_groups:
+    head:
+      tags:
+        - activities
+      summary: Get total number of activity groups.
+      description: |
+        The total number of activity groups is returned in the `Pagination-Count` header. This allows to prepare the
+        retrieval of the groups with the `GET` operation and paging parameters.
+      operationId: getActivityGroupCount
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    get:
+      tags:
+        - activities
+      summary: Get activity groups overview with paging.
+      description: |
+        Returns an overview of all defined activity groups with the given paging parameters. Use the `HEAD` operation to
+        retrieve the total number of defined groups.
+
+        The overview information doesn't include all details of an activity group. The full group information is
+        retrievable with `/activity_group/{groupId}`.
+      operationId: getActivityGroups
+      parameters:
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityGroups'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    post:
+      tags:
+        - activities
+      summary: Create a new activity group.
+      description: |
+        Create a new activity group.
+      operationId: createActivityGroup
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ActivityGroupUpdate'
+        required: true
+      responses:
+        '201':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Activity'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+    delete:
+      tags:
+        - activities
+      summary: Delete all activity groups.
+      description: |
+        ⚠️ All defined activity groups will be irrevocably deleted!
+      operationId: deleteAllActivityGroups
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/activity_groups/{groupId}':
+    get:
+      tags:
+        - activities
+      summary: Get an activity group by its group_id.
+      description: |
+        Returns all the information required to manage an existing activity group.
+      operationId: getActivityGroup
+      parameters:
+        - $ref: '#/components/parameters/group_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityGroup'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - activities
+      summary: Update an activity group.
+      operationId: updateActivityGroup
+      description: |
+        Update one or multiple properties of an activity group. The omitted properties are ignored and not deleted.
+      parameters:
+        - $ref: '#/components/parameters/group_id'
+      requestBody:
+        description: Properties to update in the existing activity group.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ActivityGroupUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityGroup'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - activities
+      summary: Delete an activity group.
+      description: |
+        ⚠️ The given activity group is irrevocably deleted.
+      operationId: deleteActivityGroup
+      parameters:
+        - $ref: '#/components/parameters/group_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  /macros:
+    head:
+      tags:
+        - macros
+      summary: Get total number of macro entities.
+      description: |
+        The total number of available macros are returned in the `Pagination-Count` header. This allows to prepare the
+        retrieval of the macros with the `GET` operation and paging parameters.
+      operationId: getMacroCount
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    get:
+      tags:
+        - macros
+      summary: Get macro entities overview with paging.
+      description: |
+        Returns an overview of all defined macros with the given paging parameters. Use the `HEAD` operation to retrieve
+        the total number of defined macros.
+
+        The overview information doesn't include all details of a macro. The full macro information is retrievable
+        with `/macros/{entityId}`.
+      operationId: getMacros
+      parameters:
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Macros'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    post:
+      tags:
+        - macros
+      summary: Create a new macro entity.
+      description: |
+        Create a new entity of type `macro`. An macro entity is a special internal entity without association to an
+        integration driver.
+
+        To create a new macro at least a name must be provided. The `icon`, `description` and `options.entity_ids`
+        are optional and can be set later with the `PUT` update operation.
+
+        When setting a text in a multilingual field, like name or description, the default `en` identifier should always be
+        included.
+
+        The new macro can be cloned from another macro-entity identifier in `clone_from`. All applicable configuration will
+        be copied, except a new macro name must be specified. The `icon` and `description` fields can still be specified and
+        will override the copied data. The `options.entity_ids` is not allowed when cloning data, additional entities
+        can be added later with the `PUT` update operation.
+
+        The `entity_ids` may be omitted when creating a new macro and specified later when updating the macro.
+      operationId: createMacro
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MacroCreate'
+            examples:
+              simple:
+                value:
+                  name:
+                    en: My new macro
+              macro with icon and description:
+                value:
+                  name:
+                    en: My new macro
+                  icon: 'uc:bell'
+                  description:
+                    en: Testing the macro feature
+              clone:
+                value:
+                  name:
+                    en: My cloned macro
+                  clone_from: uc.main.macro.vacation-mode
+        required: true
+      responses:
+        '201':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Macro'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+    delete:
+      tags:
+        - macros
+      summary: Delete all macro entities.
+      description: |
+        ⚠️ All defined macros will be irrevocably deleted!
+      operationId: deleteAllMacros
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/macros/{entityId}':
+    get:
+      tags:
+        - macros
+      summary: Get a macro by its entity_id.
+      description: |
+        Returns all the information required to manage an existing macro. The included entities are enriched with `name`,
+        `icon`, `entity_type`, available commands and if the entity is still available or has been removed since the
+        macro was defined.
+      operationId: getMacro
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Macro'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - macros
+      summary: Update a macro entity.
+      operationId: updateMacro
+      description: |
+        Update one or multiple properties of a macro. The omitted properties are ignored and not deleted. To clear an
+        array simply provide an empty array.
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      requestBody:
+        description: Properties to update in the existing macro.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MacroUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Macro'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - macros
+      summary: Delete a macro entity.
+      description: |
+        ⚠️ The given macro is irrevocably deleted.
+      operationId: deleteMacro
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  /ir/codes/manufacturers:
+    get:
+      tags:
+        - infrared
+      summary: Search supported infrared device manufacturers.
+      description: |
+        Device manufacturer search. The returned manufacturer identification will be used for the manufacturer specific IR
+        code set search with `GET /ir/codes/manufacturers/{manufacturerId}`.
+      operationId: searchIrDeviceManufacturers
+      parameters:
+        - name: q
+          in: query
+          description: Manufacturer name query
+          required: true
+          schema:
+            type: string
+            minLength: 2
+          example: Lucky Goldstar
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      description: Manufacturer identification
+                      type: string
+                    name:
+                      description: Manufacturer name
+                      type: string
+                    custom:
+                      description: Flag indicating if this manufacturer was created by the user
+                      type: boolean
+                  required:
+                    - id
+                    - name
+              example:
+                - id: lg
+                  name: LG
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/ir/codes/manufacturers/{manufacturerId}':
+    get:
+      tags:
+        - infrared
+      summary: Search for infrared device code sets by manufacturer to create a remote entity.
+      description: |
+        Searching without the optional device query will only return the generic manufacturer IR code sets.
+      operationId: searchInfraredDevice
+      parameters:
+        - name: manufacturerId
+          in: path
+          description: Manufacturer identification from search
+          required: true
+          schema:
+            type: string
+        - name: q
+          in: query
+          description: Device name query for fulltext search. At least two characters are required.
+          required: false
+          schema:
+            type: string
+            minLength: 2
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      description: Code set identifier
+                      type: string
+                    name:
+                      description: Device name
+                      type: string
+                    custom:
+                      description: Flag indicating if this manufacturer was created by the user
+                      type: boolean
+                  required:
+                    - id
+                    - name
+              example:
+                - id: '1'
+                  name: Generic TV 1
+                  custom: false
+                - id: '2'
+                  name: Generic TV 2
+                  custom: false
+                - id: '3'
+                  name: Generic TV 3
+                  custom: false
+                - id: '4'
+                  name: Generic Projector
+                  custom: false
+                - id: '5'
+                  name: My BluRay Player
+                  custom: true
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/ir/codes/manufacturers/{manufacturerId}/{codeSetId}':
+    get:
+      tags:
+        - infrared
+      summary: Retrieve IR codeset command information for testing IR commands.
+      description: |
+        Returns all command identifiers of a given manufacturer code set.
+      operationId: getManufacturerCodeSet
+      parameters:
+        - name: manufacturerId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: codeSetId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+              example:
+                - POWER_ON
+                - POWER_OFF
+                - POWER_TOGGLE
+                - VOLUME_UP
+                - VOLUME_DOWN
+                - MUTE
+                - CHANNEL_UP
+                - CHANNEL_DOWN
+                - DPAD_LEFT
+                - DPAD_RIGHT
+                - DPAD_UP
+                - DPAD_DOWN
+                - ENTER
+                - OSD
+                - SETUP
+                - NUMPAD_0
+                - NUMPAD_1
+                - NUMPAD_2
+                - NUMPAD_3
+                - NUMPAD_4
+                - NUMPAD_5
+                - NUMPAD_6
+                - NUMPAD_7
+                - NUMPAD_8
+                - NUMPAD_9
+                - HDMI_1
+                - HDMI_2
+                - HDMI_3
+                - HDMI_4
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  /ir/codes/custom:
+    head:
+      tags:
+        - infrared
+      summary: Get total number of custom infrared code sets.
+      operationId: getCustomIrDeviceCount
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    get:
+      tags:
+        - infrared
+      summary: Get all custom infrared code sets or export as CSV.
+      description: |
+        Depending on the `Content-Type` header, the custom infrared code sets are either returned as JSON objects
+        or exported as a CSV file.
+
+        - `Content-Type: application/json` or none: retrieve all custom infrared code set with paging.  
+          Use `GET /ir/codes/custom/{codeSetId}` to access the IR code definitions of a codeset.
+
+        - `Content-Type: text/csv`: retrieve all custom codes as CSV export (without paging).  
+          Query parameters `page` and `limit` are ignored.
+      operationId: getCustomIrDeviceCodes
+      parameters:
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+        - name: delimiter
+          in: query
+          description: CSV delimiter character. Only for CSV export.
+          schema:
+            type: string
+            default: ','
+            minLength: 1
+            maxLength: 1
+      responses:
+        '200':
+          description: 'Successful operation, either with paginated JSON or CSV response.'
+          headers:
+            Pagination-Count:
+              description: Total number of code sets.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items. Only for json response.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based. Only for json response.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CodeSetInfo'
+            text/csv:
+              schema:
+                type: string
+              example: |
+                manufacturer,device,key,format,code
+                custom,My AVR,CURSOR_DOWN,HEX,3;0x20F0827D;32;0
+                custom,My AVR,CURSER_ENTER,HEX,3;0x20F022DD;32;0
+                custom,My AVR,CURSOR_LEFT,HEX,3;0x20F0E01F;32;0
+                custom,My AVR,CURSOR_RIGHT,HEX,3;0x20F0609F;32;0
+                custom,My AVR,CURSOR_UP,HEX,3;0x20F002FD;32;0
+                Foobar,TV,POWER_ON,PRONTO,0000 006d 0000 0024 0157 00ac 0015 0015 0015 0015 0015 0040 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0040 0015 0040 0015 0015 0015 0040 0015 0040 0015 0040 0015 0040 0015 0040 0015 0015 0015 0015 0015 0040 0015 0015 0015 0015 0015 0015 0015 0040 0015 0040 0015 0040 0015 0040 0015 0015 0015 0040 0015 0040 0015 0040 0015 0015 0015 0015 0015 0689 0157 0056 0015 0e94
+                Foobar,TV,POWER_OFF,PRONTO,0000 006d 0000 0024 0157 00ab 0015 0015 0016 0015 0016 003f 0016 0015 0015 0016 0015 0015 0016 0015 0016 0015 0015 0040 0015 0040 0015 0015 0016 003f 0016 003f 0016 003f 0016 003f 0016 003f 0016 003f 0016 0015 0016 003f 0016 0015 0015 0015 0016 0015 0016 003f 0016 003f 0016 0015 0015 0040 0015 0015 0016 003f 0016 003f 0016 003f 0016 0015 0016 0015 0015 05fd 0156 0055 0016 0ee1
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    post:
+      tags:
+        - infrared
+      summary: Create a new custom infrared code set.
+      description: |
+        Create a new custom codeset for an IR device. The IR codes can already be provided or added later with
+        `GET /ir/codes/custom/{codeSetId}/{key}`.
+
+        If the manufacturer isn't provided, the codeset will be linked to the custom manufacturer entry for self learned
+        codes.
+      operationId: createCustomIrDevice
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CodeSetCreate'
+        required: true
+      responses:
+        '201':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CodeSetInfo'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+    delete:
+      tags:
+        - infrared
+      summary: Delete all custom infrared code sets.
+      description: |
+        ⚠️ All defined custom infrared device codes will be irrevocably deleted!
+      operationId: deleteAllCustomIrDeviceCodes
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/ir/codes/custom/{codeSetId}':
+    get:
+      tags:
+        - infrared
+      summary: Get custom infrared code set or export as CSV.
+      description: |
+        Depending on the `Content-Type` header, the full definition of a custom infrared code set including the IR codes is
+        returned as JSON or exported as a CSV file.
+
+        - `Content-Type: application/json` or none: retrieve infrared code set as JSON.
+        - `Content-Type: text/csv`: export codeset as CSV.
+      operationId: getCustomIrDeviceCodeSet
+      parameters:
+        - name: codeSetId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: delimiter
+          in: query
+          description: CSV delimiter character. Only for CSV export.
+          schema:
+            type: string
+            default: ','
+            minLength: 1
+            maxLength: 1
+      responses:
+        '200':
+          description: 'Successful operation, either with paginated JSON or CSV response.'
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items. Only for json response.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based. Only for json response.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CodeSet'
+            text/csv:
+              schema:
+                type: string
+              example: |
+                key,format,code
+                CURSOR_DOWN,HEX,3;0x20F0827D;32;0
+                CURSER_ENTER,HEX,3;0x20F022DD;32;0
+                CURSOR_LEFT,HEX,3;0x20F0E01F;32;0
+                CURSOR_RIGHT,HEX,3;0x20F0609F;32;0
+                CURSOR_UP,HEX,3;0x20F002FD;32;0
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - infrared
+      summary: Modify a custom infrared code set.
+      description: |
+        Rename the device or change the device type of an infrared code set.
+
+        A device name must be unique and only custom infrared code sets can be modified.
+      operationId: updateCustomIrDeviceCodeSet
+      parameters:
+        - name: codeSetId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CodeSetUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CodeSetInfo'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+    post:
+      tags:
+        - infrared
+      summary: Bulk upload infrared codes with a CSV file.
+      description: |
+        Upload multiple IR codes from a CSV file into an existing code set.
+
+        CSV file format:
+        - delimiter character is `,` (comma). This can be overwritten with the query parameter `delimiter`.
+        - character set: plain ASCII or UTF-8.
+        - the first line must contain a header row.
+        - required header columns:
+          - `key`: Key / button of the IR code.
+            - Valid character RegEx: `^[a-zA-Z0-9\-_\.]{1,50}$`
+            - Invalid characters will be replaced with an underscore.
+          - `code`: IR code
+          - ⚠️`key` and `code` must be lower-case, otherwise a validation error will be returned.
+        - optional header column:
+          - `format`: IR code format: `PRONTO` or `HEX`. Default if missing: `PRONTO`
+        - order of the header columns is not relevant, additional columns will be ignored.
+        - rows with an empty `key` or `code` value are ignored.
+        - duplicate `key` values are not allowed.
+          - The optional `overwrite` query parameter applies to existing keys only.
+        - max size: 10 MB
+
+        Minimal example:
+        ```csv
+        key,code
+        POWER_ON,0000 006d 0000 0020 000a
+        POWER_OFF,0000 006d 0000 0020 000b
+        ```
+
+        Notes:    
+        - If multiple files are specified in the form-data, only the first one will be processed.
+        - Header and values are automatically trimmed from leading and trailing whitespace.
+        - ⚠️ In case there's an invalid record in the CSV file, all previous valid records will be added to the data set.
+      operationId: uploadCustomIrDeviceCodeSet
+      parameters:
+        - name: codeSetId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: overwrite
+          in: query
+          description: Overwrite existing IR codes with the same key. Otherwise only new codes are added.
+          schema:
+            type: boolean
+            default: false
+        - name: delimiter
+          in: query
+          description: CSV delimiter character
+          schema:
+            type: string
+            default: ','
+            minLength: 1
+            maxLength: 1
+        - name: comment
+          in: query
+          description: |
+            The comment character at the start of a line to use when parsing CSV. No comment character is set by default.
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 1
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  description: IR code file to upload. File ending must be `.csv`.
+                  type: string
+                  format: binary
+        required: true
+      responses:
+        '200':
+          description: Successful CSV import
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CodeSetUploadResult'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - infrared
+      summary: Delete custom infrared code set.
+      description: |
+        ⚠️ All defined custom infrared device codes will be irrevocably deleted!
+      operationId: deleteCustomIrDeviceCodeSet
+      parameters:
+        - name: codeSetId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/ir/codes/custom/{codeSetId}/{key}':
+    get:
+      tags:
+        - infrared
+      summary: Get a code definition from a custom infrared code set.
+      description: |
+        Retrieve the code definition for the given key in the infrared code set.
+      operationId: getCodeInCustomIrDeviceCodeSet
+      parameters:
+        - name: codeSetId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/ir_key'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IrCode'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    post:
+      tags:
+        - infrared
+      summary: Add a new key to a custom infrared code set.
+      description: |
+        Enhance the infrared code set with a new key. The key must be unique in a given code set. Only custom code sets can
+        be modified.
+      operationId: addKeyInCustomIrDeviceCodeSet
+      parameters:
+        - name: codeSetId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/ir_key'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IrCodeUpdate'
+        required: true
+      responses:
+        '201':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+    put:
+      tags:
+        - infrared
+      summary: Modify a code in a custom infrared code set.
+      description: |
+        Update the code definition of a key in an infrared code set. Only custom code sets can be modified.
+      operationId: updateCodeInCustomIrDeviceCodeSet
+      parameters:
+        - name: codeSetId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/ir_key'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IrCodeUpdate'
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - infrared
+      summary: Delete an entry in a custom infrared code set.
+      description: |
+        ⚠️ The key in the custom infrared device code set will be irrevocably deleted!
+      operationId: deleteKeyInCustomIrDeviceCodeSet
+      parameters:
+        - name: codeSetId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/ir_key'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/ir/convert/{format}':
+    get:
+      tags:
+        - infrared
+      summary: Convert an IR code into a different format.
+      description: |
+        This GET endpoint to convert IR codes is intended for simple scripts and tests.
+
+        Parameters:
+        - `code`: URL encoded PRONTO code or HEX Code (spaces, commas and semicolons must be encoded).
+        - `repeat`: How many times to decode the repeat part of the IR code.
+          - Only relevant for IR formats not containing a repeat count, as: PRONTO
+          - PRONTO codes: repeats the data in the repeat sequence of the code.
+            - If the 4th field of the PRONTO code is `0000`, then it doesn't contain a repeat sequence and the repeat
+              parameter is ignored!
+            - If the code only contains a repeat sequence and a missing first sequence (3rd field is `0000`), the repeat
+              sequence is encoded at least once and the repeat count automatically increased by one.
+        - `to`: The destination format. Only RAW IR timings are supported at the moment.
+      operationId: convertIrCode
+      parameters:
+        - name: format
+          in: path
+          description: IR format
+          required: true
+          schema:
+            $ref: '#/components/schemas/IrCodeFormat'
+        - name: code
+          in: query
+          description: IR code
+          required: true
+          schema:
+            type: string
+            minLength: 1
+        - name: repeat
+          in: query
+          description: Repeat count for PRONTO code
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 20
+        - name: to
+          in: query
+          description: Destination IR format
+          required: false
+          schema:
+            type: string
+            enum:
+              - RAW
+      responses:
+        '200':
+          description: Successful IR code conversion
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IrRawCode'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  /ir/emitters:
+    head:
+      tags:
+        - infrared
+      summary: Get total number of infrared emitter devices.
+      operationId: getInfraredEmitterCount
+      parameters:
+        - $ref: '#/components/parameters/active'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    get:
+      tags:
+        - infrared
+      summary: Get all infrared emitter devices for sending IR codes.
+      operationId: getInfraredEmitters
+      parameters:
+        - $ref: '#/components/parameters/active'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IrEmitters'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/ir/emitters/{emitterId}':
+    get:
+      tags:
+        - infrared
+      summary: Get an IR emitter device.
+      operationId: getIrEmitter
+      parameters:
+        - $ref: '#/components/parameters/emitter_id'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IrEmitter'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/ir/emitters/{emitterId}/send':
+    put:
+      tags:
+        - infrared
+      summary: Send IR command.
+      description: |
+        Send an IR command from the specified command set or a learned / custom code on the given emitter and output port.
+
+        ### Continuous IR repeat
+        If supported by the emitter, this feature allows to repeat an IR signal autonomously by the emitting device for
+        a specified number of times.
+
+        ⚠️ Supported on the UnfoldedCircle Dock with firmware version 0.9.0 or newer. 
+
+        The repeated IR signal is usually a special IR command to tell the receiving device, that a button on a remote
+        control is hold for a longer time. Depending on the device, a repeat signal can either simply execute the same
+        action as if someone would rapidly press the same button, or it can adjust the command to a different function.
+        One common example is to progressively increase the volume steps, e.g. start slowly with 0.1 dBA steps, then
+        after a short time increase to 0.5 or 1 dBA steps.  
+        Please note that not all devices or IR formats / commands support this feature. This is manufacturer specific.
+
+        The continuous IR repeat feature is activated with the optional `repeat` field in the request.
+        - The IR repeat signal will automatically be sent the number of times specified in the repeat field.
+        - If the next request contains the same IR command, the repeat count will be reset in the dock and therefore
+          the repeat signal prolonged.
+        - A 'PUT /ir/emitters/{emitterId}/stop_send' request will stop the remaining repeat commands.
+        - Depending on the IR `format`, a repeat value might be already part of the `code`.
+          - ⚠️ The `repeat` value will override the embedded repeat information.
+          - See _IR formats_ below.
+
+        If `repeat` is not specified (or set to zero):
+        - The stored IR code in the `codeset_id` or provided `code` is sent as is, with the contained repeat information
+          (depending on IR format).
+        - Continuous IR repeat is not activated:
+          - every IR send request will send the full IR command.
+          - ⚠️ the 'PUT /ir/emitters/{emitterId}/stop_send' command will have no effect!
+
+        ### IR formats
+        - `PRONTO`: PRONTO HEX format:
+          - Only raw codes are supported (first number is `0000`).
+          - The PRONTO HEX format does not include a dedicated repeat count field, but an optional 2nd burst
+            pair sequence used for repeats.
+            - The third number in the PRONTO code specifies the number of burst pairs in the 1st sequence.
+            - The fourth number in the PRONTO code specifies the number of burst pairs in the 2nd sequence.
+            - If the fourth number is 0, then there's no repeat sequence.
+            - Note that either sequence is optional. Also there might be both sequences defined, or only the
+              1st or 2nd one.
+          - If the `repeat` field is set (> 0), the 2nd burst pair sequence of the PRONTO code is repeated.
+            - If the PRONTO code doesn't contain a 2nd burst pair sequence, then the repeat value is ignored.
+        - `HEX`: Unfolded Circle format:
+          - The repeat count is part of the code and might be required for certain protocols.
+            - E.g. Sony needs to send the same command two or three times so it's recognized as a single
+              command by a device.
+          - If the `repeat` field is set (> 0), this will override the repeat count in `code` (and not multiply the total
+            repeat count)!
+          - The actual emitted IR repeat signal depends on the IR protocols.
+            - E.g. Denon will simply repeat the full command, whereas LG has a mandatory repeat-specific code
+              sent after the command. This is all handled by the dock, when sending the IR code.
+      operationId: sendCommandOnEmitter
+      parameters:
+        - $ref: '#/components/parameters/emitter_id'
+      requestBody:
+        description: IR command
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - type: object
+                  description: Command from a codeset.
+                  properties:
+                    codeset_id:
+                      description: Infrared codeset identifier.
+                      type: string
+                    cmd_id:
+                      description: Command identifier in the codeset.
+                      type: string
+                    repeat:
+                      description: |
+                        Optional repeat value for sending continuous IR repeat signals (depending on IR protocol).
+                      type: integer
+                      minimum: 0
+                      maximum: 20
+                    cmd_delay:
+                      description: |
+                        Optional delay between sending IR commands, if `cmd_id` refers to a command with multiple IR codes.
+                      type: integer
+                      minimum: 0
+                    port_id:
+                      description: Optional output port identifier. The default output will be used if omitted.
+                      type: string
+                  required:
+                    - codeset_id
+                    - cmd_id
+                - type: object
+                  description: IR code.
+                  properties:
+                    code:
+                      description: |
+                        IR code to send.
+                        - PRONTO codes can use a space or comma as separator.
+                        - Multiple codes can be separated by a plus `+` (for example: `0000 0068 0001 0000 0001 + 0000 0068 0001 0000 0002`).
+                      type: string
+                    format:
+                      $ref: '#/components/schemas/IrCodeFormat'
+                    repeat:
+                      description: |
+                        Optional repeat value for sending continuous IR repeat signals (depending on IR protocol).
+                      type: integer
+                      minimum: 0
+                      maximum: 20
+                    cmd_delay:
+                      description: |
+                        Optional delay between sending commands if `code` contains more than one IR command.
+                      type: integer
+                      minimum: 0
+                    port_id:
+                      description: Optional output port identifier. The default output will be used if omitted.
+                      type: string
+                  required:
+                    - code
+                    - format
+            examples:
+              Command from a codeset on default output:
+                value:
+                  codeset_id: ir.manufacturer.123
+                  cmd_id: CHANNEL_DOWN
+              Command from a codeset on default output and repeat count:
+                value:
+                  codeset_id: ir.manufacturer.123
+                  cmd_id: VOLUME_DOWN
+                  repeat: 4
+              Command from a codeset on specific output:
+                value:
+                  codeset_id: ir.manufacturer.123
+                  cmd_id: CHANNEL_DOWN
+                  port_id: '4'
+              PRONTO code on default output:
+                value:
+                  code: '0000,0068,0000,0010,0060,0018,0030,0018,0018,0018,0030,0018,0018,0018,0018,0018,0030,0018,0018,0018,0030,0018,0030,0018,0030,0018,0018,0018,0030,0018,0018,0018,0018,0018,0030,0318'
+                  format: PRONTO
+              PRONTO code on default output and repeat count:
+                value:
+                  code: 0000 0068 0000 0010 0060 0018 0030 0018 0018 0018 0030 0018 0018 0018 0018 0018 0030 0018 0018 0018 0030 0018 0030 0018 0030 0018 0018 0018 0030 0018 0018 0018 0018 0018 0030 0318
+                  format: PRONTO
+                  repeat: 4
+              Learned HEX code on specific output:
+                value:
+                  code: 3;0x20F0A956;32;0
+                  format: HEX
+                  port_id: '4'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+  '/ir/emitters/{emitterId}/stop_send':
+    put:
+      tags:
+        - infrared
+      summary: Stop sending an IR command.
+      description: |
+        Stop an active IR repeat transmission.
+      operationId: stopSendOnEmitter
+      parameters:
+        - $ref: '#/components/parameters/emitter_id'
+      requestBody:
+        description: IR stop command
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                port_id:
+                  description: |
+                    Optional output port identifier. Requires support by IR emitter device.
+                    Not supported by Unfolded Circle dock
+                  type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+  '/ir/emitters/{emitterId}/learn':
+    get:
+      tags:
+        - infrared
+      summary: Get IR learning status and results.
+      description: |
+        Returns the current status and if the dock is in IR learning mode. All learned codes will be returned since the
+        start of the learning session.
+      operationId: irLearningStatusEmitter
+      parameters:
+        - $ref: '#/components/parameters/emitter_id'
+      responses:
+        '200':
+          description: IR learning status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IrEmitterLearnStatus'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    put:
+      tags:
+        - infrared
+      summary: Start IR learning.
+      description: |
+        Learn IR commands from the given emitter with learning capability. The learning session will be stopped
+        automatically after the timeout, unless it hasn't been stopped with the `DELETE` operation, or a new learning
+        session has been initiated.
+
+        Any learned code will immediately be sent as a WebSocket `ir_learning`event message in the `emitters` channel.
+        Furthermore, the codes are stored for retrieval with the `GET` status call. There's a maximum of 16 learned
+        codes per session. Any additional codes will be ignored and only sent as a WebSocket event.
+
+        Calling this function, while learning is still active, will extend the timeout. Any previously learned codes
+        will not be deleted.
+      operationId: startIrLearningEmitter
+      parameters:
+        - $ref: '#/components/parameters/emitter_id'
+        - name: timeout
+          in: query
+          description: Timeout in seconds.
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 60
+            minimum: 1
+            maximum: 300
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    delete:
+      tags:
+        - infrared
+      summary: Stop IR learning and clear results.
+      description: |
+        The current status and any learned codes will be returned. After this call the learned codes are no longer
+        accessible through the `GET` status call.
+      operationId: stopIrLearningEmitter
+      parameters:
+        - $ref: '#/components/parameters/emitter_id'
+      responses:
+        '200':
+          description: IR learning status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IrEmitterLearnStatus'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  /remotes:
+    head:
+      tags:
+        - remotes
+      summary: Get total number of remote-entities.
+      description: |
+        The total number of available remotes are returned in the `Pagination-Count` header. This allows to prepare the
+        retrieval of the remotes with the `GET` operation and paging parameters.
+      operationId: getRemoteCount
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    get:
+      tags:
+        - remotes
+      summary: Get remote-entities overview with paging.
+      description: |
+        Returns an overview of all defined remotes with the given paging parameters. Use the `HEAD` operation to retrieve
+        the total number of defined remotes.
+
+        The overview information doesn't include all details of a remote. The full remote information is retrievable
+        with `/remotes/{entityId}`.
+      operationId: getInfraredEntities
+      parameters:
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Remotes'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    post:
+      tags:
+        - remotes
+      summary: Create a new remote-entity with a manufacturer IR code set or an empty custom code set.
+      description: |
+        Create a new entity of type `remote`. An remote-entity is a special internal entity without association to an
+        integration driver.
+
+        To create a new remote at least a name must be provided. If no manufacturer infrared code set is specified in
+        `options.codeset_id`, a new custom code set is automatically created for the user to manually specify or learn the
+        codes.  
+        The `icon` and `description` properties are optional and can be set later with the `PUT` update operation.
+
+        When setting a text in a multilingual field, like name or description, the default `en` identifier should always be
+        included.
+
+        The new remote can be cloned from another remote-entity identifier in `clone_from`. All applicable configuration
+        will be copied, except a new remote name must be specified. The `icon` and `description` fields can still be
+        specified and will override the copied data. The `options.codeset_id` is not allowed when cloning data.
+      operationId: createRemote
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RemoteCreate'
+            examples:
+              create with existing code set:
+                value:
+                  name:
+                    en: My new remote
+                  codeset_id: ir.manufacturer.123
+              crate with custom code set (default device type & manufacturer):
+                value:
+                  name:
+                    en: My custom remote
+                  custom_codeset:
+                    device_name: My device
+              'remote with icon, description and custom code set':
+                value:
+                  name:
+                    en: My custom remote
+                  icon: 'uc:movie'
+                  description:
+                    en: Testing the custom code set feature
+                  custom_codeset:
+                    manufacturer_id: custom
+                    device_name: My device
+                    device_type: various
+              clone:
+                value:
+                  name:
+                    en: My cloned remote
+                  clone_from: uc.main.remote.my-other-remote
+        required: true
+      responses:
+        '201':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Remote'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+    delete:
+      tags:
+        - remotes
+      summary: Delete all remote-entities.
+      description: |
+        ⚠️ All defined entities will be irrevocably deleted!
+      operationId: deleteAllRemotes
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/remotes/{entityId}':
+    get:
+      tags:
+        - remotes
+      summary: Get a remote-entity by its entity_id.
+      description: |
+        Returns all the information required to manage an existing remote.
+      operationId: getRemote
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Remote'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - remotes
+      summary: Update a remote-entity.
+      operationId: updateRemote
+      description: |
+        Update one or multiple properties of a remote-entity. The omitted properties are ignored and not deleted.
+        To clear an array simply provide an empty array.
+
+        - Button mappings are configured with the dedicated `/remotes/{entityId}/buttons` and
+          `/remote/{entityId}/buttons/{button}` endpoints.
+        - The user interface is configured with the dedicated `/remotes/{entityId}/ui`, `/remotes/{entityId}/ui/pages`
+          and `/remotes/{entityId}/ui/pages/{pageId}` endpoints.
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      requestBody:
+        description: Properties to update in the existing remote-entity.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RemoteUpdate'
+            examples:
+              'Name, icon and description':
+                value:
+                  name:
+                    en: New remote name
+                  icon: 'uc:tv'
+                  description:
+                    en: Updated description
+              Output emitter:
+                value:
+                  options:
+                    ir:
+                      output:
+                        device_id: sim.1
+                        port_id: '4'
+              Infrared code set (NOT YET IMPLEMENTED):
+                value:
+                  options:
+                    ir:
+                      codeset:
+                        id: lg3
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Remote'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - remotes
+      summary: Delete a remote-entity.
+      description: |
+        ⚠️ The given entity is irrevocably deleted.
+      operationId: deleteRemote
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/remotes/{entityId}/ir':
+    get:
+      tags:
+        - remotes
+      summary: Get the infrared dataset of the remote-entity.
+      description: |
+        Returns all the information required to manage the infrared dataset.
+      operationId: getRemoteIrDataSet
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteIrDataSet'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/remotes/{entityId}/ir/{cmdId}':
+    post:
+      tags:
+        - remotes
+      summary: Add a custom infrared command to the codeset.
+      operationId: addRemoteIrCode
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - $ref: '#/components/parameters/cmd_id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                value:
+                  $ref: '#/components/schemas/IrCodeValue'
+                format:
+                  $ref: '#/components/schemas/IrCodeFormat'
+              required:
+                - value
+                - format
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteIrCode'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    get:
+      tags:
+        - remotes
+      summary: Gets an infrared code in the codeset.
+      description: |
+        Returns the details of a given infrared command.
+      operationId: getRemoteIrCode
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - name: cmdId
+          in: path
+          description: IR command identification.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteIrCode'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - remotes
+      summary: Update an infrared command in the codeset.
+      operationId: updateRemoteIrCode
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - name: cmdId
+          in: path
+          description: IR command identification.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                value:
+                  $ref: '#/components/schemas/IrCodeValue'
+                format:
+                  $ref: '#/components/schemas/IrCodeFormat'
+              required:
+                - value
+                - format
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteIrCode'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - remotes
+      summary: Delete a custom ir code or reset a modified manufacturer code in the codeset.
+      operationId: deleteOrResetRemoteIrCode
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - name: cmdId
+          in: path
+          description: IR command identification.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/remotes/{entityId}/buttons':
+    get:
+      tags:
+        - remotes
+      summary: Get the physical button mappings.
+      operationId: getRemoteButtonMappings
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceButtonMappings'
+              example:
+                - button: DPAD_DOWN
+                  short_press:
+                    cmd_id: CURSOR_DOWN
+                  long_press:
+                    cmd_id: BACK
+                - button: DPAD_MIDDLE
+                  short_press:
+                    cmd_id: CURSOR_ENTER
+                - button: DPAD_LEFT
+                  short_press:
+                    cmd_id: CURSOR_LEFT
+                - button: DPAD_RIGHT
+                  short_press:
+                    cmd_id: CURSOR_RIGHT
+                - button: DPAD_UP
+                  short_press:
+                    cmd_id: CURSOR_UP
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - remotes
+      summary: Reset the physical button mappings to their default state.
+      description: |
+        An automatic mapping of common functions to the physical buttons is performed. This depends on the chosen IR codeset
+        if e.g. the volume up & down keys are automatically mapped.
+
+        ⚠️ The previous customization of the physical button mapping is irrevocably deleted.
+      operationId: resetRemoteButtonMappings
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceButtonMappings'
+              example:
+                - button: BACK
+                  short_press:
+                    cmd_id: BACK
+                - button: DPAD_DOWN
+                  short_press:
+                    cmd_id: CURSOR_DOWN
+                - button: DPAD_MIDDLE
+                  short_press:
+                    cmd_id: CURSOR_ENTER
+                - button: DPAD_LEFT
+                  short_press:
+                    cmd_id: CURSOR_LEFT
+                - button: DPAD_RIGHT
+                  short_press:
+                    cmd_id: CURSOR_RIGHT
+                - button: DPAD_UP
+                  short_press:
+                    cmd_id: CURSOR_UP
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/remotes/{entityId}/buttons/{buttonId}':
+    get:
+      tags:
+        - remotes
+      summary: Get a physical button mapping.
+      operationId: getRemoteButtonMapping
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - $ref: '#/components/parameters/button_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceButtonMapping'
+              example:
+                button: DPAD_DOWN
+                short_press:
+                  cmd_id: HOME
+                long_press:
+                  cmd_id: MENU
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - remotes
+      summary: Update a physical button mapping.
+      description: |
+        Update the button mapping for either a short- or a long-press.
+
+        ⚠️ In the EntityCommand object the `entity_id` may not be specified. A remote-entity always operates on its own
+        commands. If you want to control other entities, an activity must be used.
+      operationId: updateRemoteButtonMapping
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - $ref: '#/components/parameters/button_id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - type: object
+                  properties:
+                    short_press:
+                      $ref: '#/components/schemas/EntityCommand'
+                  required:
+                    - short_press
+                - type: object
+                  properties:
+                    long_press:
+                      $ref: '#/components/schemas/EntityCommand'
+                  required:
+                    - long_press
+            examples:
+              short button press:
+                value:
+                  short_press:
+                    cmd_id: HOME
+              long button press:
+                value:
+                  long_press:
+                    cmd_id: MENU
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceButtonMapping'
+              example:
+                button: DPAD_DOWN
+                short_press:
+                  cmd_id: HOME
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - remotes
+      summary: Remove a physical button mapping.
+      description: |
+        ⚠️ The previous customization of the physical button mapping is irrevocably deleted.
+      operationId: deleteRemoteButtonMapping
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - $ref: '#/components/parameters/button_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceButtonMappings'
+              example:
+                - button: DPAD_MIDDLE
+                  short_press:
+                    cmd_id: CURSOR_ENTER
+                - button: DPAD_LEFT
+                  short_press:
+                    cmd_id: CURSOR_LEFT
+                - button: DPAD_RIGHT
+                  short_press:
+                    cmd_id: CURSOR_RIGHT
+                - button: DPAD_UP
+                  short_press:
+                    cmd_id: CURSOR_UP
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/remotes/{entityId}/ui':
+    get:
+      tags:
+        - remotes
+      summary: Get the user interface definition of a remote-entity.
+      description: |
+        Returns all the information required to manage an existing remote user interface.
+
+        At the moment a user interface only consists of pages.
+      operationId: getRemoteUi
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityUserInterface'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - remotes
+      summary: Reset a remote user interface to its default state.
+      description: |
+        ⚠️ The customization of the remote user interface is irrevocably deleted.
+      operationId: deleteRemoteUi
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityUserInterface'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/remotes/{entityId}/ui/pages':
+    post:
+      tags:
+        - remotes
+      summary: Create a new user interface page
+      description: |
+        Append a new empty page to the user interface pages. The new page identifier is returned in the response.
+
+        The payload fields are optional. A page name and the items of the page can be specified, or later be added with 
+        `PATCH /remotes/{entityId}/ui/pages/{pageId}`. If `grid` is not specified, the default grid size is used from
+        the screen metadata layout in `GET /cfg/device/screen_layout`
+
+        ⚠️ If the user interface items with `command` objects are specified, then the `EntityCommand` structure may not
+        contain an `entity_id` field. A remote-entity always operates on itself.
+      operationId: createRemoteUiPage
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ActivityUserInterfacePageUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  page_id:
+                    $ref: '#/components/schemas/SimpleId'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    get:
+      tags:
+        - remotes
+      summary: Get the user interface pages of a remote-entity.
+      operationId: getRemoteUiPages
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ActivityUserInterfacePage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - remotes
+      summary: Update the remote user interface page order.
+      operationId: updateRemoteUiPageOrder
+      description: |
+        Reorder the pages in the user interface according to the page identifiers in the `page_order` array.
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                page_order:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/SimpleId'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ActivityUserInterfacePage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - remotes
+      summary: Reset the remote user interface pages to the default state.
+      description: |
+        The default page(s) is created and the page array returned.
+
+        ⚠️ The customization of the remote user interface is irrevocably deleted.
+      operationId: resetRemoteUiPages
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ActivityUserInterfacePage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/remotes/{entityId}/ui/pages/{pageId}':
+    get:
+      tags:
+        - remotes
+      summary: Get the user interface page definition of a remote-entity.
+      operationId: getRemoteUiPage
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - $ref: '#/components/parameters/page_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityUserInterfacePage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - remotes
+      summary: Update a remote user interface page.
+      operationId: updateRemoteUiPage
+      description: |
+        Update one or multiple properties of a remote user interface page. The omitted properties are ignored and not deleted.
+        To clear an array simply provide an empty array.
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - $ref: '#/components/parameters/page_id'
+      requestBody:
+        description: Properties to update in the existing remote user interface page.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ActivityUserInterfacePageUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityUserInterfacePage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - remotes
+      summary: Delete a remote user interface page.
+      description: |
+        The given page is removed and the array of remaining pages is returned.
+
+        ⚠️ The customization of the remote user interface page is irrevocably deleted.
+      operationId: deleteRemoteUiPage
+      parameters:
+        - $ref: '#/components/parameters/entity_id'
+        - $ref: '#/components/parameters/page_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ActivityUserInterfacePage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  /profiles:
+    post:
+      tags:
+        - profiles
+      summary: Create a new profile.
+      description: |
+        There are two different types of profiles:
+
+        - Normal profile (default): can do anything, change settings, add pages, entities, integrations, etc.
+        - Restricted profile: intended for guests or children, who can only use the remote, but cannot change settings.
+
+        The admin PIN is required to switch from a restricted to a normal profile. It can be defined in settings.  
+
+        - Switching away from a restricted profile will prompt the user to enter the admin PIN.
+        - Switching to a restricted profile can be done without entering the admin PIN.
+
+        Profile request object:    
+        - `profile_id` is optional and auto-generated if not specified. Otherwise it needs to be a unique profile identifier.
+        - `name` is mandatory and must be unique.
+        - if the first profile is added, it is automatically set as the active profile.
+      operationId: createProfile
+      requestBody:
+        description: Profile data
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProfileRequest'
+            examples:
+              Simple profile:
+                value:
+                  name: My profile
+              Profile with an icon:
+                value:
+                  name: My profile
+                  icon: 'uc:star'
+              Restricted profile:
+                value:
+                  name: Guests
+                  icon: 'uc:lock'
+                  restricted: true
+        required: true
+      responses:
+        '201':
+          description: Successful operation returning the profile identifier in the response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Profile'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+    put:
+      tags:
+        - profiles
+      summary: Switch active profile.
+      description: |
+        The administrator PIN in `admin_pin` is required to switch from a restricted to a normal profile.
+        If the current profile is a restricted profile and the pin is missing, error `401` is returned.
+      operationId: switchProfile
+      parameters:
+        - name: active_profile_id
+          in: query
+          description: Active profile identifier
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Optional administrator pin
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                admin_pin:
+                  $ref: '#/components/schemas/AdminPin'
+        required: false
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    get:
+      tags:
+        - profiles
+      summary: Get all profiles or the active profile.
+      description: |
+        If the active profile is requested and no profile exists, or set active, 404 is returned.
+      operationId: getProfiles
+      parameters:
+        - $ref: '#/components/parameters/active'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Profiles'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - profiles
+      summary: Delete all profiles.
+      operationId: deleteAllProfiles
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/profiles/{profileId}':
+    get:
+      tags:
+        - profiles
+      summary: Get profile.
+      operationId: getProfile
+      parameters:
+        - $ref: '#/components/parameters/profile_id'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Profile'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - profiles
+      summary: Update properties of a profile.
+      description: |
+        Update one or multiple properties of a profile. A missing property will not update its current value.  
+        - `profile_id` is mandatory and can't be changed.
+        - an empty `icon` value removes an existing icon identifier.
+        - a missing `pages` property will not change the page order.
+        - ⚠️ an empty `pages` array removes all pages and groups in the profile!
+        - ⚠️ missing page identifiers in the `pages` array will remove the page configuration!
+      operationId: updateProfile
+      parameters:
+        - $ref: '#/components/parameters/profile_id'
+      requestBody:
+        description: Properties to update in the existing profile.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProfileUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Profile'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - profiles
+      summary: Delete profile.
+      operationId: deleteProfile
+      parameters:
+        - $ref: '#/components/parameters/profile_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/profiles/{profileId}/pages':
+    post:
+      tags:
+        - profiles
+      summary: Create a new page in the profile.
+      operationId: createPage
+      parameters:
+        - $ref: '#/components/parameters/profile_id'
+      requestBody:
+        description: Profile data
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PageCreate'
+            examples:
+              Simple page:
+                value:
+                  name: My page
+              New page at the first position:
+                value:
+                  name: Favorites
+                  pos: 1
+              New page with items:
+                value:
+                  name: My other page
+                  items:
+                    - entity_id: switch1
+                    - entity_id: mediaplayer1
+                    - entity_id: blind1
+                    - group_id: 'def:g2'
+        required: true
+      responses:
+        '201':
+          description: Successful operation returning the page identifier in the response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Page'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+    get:
+      tags:
+        - profiles
+      summary: Get all pages of the profile.
+      operationId: getPagesInProfile
+      parameters:
+        - $ref: '#/components/parameters/profile_id'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Page'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - profiles
+      summary: Delete all pages of the profile.
+      operationId: deleteAllPagesInProfile
+      parameters:
+        - $ref: '#/components/parameters/profile_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/profiles/{profileId}/pages/{pageId}':
+    get:
+      tags:
+        - profiles
+      summary: Get a page of the profile
+      operationId: getPage
+      parameters:
+        - $ref: '#/components/parameters/profile_id'
+        - $ref: '#/components/parameters/page_id'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Page'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - profiles
+      summary: Update properties of a page.
+      operationId: updatePage
+      parameters:
+        - $ref: '#/components/parameters/profile_id'
+        - $ref: '#/components/parameters/page_id'
+      requestBody:
+        description: Properties to update in the existing page.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PageUpdate'
+            examples:
+              Rename page:
+                value:
+                  name: A better name
+              Rearrange items:
+                value:
+                  items:
+                    - entity_id: mediaplayer1
+                    - group_id: 'def:g2'
+                    - entity_id: blind1
+                    - entity_id: switch1
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Page'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - profiles
+      summary: Delete a page of the profile.
+      operationId: deletePage
+      parameters:
+        - $ref: '#/components/parameters/profile_id'
+        - $ref: '#/components/parameters/page_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/profiles/{profileId}/groups':
+    post:
+      tags:
+        - profiles
+      summary: Create a new group in the profile.
+      operationId: createGroup
+      parameters:
+        - $ref: '#/components/parameters/profile_id'
+      requestBody:
+        description: Profile data
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Group'
+        required: true
+      responses:
+        '201':
+          description: Successful operation returning the page identifier in the response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+    get:
+      tags:
+        - profiles
+      summary: Get all groups of the profile.
+      operationId: getGroupsInProfile
+      parameters:
+        - $ref: '#/components/parameters/profile_id'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Groups'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - profiles
+      summary: Delete all groups of the profile.
+      operationId: deleteAllGroupsInProfile
+      parameters:
+        - $ref: '#/components/parameters/profile_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/profiles/{profileId}/groups/{groupId}':
+    get:
+      tags:
+        - profiles
+      summary: Get a group in the profile.
+      operationId: getGroup
+      parameters:
+        - $ref: '#/components/parameters/profile_id'
+        - $ref: '#/components/parameters/group_id'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - profiles
+      summary: Update properties of a group.
+      operationId: updateGroup
+      parameters:
+        - $ref: '#/components/parameters/profile_id'
+        - $ref: '#/components/parameters/group_id'
+      requestBody:
+        description: Properties to update in the existing group.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - profiles
+      summary: Delete a group of the profile.
+      operationId: deleteGroup
+      parameters:
+        - $ref: '#/components/parameters/profile_id'
+        - $ref: '#/components/parameters/group_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  /cfg:
+    get:
+      tags:
+        - cfg
+      summary: Get all configuration settings.
+      description: |
+        Retrieve all system configuration settings at once. Updating a configuration setting must be performed with the
+        corresponding endpoint.
+      operationId: getAllSettings
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgAll'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    delete:
+      tags:
+        - cfg
+      summary: Reset all settings to default values.
+      description: |
+        This resets all system configuration settings to factory defaults. Integration & profile settings are not affected.
+      operationId: resetAllSettings
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgAll'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/button:
+    get:
+      tags:
+        - cfg
+      summary: Get button settings.
+      description: |
+        Button backlight configuration.
+      operationId: getButtonSettings
+      parameters:
+        - name: default
+          in: query
+          description: Get default values instead of configured values.
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgButtons'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    patch:
+      tags:
+        - cfg
+      summary: Modify button settings.
+      description: |
+        Change one or multiple button backlight settings.
+      operationId: updateButtonSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CfgButtons'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgButtons'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/device:
+    get:
+      tags:
+        - cfg
+      summary: Get remote device settings.
+      description: |
+        The remote device settings contain the custom name of the remote.
+      operationId: getRemoteDeviceSettings
+      parameters:
+        - name: default
+          in: query
+          description: Get default values instead of configured values.
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgRemoteDevice'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    patch:
+      tags:
+        - cfg
+      summary: Modify remote device settings.
+      description: |
+        Change one or multiple remote device settings.
+      operationId: updateRemoteDeviceSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CfgRemoteDevice'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgRemoteDevice'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/device/button_layout:
+    get:
+      tags:
+        - cfg
+      summary: Get the button layouts of the device.
+      description: |
+        Meta-information about the button groups and button layouts.
+      operationId: getRemoteDeviceButtonLayoutSettings
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DeviceButtonLayout'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/device/icon_mapping:
+    get:
+      tags:
+        - cfg
+      summary: Get the native icon mapping of the device.
+      description: |
+        Meta-information about the native icon mappings. These are the icon identifiers prefixed with `uc:`, e.g. `uc:cool`.
+        The remaining label is mapped to a unicode number in the icon font. For `uc:cool` the mapping will be: (`cool`, `\uE91E`)
+
+        Note: the example response omits the leading backslash to avoid character substitution in the browser!
+      operationId: getRemoteDeviceIconMapping
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                description: Label -> Unicode map
+                type: object
+                additionalProperties:
+                  type: string
+              example:
+                cool: uE91E
+                heat: uE91F
+                home: uE900
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/device/screen_layout:
+    get:
+      tags:
+        - cfg
+      summary: Get the screen layout of the device.
+      description: |
+        Meta-information about the screen grid size.
+      operationId: getRemoteDeviceScreenLayoutSettings
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DeviceScreenLayout'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/display:
+    get:
+      tags:
+        - cfg
+      summary: Get display settings.
+      description: |
+        Display brightness and auto brightness configuration.
+      operationId: getDisplaySettings
+      parameters:
+        - name: default
+          in: query
+          description: Get default values instead of configured values.
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgDisplay'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    patch:
+      tags:
+        - cfg
+      summary: Modify display settings.
+      description: |
+        Change one or multiple display settings.
+      operationId: updateDisplaySettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CfgDisplay'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgDisplay'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/entity/commands:
+    get:
+      tags:
+        - cfg
+      summary: Get entity command definitions.
+      description: |
+        Meta-information about the entity commands.
+      operationId: getEntityCommandMetadata
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EntityCommandMetadata'
+              example:
+                - id: button.press
+                  cmd_id: press
+                  name:
+                    en: Press
+                    de: Betätigen
+                - id: switch.on
+                  cmd_id: 'on'
+                  name:
+                    en: 'On'
+                    de: Ein
+                - id: switch.off
+                  cmd_id: 'off'
+                  name:
+                    en: 'Off'
+                    de: Aus
+                - id: switch.toggle
+                  cmd_id: toggle
+                  name:
+                    en: Toggle
+                    de: Umschalten
+                - id: light.on
+                  cmd_id: 'on'
+                  name:
+                    en: Turn on
+                    de: Einschalten
+                - id: light.off
+                  cmd_id: 'off'
+                  name:
+                    en: Turn off
+                    de: Ausschalten
+                - id: light.toggle
+                  cmd_id: toggle
+                  name:
+                    en: Toggle state
+                    de: Umschalten
+                - id: light.dim
+                  cmd_id: 'on'
+                  name:
+                    en: Set brightness
+                    de: Setze Helligkeit
+                  params:
+                    - name:
+                        en: brightness
+                        de: Helligkeit
+                      param: brightness
+                      type: int
+                      min: 0
+                      max: 100
+                      step: 1
+                      unit: '%'
+                - id: light.color_temperature
+                  cmd_id: 'on'
+                  name:
+                    en: Set color temperature
+                    de: Setze Farbtemperatur
+                  params:
+                    - name:
+                        en: Color temperature
+                        de: Farbtemperatur
+                      param: color_temperature
+                      type: int
+                      min: 0
+                      max: 100
+                      step: 1
+                      unit: '%'
+                - id: light.color
+                  cmd_id: 'on'
+                  name:
+                    en: Set color
+                    de: Setze Farbe
+                  params:
+                    - name:
+                        en: Hue
+                        de: Farbton
+                      param: hue
+                      type: int
+                      min: 0
+                      max: 360
+                      step: 1
+                      unit: °
+                    - name:
+                        en: saturation
+                        de: Farbsättigung
+                      param: saturation
+                      type: int
+                      min: 0
+                      max: 100
+                      step: 1
+                      unit: '%'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/features:
+    get:
+      tags:
+        - cfg
+      summary: Get feature flag settings.
+      description: |
+        Feature flag configuration.
+      operationId: getFeatureFlagSettings
+      parameters:
+        - name: default
+          in: query
+          description: Get default values instead of configured values.
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgFeatures'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    patch:
+      tags:
+        - cfg
+      summary: Modify a feature flag.
+      description: |
+        Enable or disable a feature flag setting.
+      operationId: updateFeatureFlagSetting
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CfgFeatureUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgFeatures'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/haptic:
+    get:
+      tags:
+        - cfg
+      summary: Get haptic settings.
+      description: |
+        Haptic configuration.
+      operationId: getHapticSettings
+      parameters:
+        - name: default
+          in: query
+          description: Get default values instead of configured values.
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgHaptic'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    patch:
+      tags:
+        - cfg
+      summary: Modify haptic settings.
+      description: |
+        Change one or multiple haptic settings.
+      operationId: updateHapticSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CfgHaptic'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgHaptic'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/localization:
+    get:
+      tags:
+        - cfg
+      summary: Get localization settings.
+      description: |
+        Retrieve the language and region configuration.
+      operationId: getLocalizationSettings
+      parameters:
+        - name: default
+          in: query
+          description: Get default values instead of configured values.
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgLocalization'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    patch:
+      tags:
+        - cfg
+      summary: Modify localization settings.
+      description: |
+        Change one or multiple localization settings.
+      operationId: updateLocalizationSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CfgLocalization'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgLocalization'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/localization/tz_names:
+    get:
+      tags:
+        - cfg
+      summary: Get all available time zone names.
+      operationId: getTimezoneNames
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/localization/countries:
+    get:
+      tags:
+        - cfg
+      summary: Get all available countries.
+      operationId: getLocalizationCountries
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    code:
+                      $ref: '#/components/schemas/CountryCode'
+                    name_en:
+                      description: |
+                        Country name in english. Native country names will be provided in additional `name_<language_code>`
+                        properties.
+                      type: string
+                  additionalProperties: true
+                  required:
+                    - code
+                    - name_en
+              example:
+                - code: CH
+                  name_de: Schweiz
+                  name_en: Switzerland
+                  name_fr: Suisse
+                  name_it: Svizzera
+                - code: DE
+                  name_de: Deutschland
+                  name_en: Germany
+                - code: DK
+                  name_dk: Danmark
+                  name_en: Denmark
+                - code: HU
+                  name_en: Hungary
+                  name_hu: Magyarország
+                - code: NL
+                  name_en: Netherlands
+                  name_nl: Nederland
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/localization/translations:
+    get:
+      tags:
+        - cfg
+      summary: Get all available translations.
+      description: |
+        The available translations are provided from the UI application.  
+        Future UI versions might provide new or updated translations.
+      operationId: getTranslations
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: string
+                  translations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        code:
+                          $ref: '#/components/schemas/LanguageCode'
+                        name:
+                          type: string
+                      required:
+                        - code
+                        - name
+                required:
+                  - version
+                  - translations
+              example:
+                version: default
+                translations:
+                  - code: da_DK
+                    name: Dansk
+                  - code: de_DE
+                    name: Deutsch
+                  - code: de_CH
+                    name: Schwiizertüütsch
+                  - code: fr_CH
+                    name: Français (Suisse)
+                  - code: it_CH
+                    name: Italiano (Svizzera)
+                  - code: hu_HU
+                    name: Magyar
+                  - code: nl_NL
+                    name: Nederlands
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/network:
+    get:
+      tags:
+        - cfg
+      summary: Get network settings.
+      description: |
+        Retrieve network settings, as WiFi or Bluetooth status.
+      operationId: getNetworkSettings
+      parameters:
+        - name: default
+          in: query
+          description: Get default values instead of configured values.
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgNetwork'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    patch:
+      tags:
+        - cfg
+      summary: Modify network settings.
+      description: |
+        Change one or multiple network settings.
+
+        ⚠️ The `ws` configuration object is an expert setting intended for support issues. Those settings may not be
+        exposed in a user frontend.
+        - The `ws` object is only returned, after it has been set manually.
+        - Settings stay persisted for PATCH requests not containing the `ws` key.
+        - Return and apply current system settings: send a PATCH request with an empty object: `"ws": {}".
+        - The `ws` settings can only be removed with a configuration reset: `DELETE /cfg`
+        - Modifying any `ws` settings requires a system reboot.
+      operationId: updateNetworkSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CfgNetwork'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgNetwork'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/power_saving:
+    get:
+      tags:
+        - cfg
+      summary: Get power settings.
+      description: |
+        Sleep timeout and wakeup sensitivity configuration.
+      operationId: getPowerSettings
+      parameters:
+        - name: default
+          in: query
+          description: Get default values instead of configured values.
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgPowerSaving'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    patch:
+      tags:
+        - cfg
+      summary: Modify power settings.
+      description: |
+        Change one or multiple power saving settings.
+      operationId: updatePowerSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CfgPowerSaving'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgPowerSaving'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/profile:
+    get:
+      tags:
+        - cfg
+      summary: Get profile settings.
+      operationId: getProfileSettings
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  has_admin_pin:
+                    description: An administrator pin has been set to use restricted profiles.
+                    type: boolean
+                required:
+                  - has_admin_pin
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    patch:
+      tags:
+        - cfg
+      summary: Modify profile settings.
+      description: |
+        Change profile administrator pin.
+
+        - an empty `admin_pin` value will remove the pin.
+      operationId: updateProfileSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                admin_pin:
+                  $ref: '#/components/schemas/AdminPin'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/paths/~1cfg~1profile/get/responses/200/content/application~1json/schema'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/software_update:
+    get:
+      tags:
+        - cfg
+      summary: Get software update settings.
+      description: |
+        Software update configuration. See PATCH operation and data model description for more information.
+      operationId: getSoftwareUpdateSettings
+      parameters:
+        - name: default
+          in: query
+          description: Get default values instead of configured values.
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgSoftwareUpdate'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    patch:
+      tags:
+        - cfg
+      summary: Modify software update settings.
+      description: |
+        Change one or multiple software update settings.
+
+        If `check_for_updates` is enabled:
+        - the device automatically checks for new updates daily. The check happens during a random time within the 
+          OTA window time frame `ota_window_start` - `ota_window_end`.
+        - if a new update is available, the update metadata is immediately downloaded and the firmware update file is
+          scheduled to download.
+        - the firmware file will only download if the remote has at least 50% battery charge.
+        - if the remote is not in the dock and suspended, the remote will not automatically wake up and the check
+          will be skipped.
+
+        If `auto_update` is enabled:
+        - once the firmware file is downloaded it will be automatically installed in the next OTA check window.
+        - the installation will only start if the remote has at least 50% battery charge.
+
+        OTA window fields:
+        - the stored values are used if omitted. 
+        - default values are set if not configured.
+        - the time of day corresponds to the configured timezone.
+        - for changing the update window, both start and end times are required, otherwise a default will be used.
+        - if the end time is before the start time, the window will spawn over midnight, e.g. `23:00:00` - `01:00:00`.
+
+        Optional software update channel & token:
+        - the default release channel is used if not configured.
+        - the stored values are used if omitted. 
+        - changing the update channel is intended for closed user groups only.  
+          ⚠️ High chance of breaking changes, bugs and loosing data!
+        - other channels than `default` might require an access token in `channel_token`.
+        - ⚠️ Changing the update channel or token requires a device restart, otherwise the automated updates will not use
+             the new channel!
+      operationId: updateSoftwareUpdateSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CfgSoftwareUpdate'
+            example:
+              check_for_updates: true
+              auto_update: false
+              ota_window_start: '02:15:00'
+              ota_window_end: '05:00:00'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgSoftwareUpdate'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/sound:
+    get:
+      tags:
+        - cfg
+      summary: Get sound settings.
+      description: |
+        Sound configuration.
+      operationId: getSoundSettings
+      parameters:
+        - name: default
+          in: query
+          description: Get default values instead of configured values.
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgSound'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    patch:
+      tags:
+        - cfg
+      summary: Modify sound settings.
+      description: |
+        Change one or multiple sound settings.
+      operationId: updateSoundSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CfgSound'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgSound'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/voice_control:
+    get:
+      tags:
+        - cfg
+      summary: Get voice control settings.
+      description: |
+        Voice control configuration.
+      operationId: getVoiceControlSettings
+      parameters:
+        - name: default
+          in: query
+          description: Get default values instead of configured values.
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgVoiceControl'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    patch:
+      tags:
+        - cfg
+      summary: Modify voice control settings.
+      description: |
+        Change one or multiple voice control settings.
+      operationId: updateVoiceControlSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CfgVoiceControl'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgVoiceControl'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /cfg/voice_control/voice_assistants:
+    get:
+      tags:
+        - cfg
+      summary: Get available voice assistants.
+      operationId: getVoiceAssistants
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /docks:
+    head:
+      tags:
+        - dock
+      summary: Get total number of configured docks.
+      description: |
+        By default only active docks are counted. This can be changed with the `active` query parameter.
+      operationId: getDockCount
+      parameters:
+        - $ref: '#/components/parameters/active'
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    get:
+      tags:
+        - dock
+      summary: List configured docks and their connection state.
+      description: |
+        Returns all dock configuration with paging. The configuration data is enriched with current connection information.
+        Use the `HEAD` operation to retrieve the total number of defined docking stations.
+
+        By default only active docks are returned. This can be changed with the `active` query parameter.
+      operationId: getDocks
+      parameters:
+        - $ref: '#/components/parameters/active'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+            Pagination-Limit:
+              description: Number of returned items.
+              schema:
+                type: integer
+            Pagination-Page:
+              description: Current page number. 1-based.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockConfigurations'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    post:
+      tags:
+        - dock
+      summary: Create a new dock configuration.
+      description: |
+        Manually create and persist a new dock configuration. This is a low-level operation without configuring and setting
+        up the dock as with the `/docks/setup` endpoints! To establish a session to the dock, the connect operation must be
+        called afterwards.  
+        - Error `422` is returned if the given service name in `dock_id` already exists.
+        - If `custom_ws_url` is not specified, the dock address is resolved through an mDNS service name lookup in `dock_id`.   
+        - The `active` flag specifies if the dock will react to connection requests.
+        - Non-active docks will not auto-connect and must be enabled first to be used.
+        - Non-active docks won't be visible in the web-configurator.
+        - If no `token` is provided the default token is used! The token is used to authenticate the WebSocket
+          connection once a connection to the dock is established. To change an existing token, use the 
+          `PATCH /docks/devices/:dockId` operation.
+        - If `model` is provided it must be one of the known dock model identifiers: `UCD2` or `YIO1DOCK`.
+      operationId: createDock
+      requestBody:
+        description: Client information requesting access
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DockConfigurationRequest'
+        required: true
+      responses:
+        '201':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockConfiguration'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+    put:
+      tags:
+        - dock
+      summary: Connect or disconnect all active dock connections.
+      description: |
+        Requests all active docks to establish or stop a session to the dock.  
+        Use `GET /docks` or `GET /docks/devices/{dockId}` to check on the connection status.
+      operationId: executeCommandOnAllDocks
+      parameters:
+        - name: cmd
+          in: query
+          description: Command to execute.
+          required: true
+          schema:
+            type: string
+            enum:
+              - CONNECT
+              - DISCONNECT
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    delete:
+      tags:
+        - dock
+      summary: Delete all dock configurations.
+      description: |
+        ⚠️ All defined dock configurations will be irrevocably deleted!
+
+        Active dock sessions will be disconnected and the persisted dock configurations removed.
+      operationId: deleteAllDocks
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /docks/discover:
+    get:
+      tags:
+        - dock
+      summary: Get docking station discovery status.
+      description: |
+        Returns the current discovery status and any discovered docks.
+
+        Use the DELETE operation to stop an active discovery and PUT to start a new discovery.
+      operationId: getDockDiscoveryStatus
+      responses:
+        '200':
+          description: Dock discovery status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockDiscoveryStatus'
+              example:
+                active: true
+                docks:
+                  - id: UC-Dock-E831CDD012A8
+                    configured: false
+                    friendly_name: Living room
+                    address: '192.168.1.106:946'
+                    model: UCD2
+                    version: 0.1.0
+                    discovery_type: NET
+                    timestamp: '2022-11-07T07:46:04.370629Z'
+                  - id: sim.1
+                    configured: false
+                    friendly_name: Simulated dock
+                    address: '127.0.0.1:946'
+                    version: 0.1.2
+                    discovery_type: NET
+                    timestamp: '2022-11-07T07:46:05.245759Z'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    put:
+      tags:
+        - dock
+      summary: Start discovery of new docking stations.
+      description: |
+        Start device discovery over Bluetooth and mDNS. Bluetooth or network discovery can be disabled with a query
+        parameter. By default the discovery automatically stops after 30 seconds. Use the GET status request to check on
+        discovered devices or DELETE to stop discovery.
+
+        By default only new network devices are returned. If a dock is already configured it will be omitted from the
+        results, unless the query parameter `new=false` is set. Docks with Bluetooth enabled are always returned, since
+        this usually means that the dock needs to be re-configured.
+
+        - If BT is disabled in the remote, the query parameter `bt` is ignored.
+        - Emits the WebSocket event `dock_discovery` with `event_type: START` when discovery starts.
+        - For each discovered device the WebSocket event `dock_discovery` with `event_type: DISCOVER` is emitted.
+        - This operation clears any old discovered devices and won't be accessible anymore with the GET operation.
+      operationId: startDockDiscovery
+      parameters:
+        - name: timeout
+          in: query
+          description: Timeout in seconds.
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
+            minimum: 1
+            maximum: 300
+        - name: bt
+          in: query
+          description: Use Bluetooth to discover new docks.
+          required: false
+          schema:
+            type: boolean
+            default: true
+        - name: net
+          in: query
+          description: Query network to discover new docks.
+          required: false
+          schema:
+            type: boolean
+            default: true
+        - name: new
+          in: query
+          description: 'Only return new devices, filter out already configured docks.'
+          required: false
+          schema:
+            type: boolean
+            default: true
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    delete:
+      tags:
+        - dock
+      summary: Stop discovery of new docking stations.
+      description: |
+        Stops the device discovery. The current discovery status is returned in the response. Already discovered devices
+        won't be returned and can still be retrieved with the GET operation.
+
+        Emits the WebSocket event `dock_discovery` with `event_type: STOP`.
+      operationId: stopDockDiscovery
+      responses:
+        '200':
+          description: Dock discovery status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockDiscoveryStatus'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/docks/discover/{dockId}':
+    get:
+      tags:
+        - dock
+      summary: Get docking station discovery device status.
+      description: |
+        Returns the discovered docking station device.
+      operationId: getDockDiscoveryDeviceStatus
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+      responses:
+        '200':
+          description: Dock discovery status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockDiscoveryStatus'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    put:
+      tags:
+        - dock
+      summary: Execute command on a discovered docking station.
+      description: |
+        Perform a WebSocket connection test with a discovered docking station. If the dock requires an API token, it must
+        be specified in the request body.  
+        The `IDENTIFY` command also blinks the status LED on the dock.
+
+        Response status codes:
+        - `200`: successful operation: the connection test was successful and docking station metadata could be retrieved.
+        - `404`: discovered dock with `dock_id` not found. Check if the discovery result is still available and has not
+                 been deleted. This can happen after a timeout since the discovery, or if the discovery result has been
+                 cleared with `DELETE /docks/discover`.
+        - `503`: docking station connection could not be established.
+      operationId: executeCommandOnDiscoveredDock
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+        - name: cmd
+          in: query
+          description: Command to execute.
+          required: true
+          schema:
+            type: string
+            enum:
+              - CONNECTION_TEST
+              - IDENTIFY
+        - name: timeout
+          in: query
+          description: Timeout in seconds.
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 5
+            minimum: 3
+            maximum: 60
+      requestBody:
+        required: false
+        description: Command payload
+        content:
+          application/json:
+            schema:
+              description: Driver connection parameters.
+              type: object
+              properties:
+                connection:
+                  type: object
+                  properties:
+                    token:
+                      description: |
+                        Optional dock authentication token.
+                      type: string
+                      maxLength: 40
+      responses:
+        '200':
+          description: Dock system information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockSystemInfo'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+  /docks/setup:
+    get:
+      tags:
+        - dock
+      summary: Get current dock setup processes.
+      description: |
+        Return a list of all active setup process identifiers. The returned ids can be used with the
+        `/docks/setup/:id` endpoints to continue or abort a setup process.
+      operationId: getDockSetupProcesses
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    post:
+      tags:
+        - dock
+      summary: Start setting up a new docking station.
+      description: |
+        Create a new setup process from a discovered dock or from a manually provided dock address.
+
+        - If there's already a setup process running for the given dock id, status code `409` is returned.
+        - Emits the WebSocket event `dock_setup_change` with `event_type: START` when this operation returns `201`.
+
+        Start setup from dock discovery:
+        - The required request data can be obtained from the `/api/docks/discover` endpoints when searching for docking
+          stations over Bluetooth or Ethernet. Simply provide the returned `DockDiscovery` data object (which is a super
+          set of the required data to start a setup process).
+        - The returned `id` in the `DockSetupInfo` response will be the identifier for the next `PUT /docks/setup/:id`
+          call to provide additional data.
+
+        Manual setup:
+        - A dock identifier will automatically be created and returned in `DockSetupInfo`.
+        - The dock must be reachable on the network with the provided `custom_ws_url` and optional `token`. Otherwise,
+          status code `503` is returned.
+        - The setup process is automatically started after a successful POST request, no call to `PUT /docks/setup/:id`
+          is required.
+
+        Response status codes:
+        - `201`: setup process successfully started. Use `GET /docks/setup/:id` to poll for status updates, or listen to
+           WebSocket `dock_setup_change` event messages.
+        - `400`: invalid data in request body.
+        - `409`: a setup process is already running. Either wait until finished, or abort it.
+        - `503`: service not available to setup docking station.  
+           E.g. Bluetooth is disabled and therefore the docking station cannot be setup over Bluetooth. Either enable
+           Bluetooth or setup the dock over Ethernet.
+      operationId: createDockSetup
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDockSetup'
+            examples:
+              From dock discovery:
+                value:
+                  discovery:
+                    id: UC-Dock-E831CDD012A8
+                    friendly_name: Living room
+                    address: '192.168.1.106:946'
+                    model: UCD2
+                    version: 0.1.0
+                    discovery_type: NET
+              Manually:
+                value:
+                  manually:
+                    name: Living room
+                    token: '0000'
+                    custom_ws_url: 192.168.1.106
+              Manually with WiFi:
+                value:
+                  manually:
+                    name: Living room
+                    token: '0000'
+                    custom_ws_url: 192.168.1.106
+                    wifi:
+                      ssid: My network
+                      password: don't tell anyone
+        required: true
+      responses:
+        '201':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockSetupInfo'
+              example:
+                id: UC-Dock-E831CDD012A8
+                name: Living room
+                discovery_type: NET
+                state: NEW
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '409':
+          $ref: '#/components/responses/Err409Conflict'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    delete:
+      tags:
+        - dock
+      summary: Abort and remove all setup processes.
+      description: |
+        Stop all setup processes at the next possible operation and remove all setup process information.
+      operationId: stopAllDockSetups
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/docks/setup/{dockId}':
+    get:
+      tags:
+        - dock
+      summary: Get docking station setup status.
+      description: |
+        Poll operation to retrieve the current docking station setup state. See the `state` and `error` fields in the
+        response message. There are also WebSocket `dock_setup_change` event messages for state changes to avoid polling.
+
+        Defined setup states:
+        - `NEW`: setup has not yet been started. Use the `PUT` operation to provide the required data and to start setting up the dock.
+        - `CONFIGURING`: setup data is currently being transferred to the dock.
+        - `RESTARTING`: dock has been configured and is restarting to integrate into the network.
+        - `OK`: setup process has been completed successfully, the dock can now be used.
+        - `ERROR`: the setup process failed. Check the `error` field for more information.
+      operationId: getDockSetupStatus
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockSetupInfo'
+              example:
+                id: UC-Dock-E831CDD012A8
+                name: Living room
+                model: UCD2_VIRTUAL
+                discovery_type: NET
+                state: OK
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    put:
+      tags:
+        - dock
+      summary: Setup docking station.
+      description: |
+        Set required data to start the setup process and configure the docking station.
+        When using Bluetooth the WiFi network name and credentials must be provided to connect the dock to the WiFi network.
+
+        The `state` field in the response message indicate the current state of the setup process. Use the `GET` operation
+        to poll for state updates or listen to the corresponding WebSocket `dock_setup_change` event messages with
+        `event_type: SETUP`.
+      operationId: startDockSetup
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DockSetup'
+            example:
+              name: Living room
+              token: '123'
+              description: Setup test
+              wifi:
+                ssid: My Network
+                password: 0123456789
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockSetupInfo'
+              example:
+                id: UC-Dock-E831CDD012A8
+                name: Living room
+                model: UCD2
+                discovery_type: NET
+                state: CONFIGURING
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    delete:
+      tags:
+        - dock
+      summary: Abort the dock setup process.
+      description: |
+        Stop the setup process at the next possible operation and remove the setup process information.  
+        To start a new setup process, use the `POST /docks/setup` operation again.
+
+        Emits the WebSocket event `dock_setup_change` with `event_type: STOP`.
+      operationId: stopDockSetup
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/docks/devices/{dockId}':
+    get:
+      tags:
+        - dock
+      summary: Get dock configuration.
+      description: |
+        Returns the dock configuration, enriched with the current session information if a dock connection is established.
+      operationId: getDock
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockConfiguration'
+              example:
+                dock_id: UC-Dock-E831CDD012A8
+                name: Living room
+                resolved_ws_url: 'ws://192.168.1.23:946'
+                active: true
+                model: UCD2
+                revision: '5.4'
+                led_brightness: 88
+                state: CONNECTED
+                version: 0.9.2
+                learning_active: false
+                description: Setup test
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    patch:
+      tags:
+        - dock
+      summary: Change dock configuration like auto-connect or access token.
+      description: |
+        Update one or more dock fields.
+
+        - If the dock is in an `active` connection state, then the `name`, `token` and `wifi` values are persisted in the
+          dock if provided in the request. The request fails with `503` service unavailable if the configuration can't be
+          set in the docking station.
+        - An empty `custom_ws_url` value will remove the custom URL.
+        - If the dock is not active, the values are only stored in the remote. A changed `token` will be used for the next
+          connection attempt.
+      operationId: updateDock
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+      requestBody:
+        description: 'Fields to update, omit the ones without change.'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DockUpdateRequest'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockConfiguration'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    put:
+      tags:
+        - dock
+      summary: Start or stop a dock connection.
+      description: |
+        Establish or stop a session to the dock.  
+        Use `GET /docks` or `GET /docks/devices/{dockId}` to check on the connection status.
+      operationId: dockConnectionCommand
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+        - name: cmd
+          in: query
+          description: Command to execute.
+          required: true
+          schema:
+            type: string
+            enum:
+              - CONNECT
+              - DISCONNECT
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    delete:
+      tags:
+        - dock
+      summary: Delete dock configuration.
+      description: |
+        ⚠️ The dock configuration will be irrevocably deleted!
+
+        An active dock session will be disconnected and the persisted dock configuration removed.
+      operationId: deleteDock
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/docks/devices/{dockId}/command':
+    post:
+      tags:
+        - dock
+      summary: Send a dock command.
+      description: |
+        The following `command` values are defined:
+        - `SET_LED_BRIGHTNESS`: set the maximum brightness of the front indicator LED. Set the `0..100` percentage as
+           string parameter in the `value` field.  
+        - `IDENTIFY`: identify the dock with blinking the indicator LED.
+        - `REMOTE_LOW_BATTERY`: trigger the low battery status indicator on the dock.
+        - `REMOTE_CHARGED`: trigger the remote charged indicator on the dock.
+        - `REMOTE_NORMAL`: trigger the normal remote operation mode on the dock.
+        - `REBOOT`: reboot the dock.
+        - `RESET`: ⚠️ factory reset the dock. Requires administrator privileges.  
+           The dock configuration will be deleted from the remote.
+      operationId: dockCommand
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+      requestBody:
+        description: Dock command
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                command:
+                  type: string
+                  enum:
+                    - SET_LED_BRIGHTNESS
+                    - IDENTIFY
+                    - REMOTE_LOW_BATTERY
+                    - REMOTE_CHARGED
+                    - REMOTE_NORMAL
+                    - REBOOT
+                    - RESET
+                value:
+                  description: Command parameter value. Required for `SET_LED_BRIGHTNESS`.
+                  type: string
+              required:
+                - command
+            examples:
+              Set LED brightness to 50%:
+                value:
+                  command: SET_LED_BRIGHTNESS
+                  value: '50'
+              Set LED brightness to maximum:
+                value:
+                  command: SET_LED_BRIGHTNESS
+                  value: '100'
+              Identify the dock:
+                value:
+                  command: IDENTIFY
+              Trigger low battery indicator:
+                value:
+                  command: REMOTE_LOW_BATTERY
+              Trigger remote charged indicator:
+                value:
+                  command: REMOTE_CHARGED
+              Reboot the dock:
+                value:
+                  command: REBOOT
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/docks/devices/{dockId}/update':
+    get:
+      tags:
+        - dock
+      summary: Check for dock firmware updates.
+      description: |
+        Check if there is an update available for the dock.
+
+        This operation will use the cached update information from the software update cloud service, which runs
+        periodically to check for available updates and independently from this operation.  
+        The returned `update_check_enabled` flag indicates if the online update check is enabled or not.
+
+        If `update_id` is set then an update is currently in progress and can be monitored either with listening to the
+        WebSocket `dock_update_change` event messages or polling the status with the
+        `GET /docks/devices/{dockId}/update/{id}` operation.
+      operationId: checkDockFirmwareUpdate
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockUpdateCheck'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    put:
+      tags:
+        - dock
+      summary: Force dock firmware update check.
+      description: |
+        Check if there is an update available for the dock.
+
+        This operation will contact the software update cloud service to check for available updates.    
+        The returned `update_check_enabled` flag indicates if the online update check is enabled or not.
+
+        If `update_id` is set then an update is currently in progress and can be monitored either with listening to the
+        WebSocket `dock_update_change` event messages or polling the status with the
+        `GET /docks/devices/{dockId}/update/{id}` operation.
+
+        New updates will automatically downloaded. The download state can be retrieved with the GET operation and is
+        shown in the `firmware_update.download` enum field.
+      operationId: forceCheckDockFirmwareUpdate
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockUpdateCheck'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    post:
+      tags:
+        - dock
+      summary: Update dock firmware.
+      description: |
+        Start a firmware update on the given dock. The returned update identifier can be used to poll for the update 
+        progress with the `GET /docks/devices/{dockId}/update/{id}` operation or listen to the WebSocket
+        `dock_update_change` event message.
+
+        Response codes:
+        - `409`: Conflict, an update is already running. Use the `GET` operation to retrieve the current update identifier.
+        - `503`: The dock is not connected, or the update service is unavailable. Please try again later.
+      operationId: updateDockFirmware
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+      responses:
+        '201':
+          description: Firmware update started
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '409':
+          $ref: '#/components/responses/Err409Conflict'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    delete:
+      tags:
+        - dock
+      summary: "\U0001F6A7 Abort the dock firmware update."
+      description: |
+        Stop the firmware update process at the next possible operation and remove the update process information.
+
+        Emits the WebSocket event `dock_update_change` with `event_type: STOP`
+      operationId: stopDockFirmwareUpdate
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  '/docks/devices/{dockId}/update/{id}':
+    get:
+      tags:
+        - dock
+      summary: Check for dock firmware update progress.
+      description: |
+        Get the current progress and status information about a dock firmware upgrade.
+
+        Instead of using polling one can also listen to the WebSocket `dock_update_change` event messages.
+      operationId: dockFirmwareUpdateProgress
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+        - name: id
+          in: path
+          description: Update identification
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockUpdateProgress'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+  '/docks/devices/{dockId}/ir/send':
+    get:
+      tags:
+        - dock
+      summary: "\U0001F477 Test IR command."
+      description: |
+        ⚠️ This is for testing only. Please use the `/ir/emitters/` endpoints for sending IR codes.
+
+        Test function for sending IR commands. The IR code can either be in Pronto format or Hex.
+        If no output is specified, the code will only be emitted from the dock.
+      operationId: sendIrTest
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+        - name: int1
+          in: query
+          description: Main internal ir blaster
+          schema:
+            type: boolean
+        - name: int2
+          in: query
+          description: 'Second internal ir blaster. V2 dock: top'
+          schema:
+            type: boolean
+        - name: ext1
+          in: query
+          description: External IR blaster 1
+          schema:
+            type: boolean
+        - name: ext2
+          in: query
+          description: External IR blaster 2
+          schema:
+            type: boolean
+        - name: pronto
+          in: query
+          description: 'Pronto IR code, values separated by comma'
+          required: false
+          schema:
+            type: string
+            pattern: '^[a-fA-F0-9]{4}(,[a-fA-F0-9]{4}){3,}$'
+        - name: hex
+          in: query
+          description: Hex IR code
+          required: false
+          schema:
+            type: string
+            pattern: '^[\d]{1,3};0x[a-fA-F0-9]{1,16};[\d]{1,2};[\d]{1,2}$'
+        - name: repeat
+          in: query
+          description: |
+            Optional repeat value for sending continuous IR repeat signals (depending on IR protocol).
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 20
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    post:
+      tags:
+        - dock
+      summary: "\U0001F477 Send IR command."
+      description: |
+        ⚠️ This is for testing only. Please use the `/ir/emitters/` endpoints for sending IR codes.
+
+        Send an IR command, either in Pronto or [IRremoteESP8266 Hex](https://github.com/unfoldedcircle/IRremoteESP8266) format.
+
+        Hex format: `<protocol>;<hex-ir-code>;<bits>;<repeat-count>`
+        - protocol: numeric value from supported and enabled protocols. See: [decode_type_t](https://github.com/unfoldedcircle/IRremoteESP8266/blob/v2.8.5-ucd2.2/src/IRremoteESP8266.h#L1011)
+        - hex-ir-code: HEX value prefixed with `0x`
+        - bits: number of bits in hex value
+        - repeat-count: number of repeats
+      operationId: sendIr
+      parameters:
+        - $ref: '#/components/parameters/dock_id'
+      requestBody:
+        description: IR command
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                int1:
+                  description: Main internal ir blaster
+                  type: boolean
+                int2:
+                  description: 'Second internal ir blaster. V2 dock: top'
+                  type: boolean
+                ext1:
+                  description: External IR blaster 1
+                  type: boolean
+                ext2:
+                  description: External IR blaster 2
+                  type: boolean
+                pronto:
+                  description: 'Pronto IR code, values separated by space or comma'
+                  type: string
+                  pattern: '^0000((, )[a-fA-F0-9]{4}){5,}$'
+                hex:
+                  description: Hex IR code
+                  type: string
+                  pattern: '^[\d]{1,3};0x[a-fA-F0-9]{1,16};[\d]{1,2};[\d]{1,2}$'
+                repeat:
+                  description: |
+                    Optional repeat value for sending continuous IR repeat signals (depending on IR protocol).
+                  type: integer
+                  minimum: 0
+                  maximum: 20
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  /system:
+    get:
+      tags:
+        - system
+      summary: Get system information.
+      description: 'Get hardware information about the device like serial number, model number and hardware revision.'
+      operationId: getSystemInfo
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemInfo'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    post:
+      tags:
+        - system
+      summary: Perform a system command like reboot or power-off.
+      description: |
+        The following system commands can be executed:
+
+        - `STANDBY`: Put the device into standby mode.
+        - `REBOOT`: Reboot the device.
+        - `POWER_OFF`: Switch off the device
+        - `RESTART`: Restart all applications.
+        - `RESTART_UI`: Restart the ui application.
+        - `RESTART_CORE`: Restart the core service application.
+      operationId: systemCommand
+      parameters:
+        - name: cmd
+          in: query
+          description: System command
+          required: true
+          schema:
+            type: string
+            enum:
+              - STANDBY
+              - REBOOT
+              - POWER_OFF
+              - RESTART
+              - RESTART_UI
+              - RESTART_CORE
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /system/backup/export:
+    get:
+      tags:
+        - system
+      summary: Create and export a device configuration backup.
+      description: |
+        Export the full Remote Two device configuration. This allows to restore the configuration after a factory reset
+        or to load the configuration onto another device.
+
+        - The backup archive is only returned to the client and not stored on the device. 
+        - The returned backup archive can be restored with `PUT /system/backup/restore`.
+        - It is recommended to perform the backup while the remote is in the docking station.
+        - Using the remote or the Core-API should be avoided while the backup is running.
+        - The backup should only take a few seconds. The backup will take longer:
+          - if integration drivers are busy and require more time to shutdown.
+          - if many custom resources (icons, background images, etc) are present.
+
+        ⚠️ Attention:
+        - The backup archive may contain personal information and access keys to external systems.
+          - The backup archive is not encrypted. Contained information can be extracted with little effort.
+          - For example the long-lived access token for Home Assistant is included, if that integration has been configured.
+        - All integrations and docks will be disconnected and stopped during backup.
+          - They are restarted after the backup is finished. This may take several seconds until all entities are available again.
+          - Restart the device, if an integration or entities are no longer working after a backup.
+        - The device must have enough free disk space to create the backup archive. At least 100 MB must be free to start the backup process.
+
+        The backup **does not include**:
+        - WiFi network configuration and passwords.
+        - Administrator pin.
+        - Web-configurator pin.
+        - Any API-keys created with the Core-API.
+
+        Error codes:
+        - `403`: forbidden, only an administrator account may create a backup.
+        - `409`: conflict, a backup or restore process is already running.
+        - `507`: not enough disk space available.
+      operationId: exportBackup
+      responses:
+        '200':
+          description: Binary backup archive.
+          headers:
+            content-disposition:
+              description: Attachment filename.
+              schema:
+                type: string
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '409':
+          $ref: '#/components/responses/Err409Conflict'
+        '507':
+          $ref: '#/components/responses/Err507InsufficientStorage'
+  /system/backup/restore:
+    put:
+      tags:
+        - system
+      summary: Upload and restore a device configuration backup.
+      description: |
+        Restore the Remote Two device configuration from the uploaded backup archive. The backup archive is only used
+        to restore the system and deleted after restore.
+
+        - It is highly recommended to perform the restore while the remote is in the docking station.
+        - Using the remote or the Core-API should be avoided while the restore is running.
+        - The restore should only take a few seconds. The restore will take longer:
+          - if integration drivers are busy and require more time to shutdown.
+          - if many custom resources (icons, background images, etc) are present.
+
+        ⚠️ Attention:
+        - The device will not automatically restart after a system restore.
+          - The device must be restarted after the restore to activate all changed settings.
+          - Certain setting changes like OTA require a system restart.
+        - WiFi configuration, administrator pin and web-configurator pin are not overwritten by a system restore.
+        - All integrations and docks will be disconnected and stopped during restore.
+        - The device must have enough free disk space to restore the backup. At least 100 MB must be free to start the restore process.
+
+        Error codes:
+        - `400`: bad request, back archive is invalid or corrupt. Check logs for further details.
+        - `403`: forbidden, only an administrator account may restore a backup.
+        - `409`: conflict, a backup or restore process is already running.
+        - `500`: internal server error, the backup archive could not be processed. Check logs for further details.
+        - `507`: not enough disk space available.
+      operationId: restoreBackup
+      parameters:
+        - $ref: '#/components/parameters/merge'
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BackupMetadata/properties/report'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '409':
+          $ref: '#/components/responses/Err409Conflict'
+        '500':
+          $ref: '#/components/responses/Err500InternalServerError'
+        '507':
+          $ref: '#/components/responses/Err507InsufficientStorage'
+  /system/backup/snapshots:
+    get:
+      tags:
+        - system
+      summary: "\U0001F477 Get information about available system backup snapshots."
+      description: |
+        _Work in progress, might still change!_
+
+        Retrieve all available device configuration backups stored on the device.
+      operationId: getBackupSnapshots
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BackupSnapshot'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    post:
+      tags:
+        - system
+      summary: "\U0001F477 Create a new system backup snapshot."
+      description: |
+        _Work in progress, might still change!_
+
+        Create a new device configuration backup and store it on the device.
+
+        Please see `GET /system/backup/export` operation about creating a backup.
+
+        Response codes:
+        - `403`: forbidden, only an administrator account may create a backup.
+        - `409`: conflict, a maximum of 50 backups can be stored on the device, or a backup or restore process is already running.
+        - `507`: a minimum of 100 MB free space on the device is required to create a new backup.
+      operationId: createBackupSnapshot
+      responses:
+        '201':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BackupSnapshot'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '409':
+          $ref: '#/components/responses/Err409Conflict'
+        '507':
+          $ref: '#/components/responses/Err507InsufficientStorage'
+    delete:
+      tags:
+        - system
+      summary: "\U0001F477 Remove all system backups."
+      description: |
+        _Work in progress, might still change!_
+
+        Delete all device configuration backups stored on the device.
+      operationId: deleteAllBackupSnapshots
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/system/backup/snapshots/{id}':
+    get:
+      tags:
+        - system
+      summary: "\U0001F477 Get information about a system backup snapshot or download archive."
+      description: |
+        _Work in progress, might still change!_
+
+        Based on the request `Content-Type` header, either the JSON metadata information is returned or the binary
+        backup archive. If the header is missing, the binary archive is returned.
+
+        Response codes:
+        - `404`: system backup snapshot not found.
+      operationId: getBackupSnapshot
+      parameters:
+        - $ref: '#/components/parameters/backup_id'
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            content-disposition:
+              description: |
+                Attachment filename for `content-type: application/octet-stream`.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BackupMetadata'
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    put:
+      tags:
+        - system
+      summary: "\U0001F477 Restore a system backup snapshot."
+      description: |
+        _Work in progress, might still change!_
+
+        Please see `PUT /system/backup/restore` operation about restoring a backup.
+
+        Response codes:
+        - `403`: forbidden, only an administrator account may create a backup.
+        - `404`: system backup snapshot not found.
+        - `409`: conflict, a backup or restore process is already running.
+        - `500`: internal server error, the backup archive could not be processed. Check logs for further details.
+        - `507`: not enough disk space available.
+      operationId: restoreBackupSnapshot
+      parameters:
+        - $ref: '#/components/parameters/backup_id'
+        - $ref: '#/components/parameters/merge'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/paths/~1system~1backup~1restore/put/responses/200/content/application~1json/schema'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '409':
+          $ref: '#/components/responses/Err409Conflict'
+        '500':
+          $ref: '#/components/responses/Err500InternalServerError'
+        '507':
+          $ref: '#/components/responses/Err507InsufficientStorage'
+    delete:
+      tags:
+        - system
+      summary: "\U0001F477 Remove a system backup snapshot."
+      description: |
+        _Work in progress, might still change!_
+      operationId: deleteBackupSnapshot
+      parameters:
+        - $ref: '#/components/parameters/backup_id'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /system/factory_reset:
+    get:
+      tags:
+        - system
+      summary: Get factory reset token.
+      description: |
+        Get a factory reset token to perform a complete factory reset of the remote.
+
+        The token will be valid for 60 seconds. Afterwards, a new token must be requested.  
+        Whenever a new token is requested, any old tokens will be invalidated.
+      operationId: getFactoryResetToken
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    post:
+      tags:
+        - system
+      summary: Perform a factory reset.
+      description: |
+        A factory reset removes all configuration data and puts the device into a clean state.  
+
+        ⚠️ **Warning:** All user data will be erased and won't be recoverable!
+
+        A reset token must be requested first and provided to perform a factory reset.
+      operationId: performFactoryReset
+      parameters:
+        - name: token
+          in: query
+          description: Reset token
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /system/install:
+    get:
+      tags:
+        - system
+      summary: Get installed custom components.
+      description: |
+        Returns the installation status of custom system components like the user interface or web-configurator.
+      operationId: getInstalledCustomComponents
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CustomInstall'
+              example:
+                - component: ui
+                  installed: true
+                  active: true
+                  installation_date: 2023-07-24T07:57:33.000Z
+                  release:
+                    name:
+                      en: Remote UI
+                    version: 0.27.10
+                    description:
+                      en: Custom remote UI App for testing.
+                    developer:
+                      name: Unfolded Circle ApS
+                      url: 'https://www.unfoldedcircle.com'
+                      email: hello@unfoldedcircle.com
+                    home_page: 'https://www.unfoldedcircle.com'
+                    release_date: '2023-07-19'
+                    requirements:
+                      firmware_version: '>=0.13.0, <1.0.0'
+                - component: web_configurator
+                  installed: false
+                  active: false
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  '/system/install/{customComponent}':
+    get:
+      tags:
+        - system
+      summary: Get status of a custom component installation.
+      description: |
+        Returns the status of an installed custom component, as a custom UI app or web-configurator.
+
+        - Error response `400` might be returned, if the metadata of an installed custom component is no longer valid with
+          the current firmware.
+      operationId: getCustomComponentStatus
+      parameters:
+        - $ref: '#/components/parameters/custom_component'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomInstall'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    put:
+      tags:
+        - system
+      summary: Enable or disable a custom component.
+      description: |
+        Switch between a default or an installed custom component.
+
+        This does not delete the custom installation and only switches between the default component and the installed
+        custom component.
+
+        Error response codes:
+        - `400`: metadata of custom component is no longer valid with the current firmware. 
+        - `403`: user doesn't have administrator rights.
+        - `404`: the custom component is not installed and cannot be enabled or disabled.
+        - `409`: installed custom component is no longer compatible with the current firmware.
+
+        ⚠️ Attention:
+        - Switching the web-configurator might disconnect the current request. Use a GET request to check for the current state.
+        - Switching the remote-ui will restart the application and the screen will go dark for a while.
+        - For certain error conditions, the device might restart.
+      operationId: enableCustomComponent
+      parameters:
+        - $ref: '#/components/parameters/custom_component'
+        - name: enable
+          in: query
+          description: Enable or disable component.
+          required: true
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomInstall'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '409':
+          $ref: '#/components/responses/Err409Conflict'
+    delete:
+      tags:
+        - system
+      summary: Remove an installed custom component.
+      description: |
+        Deactivates the custom components and starts the default one. The custom component is removed afterwards from the
+        device.
+
+        ⚠️ Attention:
+        - Deleting the web-configurator might disconnect the current request. Use a GET request to check for the current state.
+        - Deleting an active, custom remote-ui will restart the application and the screen will go dark for a while.
+        - For certain error conditions, the device might restart.
+      operationId: removeCustomComponent
+      parameters:
+        - $ref: '#/components/parameters/custom_component'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+    post:
+      tags:
+        - system
+      summary: Upload and install a custom component.
+      description: |
+        ☢️ VOIDS WARRANTY ☢️
+
+        The `void_warranty` query parameter is required to install a custom component:
+        - The user has to agree and confirm, that the warranty will be voided by installing a custom component.
+        - The confirmation will be recorded in a write-once location on the device and cannot be reverted!
+        - The value of the parameter must be `yes`, otherwise the installation is aborted and `401` returned. 
+
+        Custom archive requirements:
+        - TAR GZip archive (either .tgz or .tar.gz file suffix).
+        - In the root of the archive, there must be a `release.json` file describing the custom version.  
+          See `CustomRelease` schema for the release.json format.
+        - No symlinks. They are automatically removed during the installation.
+        - UI:
+          - The UI binary must be named `remote-ui` in the `./bin` subdirectory.
+          - All application files must be in one of the following subdirectories, other locations are not accessible at runtime:
+            - `./bin`: application binary, usually only `remote-ui`.
+            - `./config`: configuration data. Path is accessible with `UC_CONFIG_HOME` environment variable.
+            - `./data`: application data. Path is accessible with `UC_DATA_HOME` environment variable.
+        - web-configurator:
+          - An `index.html` file must be in the root of the archive.
+
+        Error response codes:
+        - `400`: invalid archive, missing data in archive or included metadata cannot be read.
+        - `403`: user did not agree to void warranty, or user does not have administrator rights.
+        - `409`: custom component is not compatible with the current firmware.
+        - `507`: insufficient storage to upload and process installation archive.
+
+        ⚠️ Attention:
+        - Installing a custom web-configurator might disconnect the current request. Use a GET request to check for the current state.
+        - Installing a custom remote-ui will restart the application and the screen will go dark for a while.
+        - For certain error conditions, the device might restart.
+      operationId: installCustomComponent
+      parameters:
+        - $ref: '#/components/parameters/custom_component'
+        - name: void_warranty
+          in: query
+          description: User confirmation that this action voids warranty.
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  description: TAR GZip Archive file with the custom component. File extension must be `.tar.gz` or `.tgz`.
+                  type: string
+                  format: binary
+      responses:
+        '201':
+          description: Custom component successfully installed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomInstall'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '409':
+          $ref: '#/components/responses/Err409Conflict'
+  /system/logs:
+    get:
+      tags:
+        - system
+      summary: Retrieve and query log entries.
+      description: |
+        Retrieve log entries based on the query parameters.
+
+        Depending on the `Content-Type` header, the logs are either returned as JSON objects or exported as a text file.
+
+        - `Content-Type: application/json` or none: retrieve logs as json objects.
+        - `Content-Type: text/plain` or none: retrieve logs as text export.
+          - Field order: <timestamp> <service> <level> <message>
+          - Fields are separated by a tab.
+          - The message itself might contain tabs as well!
+          - The message might contain line breaks and use multiple lines.
+
+        Notes:    
+        - Number of log entries are limited to a maximum of 10'000 entries.
+        - Log entries are retrieved in reverse order.
+        - Not all services are using the priority logging yet and log all entries with priority 6 (info).  
+          They might even include their own log level in the message text.
+        - Text search is not case-sensitive. Wildcards or Regex is not supported.
+      parameters:
+        - name: p
+          in: query
+          description: Minimum priority of log message.
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 8
+            default: 5
+        - name: s
+          in: query
+          description: 'One or more service identifiers, separated by comma'
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Limit number of returned log entries
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 10000
+            default: 100
+        - name: from
+          in: query
+          description: Oldest log timestamp to consider
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          description: Newest log timestamp to consider
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: q
+          in: query
+          description: Search text in log message
+          required: false
+          schema:
+            type: string
+        - name: boot_ids
+          in: query
+          description: 'One or more boot identifiers, separated by comma'
+          required: false
+          schema:
+            type: string
+      operationId: queryLogs
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: |
+                2023-07-27T09:11:44.584555+00:00  ui  WARN  A warning message
+                2023-07-27T08:52:54.609843+00:00  ui  INFO  An information message
+                2023-07-27T08:52:53.609143+00:00  ui  DEBUG Application is starting
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SystemLogEntry'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /system/logs/boots:
+    get:
+      tags:
+        - system
+      summary: Get boot identifiers for log access.
+      description: |
+        List system boots to retrieve boot identifiers for a specific boot.
+      operationId: getBootLogIdentifiers
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SystemLogBoot'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /system/logs/services:
+    get:
+      tags:
+        - system
+      summary: Get available services to retrieve log entries from.
+      description: |
+        List the available services which can be queried for log entries.
+      operationId: getLogServices
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SystemLogService'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+  /system/power:
+    get:
+      tags:
+        - system
+      summary: Get current system power mode.
+      operationId: getPowerMode
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PowerModeResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    put:
+      tags:
+        - system
+      summary: Set a power mode
+      description: |
+        Setting `SUSPEND` will put the system immediately into suspend mode!
+      operationId: setPowerMode
+      parameters:
+        - $ref: '#/components/parameters/power_mode'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+  /system/power/battery:
+    get:
+      tags:
+        - system
+      summary: Get battery status.
+      operationId: getBatteryStatus
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatteryStatusResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+  /system/sensors/ambient_light:
+    get:
+      tags:
+        - system
+      summary: Get current ambient light reading from light sensor.
+      operationId: getAmbientLight
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AmbientLightResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+  /system/update:
+    get:
+      tags:
+        - system
+      summary: Check if system update is available.
+      description: |
+        Returns the known available system updates.
+
+        System update checks are run automatically (if not disabled in settings). Use the `PUT` operation to force
+        an update check.
+      operationId: checkSystemUpdate
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AvailableSystemUpdateResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    put:
+      tags:
+        - system
+      summary: Force system update check
+      operationId: forceSystemUpdateCheck
+      description: |
+        Contacts the update server to check if a new system update is available.
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AvailableSystemUpdateResponse'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+  '/system/update/{updateId}':
+    post:
+      tags:
+        - system
+      summary: Perform system update.
+      description: |
+        Start a system update with the given `updateId` parameter. Use `latest` to use the latest available system update.
+
+        The system update will be started if:
+        - the system update has been downloaded already (`download` state is `DOWNLOADED`).
+        - the device has at least 50% battery charge.
+
+        If the system update is started, the response message contains `state: START`. In case there's not enough battery,
+        `503 service unavailable` is returned. 
+        It is recommended to perform the update while the remote is charging in the docking station.
+
+        The progress of the system update can be retrieved with the `GET` operation, or by listening to the WebSocket 
+        `software_update` event messages.
+
+        If the system update hasn't been downloaded yet (`download` state is `PENDING` or `ERROR`), this operation will only
+        start the download and return `state: DOWNLOAD`. Once successfully downloaded, it can be installed by calling this
+        operation again.
+
+        ⚠️ Download progress events are not yet implemented!
+
+        Error codes:
+        - `404`: updateId does not exist
+        - `409`: download or update is already running
+        - `422`: for download request: update is already downloaded
+        - `503`: update service is currently not available
+      operationId: updateSystem
+      parameters:
+        - name: updateId
+          in: path
+          description: Update image identification
+          required: true
+          schema:
+            type: string
+            default: latest
+      responses:
+        '201':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemUpdateResponse'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '409':
+          $ref: '#/components/responses/Err409Conflict'
+        '422':
+          $ref: '#/components/responses/Err422UnprocessableEntity'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    get:
+      tags:
+        - system
+      summary: Get system update progress.
+      operationId: getSystemUpdateProgress
+      parameters:
+        - name: updateId
+          in: path
+          description: Update image identification
+          required: true
+          schema:
+            type: string
+            default: latest
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemUpdateProgress'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+  /system/wifi:
+    get:
+      tags:
+        - system
+      summary: Get WiFi status.
+      operationId: getWifiStatus
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WifiStatus'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    put:
+      tags:
+        - system
+      summary: WiFi connection handling.
+      description: |
+        Perform one of the following commands on the WLAN interface:
+
+        - `DISCONNECT`: Disconnect and wait for `REASSOCIATE` or `RECONNECT` command before connecting again.
+        - `RECONNECT`: Connect if disconnected (i.e. like `REASSOCIATE`, but only connect if in disconnected state).
+        - `REASSOCIATE`: Force reassociation.
+        - `ENABLE_ALL_NETWORKS`: Enable all network connections and start connecting to a network if in disconnected state.
+        - `DISABLE_ALL_NETWORKS`: Disable all network connections and disconnect if in connected state.
+
+        ⚠️Attention: `ENABLE_ALL_NETWORKS` and `DISABLE_ALL_NETWORKS` will persist the state! I.e. if all networks are 
+        disabled and the device is restarted afterwards, no WiFi connection will be established.
+      operationId: wifiCommand
+      parameters:
+        - name: cmd
+          in: query
+          description: Command
+          schema:
+            $ref: '#/components/schemas/WifiCmd'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+  /system/wifi/scan:
+    get:
+      tags:
+        - system
+      summary: Get discovered WiFi access points.
+      description: |
+        Returns the current discovery status and any discovered access points.
+
+        Use the DELETE operation to stop an active discovery and PUT to start a new discovery.
+      operationId: getWifiScanStatus
+      responses:
+        '200':
+          description: WiFi AP discovery status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApScanStatus'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    put:
+      tags:
+        - system
+      summary: Start discovery of WiFi access points.
+      description: |
+        Request a new BSS scan. A scan usually takes a few seconds and the current state is returned with the GET
+        operation, together with the already found access points.
+      operationId: startWifiScan
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    delete:
+      tags:
+        - system
+      summary: Stop discovery of WiFi access points.
+      description: |
+        Stops the access point discovery. The current discovery status is returned in the response.
+      operationId: stopWifiScan
+      responses:
+        '200':
+          description: Dock discovery status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApScanStatus'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+  /system/wifi/networks:
+    get:
+      tags:
+        - system
+      summary: Get configured WiFi networks.
+      description: |
+        Returns all configured WiFi networks.
+      operationId: getAllWifiNetworks
+      responses:
+        '200':
+          description: Configured WiFi networks.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavedNetworks'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    post:
+      tags:
+        - system
+      summary: Create a new Wifi network configuration.
+      operationId: addWifiNetwork
+      description: |
+        Add a new network configuration for the given SSID.  
+        For an open network without password the `password` field must be omitted (do not send an empty password value).
+
+        ⚠️ Only WPA-PSK (pre shared keys) and open networks are supported!
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateWifiNetwork'
+      responses:
+        '201':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    delete:
+      tags:
+        - system
+      summary: Delete all configured WiFi networks.
+      description: |
+        Disconnects the WiFi network and removes all network configurations.
+
+        ⚠️ Attention: the network configuration is automatically persisted and the network configuration cannot
+        be retrieved anymore!
+      operationId: deleteAllWifiNetworks
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+  '/system/wifi/networks/{wifiId}':
+    get:
+      tags:
+        - system
+      summary: Get WiFi network configuration.
+      description: |
+        Returns the configured wifi network.
+
+        Use the DELETE operation to remove and PATCH to edit a network configuration. A new network configuration can be
+        created with the POST operation on the `/system/wifi/networks/` resource.
+      operationId: getWifiNetwork
+      parameters:
+        - $ref: '#/components/parameters/wifi_id'
+      responses:
+        '200':
+          description: WiFi network configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavedNetwork'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    patch:
+      tags:
+        - system
+      summary: Modify a network configuration.
+      description: Change the WiFi network password.
+      operationId: modifyWifiNetwork
+      parameters:
+        - $ref: '#/components/parameters/wifi_id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModifyWifiNetwork'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    put:
+      tags:
+        - system
+      summary: WiFi network connection handling.
+      description: |
+        Perform one of the following commands on a network configuration:
+        - `ENABLE`: Enable a network. If no network is connected, it will be tried to connect to this network.
+        - `DISABLE`: Disable a network. If the network is currently connected it will be disconnected.
+        - `SELECT`: Select the given network and disable all others.
+
+        ⚠️ Attention: all network changes (enabled or disabled) are persisted!
+      operationId: wifiNetworkCommand
+      parameters:
+        - $ref: '#/components/parameters/wifi_id'
+        - name: cmd
+          in: query
+          description: Command
+          schema:
+            $ref: '#/components/schemas/WifiNetworkCmd'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    delete:
+      tags:
+        - system
+      summary: Delete a configured WiFi network.
+      description: |
+        The given network is removed from the configuration and disconnected if currently connected.
+
+        ⚠️ Attention: the network configuration is automatically persisted and the removed network configuration cannot
+        be retrieved anymore!
+      operationId: deleteWifiNetwork
+      parameters:
+        - $ref: '#/components/parameters/wifi_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessMessage'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '404':
+          $ref: '#/components/responses/Err404NotFound'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+components:
+  parameters:
+    api_key_id:
+      name: apiKeyId
+      in: path
+      description: API key identification
+      required: true
+      schema:
+        $ref: '#/components/schemas/ApiKeyId'
+    backup_id:
+      name: id
+      in: path
+      description: Backup snapshot identifier
+      required: true
+      schema:
+        type: string
+    button_id:
+      name: buttonId
+      in: path
+      description: Button identification.
+      required: true
+      schema:
+        $ref: '#/components/schemas/ButtonId'
+    cmd_id:
+      name: cmdId
+      in: path
+      description: IR command identification.
+      required: true
+      schema:
+        $ref: '#/components/schemas/IrCodeKey'
+    custom_component:
+      name: customComponent
+      in: path
+      description: Custom system component.
+      required: true
+      schema:
+        $ref: '#/components/schemas/CustomComponent'
+    dock_id:
+      name: dockId
+      in: path
+      description: Dock identification
+      required: true
+      schema:
+        $ref: '#/components/schemas/DockId'
+    driver_id:
+      name: driverId
+      in: path
+      description: Integration driver identification
+      required: true
+      schema:
+        $ref: '#/components/schemas/DriverId'
+    emitter_id:
+      name: emitterId
+      in: path
+      description: Emitter device id.
+      required: true
+      schema:
+        $ref: '#/components/schemas/SimpleId'
+    entity_id:
+      name: entityId
+      in: path
+      description: Entity identification.
+      required: true
+      schema:
+        $ref: '#/components/schemas/EntityId'
+    group_id:
+      name: groupId
+      in: path
+      description: Group identification
+      required: true
+      schema:
+        $ref: '#/components/schemas/SimpleId'
+    integration_id:
+      name: intgId
+      in: path
+      description: Integration identification
+      required: true
+      schema:
+        $ref: '#/components/schemas/IntegrationId'
+    ir_key:
+      name: key
+      in: path
+      description: IR command key
+      required: true
+      schema:
+        $ref: '#/components/schemas/IrCodeKey'
+    page_id:
+      name: pageId
+      in: path
+      description: Page identification
+      required: true
+      schema:
+        $ref: '#/components/schemas/SimpleId'
+    profile_id:
+      name: profileId
+      in: path
+      description: Profile identification
+      required: true
+      schema:
+        $ref: '#/components/schemas/SimpleId'
+    resource_id:
+      name: id
+      in: path
+      description: Resource identifier
+      required: true
+      schema:
+        type: string
+    resource_type:
+      name: type
+      in: path
+      description: Resource type
+      required: true
+      schema:
+        $ref: '#/components/schemas/ResourceType'
+    system:
+      name: system
+      in: path
+      description: Identification of the external system. E.g. _homeassistant_.
+      required: true
+      schema:
+        $ref: '#/components/schemas/ExternalSystemId'
+    token_id:
+      name: tokenId
+      in: path
+      description: Access token identification
+      required: true
+      schema:
+        $ref: '#/components/schemas/AccessTokenId'
+    wifi_id:
+      name: wifiId
+      in: path
+      description: WiFi network identification
+      required: true
+      schema:
+        type: integer
+        minimum: 0
+    active:
+      name: active
+      in: query
+      description: Filter by active flag
+      required: false
+      schema:
+        type: boolean
+    enabled:
+      name: enabled
+      in: query
+      description: Filter by enabled flag.
+      required: false
+      schema:
+        type: boolean
+    entity_types:
+      name: entity_types
+      in: query
+      description: 'Filter by multiple entity types, separated by comma.'
+      required: false
+      schema:
+        type: string
+    has_instances:
+      name: has_instances
+      in: query
+      description: |
+        Filter if a driver has integration instances or not:
+        - true = only consider drivers which have at least one integration instance,
+        - false = drivers without instances
+        - NONE = any.
+      required: false
+      schema:
+        type: boolean
+    instantiable:
+      name: instantiable
+      in: query
+      description: |
+        Filter if a driver is instantiable or not:
+        - true = only consider drivers which allow new integration instances to be created from. Either single-device drivers
+          without an instance, or multi-device drivers.
+        - false = only drivers which allow no more instances
+        - NONE = any.
+      required: false
+      schema:
+        type: boolean
+    intg_ids:
+      name: intg_ids
+      in: query
+      description: 'Filter by multiple integration identifiers, separated by comma.'
+      required: false
+      schema:
+        type: string
+    merge:
+      name: merge
+      in: query
+      description: Merge data.
+      required: false
+      schema:
+        type: boolean
+    query:
+      name: q
+      in: query
+      description: Text search
+      required: false
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 50
+    resource_type_query:
+      name: type
+      in: query
+      description: Resource type.
+      required: false
+      schema:
+        $ref: '#/components/schemas/ResourceType'
+    page:
+      name: page
+      in: query
+      description: Current page number. 1-based.
+      required: false
+      schema:
+        type: integer
+        format: int32
+        default: 1
+        minimum: 1
+    power_mode:
+      name: power_mode
+      in: query
+      description: Power mode
+      required: true
+      schema:
+        $ref: '#/components/schemas/PowerMode'
+    limit:
+      name: limit
+      in: query
+      description: Limits the number of returned items.
+      required: false
+      schema:
+        type: integer
+        format: int32
+        default: 10
+        minimum: 10
+        maximum: 100
+        multipleOf: 10
+    single_device:
+      name: single_device
+      in: query
+      description: |
+        true = only consider single-device drivers, false = only multi-device drivers, NONE = all.
+      required: false
+      schema:
+        type: boolean
+  schemas:
+    AccessTokenId:
+      type: string
+      format: '^[a-zA-Z0-9\-_]+$'
+      minLength: 1
+      maxLength: 36
+      description: Unique token identifier. Usually a UUID.
+    Activities:
+      type: array
+      items:
+        $ref: '#/components/schemas/ActivityOverview'
+    Activity:
+      description: |
+        The activity entity executes a sequence of commands and at the end displays a user interface (similar to remote entity)
+        to the user. If the entity has an off sequence, it can be turned off.
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Entity'
+        - properties:
+            entity_type:
+              type: string
+              enum:
+                - activity
+            features:
+              description: |
+                Supported features of the activity. If the activity has an `off` sequence, it supports the common `on_off`
+                feature, otherwise only `start`.
+              type: array
+              items:
+                type: string
+                enum:
+                  - on_off
+                  - start
+            options:
+              type: object
+              properties:
+                editable:
+                  description: |
+                    - `true` / property missing: activity was created by Remote Two and can be edited.
+                    - `false`: activity was provided by an integration and cannot be edited.
+                  type: boolean
+                  default: true
+                activity_group:
+                  description: |
+                    Minimal activity group information to use in a user interface with it's friendly name and icon.
+                  type: object
+                  properties:
+                    group_id:
+                      $ref: '#/components/schemas/EntityId'
+                    name:
+                      $ref: '#/components/schemas/LanguageText'
+                    icon:
+                      $ref: '#/components/schemas/IconIdentifier'
+                  required:
+                    - group_id
+                    - name
+                prevent_sleep:
+                  description: Prevent the device to go to sleep while activity is on.
+                  type: boolean
+                included_entities:
+                  $ref: '#/components/schemas/IncludedEntities'
+                sequences:
+                  $ref: '#/components/schemas/ActivitySequences'
+                button_mapping:
+                  $ref: '#/components/schemas/DeviceButtonMappings'
+                user_interface:
+                  $ref: '#/components/schemas/ActivityUserInterface'
+            attributes:
+              type: object
+              properties:
+                state:
+                  $ref: '#/components/schemas/SequenceState'
+          required:
+            - options
+            - attributes
+    ActivityId:
+      type: string
+      format: '^[a-zA-Z0-9\-_]+$'
+      minLength: 1
+      maxLength: 36
+      description: Activity identifier
+    ActivityOverview:
+      description: |
+        The activity entity executes a sequence of commands and at the end displays a user interface (similar to remote entity)
+        to the user. If the entity has an off sequence, it can be turned off.
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Entity'
+        - properties:
+            entity_type:
+              type: string
+              enum:
+                - activity
+            features:
+              description: |
+                Supported features of the activity. If the activity has an `off` sequence, it supports the common `on_off`
+                feature, otherwise only `start`.
+              type: array
+              items:
+                type: string
+                enum:
+                  - on_off
+                  - start
+            options:
+              type: object
+              properties:
+                editable:
+                  description: |
+                    - `true` / property missing: activity was created by Remote Two and can be edited.
+                    - `false`: activity was provided by an integration and cannot be edited.
+                  type: boolean
+                  default: true
+                activity_group:
+                  $ref: '#/components/schemas/EntityId'
+    ActivityRequest:
+      description: |
+        Dedicated request object to create a new activity.
+      type: object
+      allOf:
+        - properties:
+            name:
+              $ref: '#/components/schemas/LanguageText'
+            icon:
+              $ref: '#/components/schemas/IconIdentifier'
+            description:
+              $ref: '#/components/schemas/LanguageText'
+        - oneOf:
+            - type: object
+              properties:
+                clone_from:
+                  $ref: '#/components/schemas/EntityId'
+              required:
+                - clone_from
+            - type: object
+              properties:
+                options:
+                  type: object
+                  properties:
+                    entity_ids:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/EntityId'
+                  required:
+                    - entity_ids
+      required:
+        - name
+    ActivitySequences:
+      type: object
+      properties:
+        'on':
+          $ref: '#/components/schemas/CommandSequence'
+        'off':
+          $ref: '#/components/schemas/CommandSequence'
+    ActivityUpdate:
+      description: |
+        Dedicated request object to update an existing activity.  
+        All root properties are optional and only the provided objects are updated in the activity. Omitted objects are
+        ignored and not deleted from the activity.
+
+        The `entity_ids` object must be managed by the client and is persisted when updating an activity.
+
+        Notes:
+        - Entities can be included in `entity_ids` without being used in `sequences`.  
+          This allows to edit the activity in multiple sessions without having to reselect the desired entities.
+        - Every referenced entity in `sequences` must be included in `entity_ids`, otherwise the activity cannot be saved.
+        - If the client removes a configured entity from the system which is included in an activity, it must make sure to
+          also remove all references in the activity. See `IncludedEntity.available` property in the included entities
+          object when retrieving an activity.
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        description:
+          $ref: '#/components/schemas/LanguageText'
+        options:
+          type: object
+          properties:
+            prevent_sleep:
+              description: Prevent the device to go to sleep while activity is on.
+              type: boolean
+            entity_ids:
+              type: array
+              items:
+                $ref: '#/components/schemas/EntityId'
+            sequences:
+              $ref: '#/components/schemas/ActivitySequences'
+    ActivityUserInterface:
+      type: object
+      properties:
+        pages:
+          type: array
+          items:
+            $ref: '#/components/schemas/ActivityUserInterfacePage'
+    ActivityUserInterfacePage:
+      type: object
+      properties:
+        page_id:
+          $ref: '#/components/schemas/SimpleId'
+        name:
+          description: Optional page name
+          type: string
+        grid:
+          $ref: '#/components/schemas/DeviceButtonLayout/properties/grid'
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserInterfaceItem'
+      required:
+        - page_id
+        - grid
+        - items
+    ActivityUserInterfacePageUpdate:
+      type: object
+      properties:
+        name:
+          description: Optional page name
+          type: string
+        grid:
+          $ref: '#/components/schemas/DeviceButtonLayout/properties/grid'
+        items:
+          description: |
+            Updated user interface items. An empty array will REMOVE all items, if the property is omitted the existing
+            configuration is not changed.
+          type: array
+          items:
+            $ref: '#/components/schemas/UserInterfaceItem'
+    ActivityGroup:
+      description: |
+        An activity group creates a dependency between multiple activities. Switching between activities will consider
+        the current state of the included entities and only turn-on or -off the required entities.
+      type: object
+      properties:
+        group_id:
+          $ref: '#/components/schemas/EntityId'
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        description:
+          $ref: '#/components/schemas/LanguageText'
+        options:
+          $ref: '#/components/schemas/ActivityGroupOptions'
+        activities:
+          description: Included activities in the group.
+          type: array
+          items:
+            $ref: '#/components/schemas/IncludedActivity'
+      required:
+        - group_id
+        - name
+        - options
+        - activities
+    ActivityGroups:
+      type: array
+      items:
+        $ref: '#/components/schemas/ActivityGroupOverview'
+    ActivityGroupState:
+      description: |
+        - `OFF`: No included activity is running.
+        - `ACTIVE`: An included activity is running.
+        - `RUNNING`: An included activity is currently running, e.g. either switching activities, or turning off.
+        - `ERROR`: An included activity is in an error state.
+      type: string
+      enum:
+        - 'OFF'
+        - ACTIVE
+        - RUNNING
+        - ERROR
+    ActivityGroupOverview:
+      description: |
+        Minimal activity group object intended for an overview page, which is returned when retrieving all activities.
+      type: object
+      properties:
+        group_id:
+          $ref: '#/components/schemas/EntityId'
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        activity_count:
+          description: Number of included activities.
+          type: integer
+        state:
+          $ref: '#/components/schemas/ActivityGroupState'
+      required:
+        - group_id
+        - name
+        - activity_count
+    ActivityGroupUpdate:
+      description: |
+        Dedicated request object to update an existing activity group.  
+        All root properties are optional and only the provided objects are updated in the activity group. Omitted objects are
+        ignored and not deleted from the activity group.
+
+        Referenced activities must exist, an empty `activity_ids` array will remove all included activities from the group.
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        description:
+          $ref: '#/components/schemas/LanguageText'
+        options:
+          $ref: '#/components/schemas/ActivityGroupOptions'
+        activity_ids:
+          description: Entity identifiers of included activities in group.
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityId'
+    IncludedActivity:
+      description: |
+        Minimal activity object to show the activity in a user interface with it's friendly name and icon.
+      type: object
+      properties:
+        entity_id:
+          $ref: '#/components/schemas/EntityId'
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        state:
+          $ref: '#/components/schemas/SequenceState'
+      required:
+        - entity_id
+        - name
+    SequenceState:
+      description: |
+        State of an Activity or Macro sequence:
+        - `RUNNING`: Sequence is currently running
+        - `COMPLETED`: Final state for a macro
+        - `ON`: Final activity state for the `on` sequence
+        - `OFF`: Final activity state for the `off` sequence
+        - `STOPPED`: The sequence was aborted with a stop request
+        - `TIMEOUT`: The sequence timed out and was aborted
+        - `ERROR`: There was an error running the sequence and did not complete
+      type: string
+      enum:
+        - RUNNING
+        - COMPLETED
+        - 'ON'
+        - 'OFF'
+        - STOPPED
+        - TIMEOUT
+        - ERROR
+    ActivityGroupOptions:
+      description: "\U0001F477Not yet finalized!\n\nActivity group specific options, e.g. how delays are handled when switching between activities.\n"
+      type: object
+      properties:
+        remove_turn_on_delays:
+          description: |
+            - `previous_cmd_skipped`: Only remove delay steps if the previous step is skipped, because the entity is in a
+               power-on state.
+            - `between_skipped_cmds`: Only remove delay steps if the previous and next power-on steps are skipped, because
+               the entity is already in a power-on state.
+            - `never`: Never remove delay steps in the on-sequence of the new activity.
+          type: string
+          enum:
+            - previous_cmd_skipped
+            - between_skipped_cmds
+            - never
+        turn_off_unused_entities:
+          description: |
+            - `always`: Always turn off unused entities in the previous activity.  
+               All included entities are considered, not just the ones used in the on-sequence of the new activity.
+            - `in_off_sequence`: Only turn off unused entities which are included in the off-sequence of the previous activity.
+            - `run_off_sequence`: Run the original off-sequence of the old activity and dynamically filter out power-off commands.  
+               All power-off commands from entities used in the new activity's power-on sequence will be filtered out.
+            - `never`: Never turn off entities in the previous activity.
+          type: string
+          enum:
+            - always
+            - in_off_sequence
+            - run_off_sequence
+            - never
+    AdminPin:
+      type: string
+      maxLength: 20
+      description: Optional administrator pin
+    AmbientLight:
+      type: object
+      properties:
+        intensity:
+          description: 'Light intensity. 0 = pitch black, 65535 = very bright.'
+          type: integer
+          minimum: 0
+          maximum: 65535
+      required:
+        - intensity
+    AmbientLightResponse:
+      type: object
+      properties:
+        intensity:
+          description: 'Light intensity. 0 = pitch black, 65535 = very bright.'
+          type: integer
+          minimum: 0
+          maximum: 65535
+      required:
+        - intensity
+    ApiKey:
+      type: object
+      properties:
+        key_id:
+          $ref: '#/components/schemas/ApiKeyId'
+        name:
+          $ref: '#/components/schemas/ApiKeyName'
+        prefix:
+          description: Prefix of the API key for identification purposes.
+          type: string
+        active:
+          type: boolean
+          description: Only activated keys are valid for API access.
+        valid_to:
+          type: string
+          format: date-time
+          description: 'Optional expiration timestamp. If not set, the API key is valid until revoked.'
+        scopes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScopeName'
+        description:
+          $ref: '#/components/schemas/Description'
+        creation_date:
+          type: string
+          format: date-time
+    ApiKeyId:
+      type: string
+      format: '^[a-zA-Z0-9\-_]+$'
+      minLength: 1
+      maxLength: 36
+      description: Unique key identifier. Usually a UUID.
+    ApiKeyName:
+      type: string
+      minLength: 1
+      maxLength: 50
+      description: Friendly API key name to show in the app
+    ApiKeyRequest:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/ApiKeyName'
+        scopes:
+          type: array
+          items:
+            type: string
+          description: Requested access scopes for the API key.
+        active:
+          type: boolean
+          default: false
+          description: |
+            Only activated keys are valid for API access.  
+            This might be overridden if the requestor doesn't have sufficient rights. In this case the key will not be active
+            until a user with appropriate rights will set it active. The assigned `active` state will be returned in the
+            response.
+        valid_to:
+          type: string
+          format: date-time
+          description: 'Optional expiration timestamp. If not set, the API key is valid until revoked.'
+        description:
+          $ref: '#/components/schemas/Description'
+      required:
+        - name
+        - scopes
+    ApiKeyResponse:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/ApiKeyName'
+        api_key:
+          type: string
+          description: API key.
+        active:
+          type: boolean
+          description: Only activated keys are valid for API access.
+        valid_to:
+          type: string
+          format: date-time
+          description: 'Optional expiration timestamp. If not set, the API key is valid until revoked.'
+        scopes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScopeName'
+      required:
+        - name
+        - api_key
+        - active
+        - scopes
+    ApiKeys:
+      type: array
+      items:
+        $ref: '#/components/schemas/ApiKey'
+    ApiKeyUpdate:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/ApiKeyName'
+        active:
+          type: boolean
+          description: Only activated keys are valid for API access.
+        valid_to:
+          type: string
+          format: date-time
+          description: 'Optional expiration timestamp. If not set, the API key is valid until revoked.'
+        description:
+          $ref: '#/components/schemas/Description'
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Status code
+        message:
+          type: string
+          description: Status message describing the result or error. This message is intended for error analysis and should not directly shown to the end user.
+    AvailableEntity:
+      description: Provided entity from an integration which can be configured to be used in the remote.
+      type: object
+      properties:
+        entity_id:
+          $ref: '#/components/schemas/AvailableEntityId'
+        entity_type:
+          $ref: '#/components/schemas/EntityType'
+        integration_id:
+          $ref: '#/components/schemas/IntegrationId'
+        device_id:
+          $ref: '#/components/schemas/DeviceId'
+        device_class:
+          description: |
+            Optional device type. This can be used by the UI to represent the entity with a different
+            icon, behaviour etc. See entity documentation for available device classes.
+          type: string
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        features:
+          description: |
+            Supported features of the entity. See entity documentation for available features.
+          type: array
+          items:
+            type: string
+        options:
+          description: |
+            Feature options. See entity documentation for available options.
+          type: object
+        area:
+          description: Optional area if supported by the integration. E.g. `Living room`.
+          type: string
+      required:
+        - entity_id
+        - entity_type
+        - integration_id
+        - name
+        - features
+    AvailableEntityId:
+      type: string
+      format: '^[a-zA-Z0-9\-_\.]+$'
+      minLength: 1
+      maxLength: 36
+      description: |
+        Entity identifier used in an integration driver (= available entities).
+    BackupSnapshot:
+      type: object
+      properties:
+        id:
+          description: Backup identifier
+          type: string
+        creation_date:
+          description: Creation date of the backup snapshot
+          type: string
+          format: date-time
+        size:
+          description: Archive size in bytes
+          type: integer
+          format: int32
+      required:
+        - id
+        - creation_date
+        - size
+      example:
+        id: UCR2_2023-09-17_145305
+        creation_date: '2023-09-17T14:53:05+02:00'
+        size: 2370274
+    BackupMetadata:
+      type: object
+      properties:
+        id:
+          description: Backup identifier
+          type: string
+        creation_date:
+          description: Creation date of the backup snapshot
+          type: string
+          format: date-time
+        version:
+          $ref: '#/components/schemas/BackupMetadataVersion'
+        report:
+          type: object
+          properties:
+            item:
+              type: string
+              enum:
+                - db
+                - integration_driver
+                - integration
+                - activity
+                - macro
+                - remote
+                - profile
+                - dock
+                - resource
+            available:
+              type: integer
+              format: int32
+            ok:
+              type: integer
+              format: int32
+          required:
+            - item
+            - available
+            - ok
+      required:
+        - id
+        - creation_date
+        - version
+      example:
+        id: UCR2_2023-09-17_145305
+        creation_date: '2023-09-17T14:53:05+00:00'
+        version:
+          backup: 1.0.0
+          core: 0.34.5-beta
+          os: 1.2.0
+    BackupMetadataVersion:
+      type: object
+      properties:
+        backup:
+          description: 'Version of the backup data model in [SemVer](https://semver.org/) format.'
+          type: string
+        core:
+          description: Core app version
+          type: string
+        os:
+          description: Operating system version
+          type: string
+      required:
+        - backup
+    BatteryStatusResponse:
+      type: object
+      properties:
+        capacity:
+          description: Current battery charge in %
+          type: integer
+          minimum: 0
+          maximum: 100
+        status:
+          $ref: '#/components/schemas/PowerStatus'
+        power_supply:
+          description: Power supply online
+          type: boolean
+      required:
+        - capacity
+        - status
+    PowerStatus:
+      type: string
+      enum:
+        - CHARGING
+        - DISCHARGING
+        - NOT_CHARGING
+        - FULL
+    ButtonId:
+      type: string
+      format: '^[A-Z0-9_]+$'
+      minLength: 1
+      maxLength: 20
+      description: Physical button identification
+    CfgAll:
+      type: object
+      properties:
+        button:
+          $ref: '#/components/schemas/CfgButtons'
+        device:
+          $ref: '#/components/schemas/CfgRemoteDevice'
+        display:
+          $ref: '#/components/schemas/CfgDisplay'
+        features:
+          $ref: '#/components/schemas/CfgFeatures'
+        haptic:
+          $ref: '#/components/schemas/CfgHaptic'
+        localization:
+          $ref: '#/components/schemas/CfgLocalization'
+        network:
+          $ref: '#/components/schemas/CfgNetwork'
+        power_saving:
+          $ref: '#/components/schemas/CfgPowerSaving'
+        profile:
+          $ref: '#/paths/~1cfg~1profile/get/responses/200/content/application~1json/schema'
+        software_update:
+          $ref: '#/components/schemas/CfgSoftwareUpdate'
+        sound:
+          $ref: '#/components/schemas/CfgSound'
+        voice_control:
+          $ref: '#/components/schemas/CfgVoiceControl'
+        restart_required:
+          description: A configuration change requires a restart.
+          type: boolean
+    CfgButtons:
+      type: object
+      properties:
+        brightness:
+          description: 'Button backlight brightness. 0 = off, 100 = max.'
+          type: integer
+          minimum: 0
+          maximum: 100
+        auto_brightness:
+          description: 'When enabled, button backlight will automatically turn on in a dark room.'
+          type: boolean
+      required:
+        - brightness
+        - auto_brightness
+    CfgDisplay:
+      type: object
+      properties:
+        brightness:
+          description: Display brightness.
+          type: integer
+          minimum: 0
+          maximum: 100
+        auto_brightness:
+          description: Automatically adjust the display brightness based on ambient lighting conditions.
+          type: boolean
+      required:
+        - brightness
+        - auto_brightness
+    CfgFeatures:
+      type: array
+      items:
+        $ref: '#/components/schemas/CfgFeature'
+    CfgFeature:
+      type: object
+      properties:
+        id:
+          type: string
+        enabled:
+          type: boolean
+        title:
+          $ref: '#/components/schemas/LanguageText'
+        description:
+          $ref: '#/components/schemas/LanguageText'
+        help_url:
+          type: string
+          format: url
+      required:
+        - id
+        - enabled
+        - title
+        - description
+    CfgFeatureUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+        enabled:
+          type: boolean
+      required:
+        - id
+        - enabled
+    CfgHaptic:
+      type: object
+      properties:
+        enabled:
+          description: Haptic feedback enabled.
+          type: boolean
+      required:
+        - enabled
+    CfgLocalization:
+      type: object
+      properties:
+        language_code:
+          $ref: '#/components/schemas/LanguageCode'
+        country_code:
+          $ref: '#/components/schemas/CountryCode'
+        time_zone:
+          description: 'Time zone name according to IANA <https://www.iana.org/time-zones>, e.g. `Europe/Copenhagen`.'
+          type: string
+        time_format_24h:
+          type: boolean
+        measurement_unit:
+          $ref: '#/components/schemas/MeasurementUnit'
+      required:
+        - language_code
+        - country_code
+        - time_zone
+        - time_format_24h
+        - measurement_unit
+    CfgNetwork:
+      type: object
+      properties:
+        bt_enabled:
+          description: Enable Bluetooth.
+          type: boolean
+        wifi_enabled:
+          description: Enable WiFi.
+          type: boolean
+        bt:
+          description: Temporary read-only Bluetooth information until dedicated BT management endpoint is provided.
+          type: object
+          properties:
+            address:
+              description: Bluetooth MAC address
+              type: string
+        ws:
+          description: |
+            Optional expert settings for WebSocket (re-)connection handling.  
+            These settings are only intended for support issues and might change any time. Changed values are not supported
+            and might make the system unstable!
+          type: object
+          properties:
+            dock:
+              type: object
+            integration:
+              type: object
+      required:
+        - bt_enabled
+        - wifi_enabled
+    CfgPowerSaving:
+      type: object
+      properties:
+        wakeup_sensitivity:
+          description: 'Amount of movement needed to wake up the remote. 0 = disabled, 1 = min, 2 = medium, 3 = max.'
+          type: integer
+          minimum: 0
+          maximum: 3
+        display_off_sec:
+          type: integer
+          minimum: 0
+          maximum: 60
+          description: Turn off display after given seconds.
+        standby_sec:
+          type: integer
+          minimum: 0
+          maximum: 10800
+          description: Activate standby after given seconds. 0 disables standby mode.
+      required:
+        - wakeup_sensitivity
+        - display_off_sec
+        - standby_sec
+    CfgRemoteDevice:
+      type: object
+      properties:
+        name:
+          description: Custom name of the remote
+          type: string
+          minimum: 1
+          maximum: 50
+      required:
+        - name
+    CfgSoftwareUpdate:
+      type: object
+      properties:
+        check_for_updates:
+          description: |
+            Automatically check for updates. If `auto_update` is enabled, the updates are automatically installed,
+            otherwise the user is only notified about the updates.
+
+            The time window when to check for new updates can be specified in `ota_window_start` and `ota_window_end`.
+            Update checks are performed daily.
+          type: boolean
+        auto_update:
+          description: |
+            Automatically update the remote when new software is available. Requires `check_for_updates` to be enabled.
+
+            Auto-installation of new firmwares will usually happen over 2 update checks: the first check finds a new
+            update, downloads the metadata and schedules the firmware file to be downloaded. The next check will find the
+            downloaded firmware file and installs it.
+          type: boolean
+        ota_window_start:
+          description: |
+            OTA update window start time: automatic update checks will only be performed during this time window.  
+            Furthermore, the remote needs to be in the docking station and have enough battery charge.
+
+            Format: time of day - as defined by `partial-time` in RFC3339
+          type: string
+          pattern: '^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$'
+        ota_window_end:
+          description: |
+            OTA update window end time.
+
+            - If the end time is before the start time, the window will spawn over midnight, e.g. `23:00:00` - `01:00:00`.
+            - Both start and end times are required, otherwise a default will be used.
+          type: string
+          pattern: '^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$'
+        channel:
+          description: |
+            Software update channels:
+            - `default`: release channel
+            - `testing`: new test and beta versions which might become the next release if successfully tested.
+            - `development`: untested alpha versions from the developers.  
+               ⚠️ High chance of breaking changes, bugs and loosing data!
+
+            Other channels than `default` might require an access token in `channel_token`, since they are intended for
+            a closed user group.
+          type: string
+          anyOf:
+            - enum:
+                - default
+                - testing
+                - development
+            - {}
+        channel_token:
+          description: |
+            Optional access token which might be required for non-default software update channels.
+            - This token is write only and cannot be retrieved anymore.
+            - If omitted when updating settings: the stored token will be used.
+            - If the `default` channel is selected when updating settings: the token will be ignored.
+          type: string
+          pattern: '^[-a-zA-Z0-9._~+/]{1,256}=?$'
+      required:
+        - check_for_updates
+        - auto_update
+    CfgSound:
+      type: object
+      properties:
+        enabled:
+          description: Sound effects enabled.
+          type: boolean
+        volume:
+          description: Sound effects volume.
+          type: integer
+          minimum: 0
+          maximum: 100
+      required:
+        - enabled
+        - volume
+    CfgVoiceControl:
+      type: object
+      properties:
+        microphone:
+          description: |
+            Enable microphone. Disabling the microphone will completely turn it off. Voice control and dictation won't work
+            with the remote or integrations.
+          type: boolean
+        enabled:
+          description: |
+            Enable voice control. Disabling voice control will still let you use voice dictation with integrations. 
+            Disable the microphone to completely switch off any microphone related functionality.
+          type: boolean
+        voice_assistant:
+          description: |
+            TODO
+          type: string
+          default: None
+      required:
+        - microphone
+        - enabled
+        - voice_assistant
+    CommandSequence:
+      description: Sequence of commands to execute.
+      type: array
+      items:
+        oneOf:
+          - $ref: '#/components/schemas/CommandSequenceEntity'
+          - $ref: '#/components/schemas/CommandSequenceDelay'
+        discriminator:
+          propertyName: type
+          mapping:
+            command: '#/components/schemas/CommandSequenceEntity'
+            delay: '#/components/schemas/CommandSequenceDelay'
+    CommandSequenceEntity:
+      description: Entity command step in a command sequence.
+      type: object
+      properties:
+        type:
+          type: string
+        command:
+          $ref: '#/components/schemas/EntityCommand'
+      required:
+        - type
+        - command
+      example:
+        type: command
+        command:
+          entity_id: hass.main.light.living-room
+          cmd_id: 'on'
+          params:
+            brightness: 75
+    CommandSequenceDelay:
+      description: Delay step in a command sequence.
+      type: object
+      properties:
+        type:
+          type: string
+        delay:
+          description: Delay in milliseconds.
+          type: integer
+          minimum: 1
+      required:
+        - type
+        - delay
+      example:
+        type: delay
+        delay: 100
+    CountryCode:
+      description: 'Two letter country code according to [ISO-3166-1-alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).'
+      type: string
+      format: iso-3166
+    CustomInstall:
+      description: Information about an installed custom component. The `installed` flag reports if a custom installation
+      type: object
+      properties:
+        component:
+          $ref: '#/components/schemas/CustomComponent'
+        installed:
+          description: |
+            Custom component has been installed. When `installed: true` is set, more information is returned in `release`.
+          type: boolean
+        active:
+          description: Custom component is active and replacing the default component.
+          type: boolean
+        installation_date:
+          description: 'Installation date of the component. Only provided when `installed: true` is set.'
+          type: string
+          format: date-time
+        release:
+          $ref: '#/components/schemas/CustomRelease'
+      required:
+        - component
+        - installed
+        - active
+    CustomComponent:
+      description: Type of custom component.
+      type: string
+      enum:
+        - ui
+        - web_configurator
+    CustomRelease:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        version:
+          type: string
+          maxLength: 30
+        description:
+          $ref: '#/components/schemas/LanguageText'
+        developer:
+          $ref: '#/components/schemas/DriverDeveloper'
+        home_page:
+          description: Optional home page url for more information.
+          type: string
+          format: uri
+          maxLength: 255
+        release_date:
+          description: Release date of the component.
+          type: string
+          format: date
+        requirements:
+          type: object
+          properties:
+            firmware_version:
+              description: |
+                [SemVer](https://semver.org/) version requirement, describing the intersection of some version comparators to
+                match the installed Remote Two firmware.
+
+                - `>=1.0`: requires at least version 1.0.0
+                - `>=0.9.0, <0.10.0`: only works with minor version 0.9.*   
+
+                Follows the Cargo's SemVer support documented in the [Specifying Dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html)
+                chapter of the Cargo reference.
+              type: string
+    Description:
+      type: string
+      maxLength: 255
+      description: Optional description
+    DeviceButtonGroup:
+      description: Button group type.
+      type: string
+      enum:
+        - keypad
+    DeviceButtonLayout:
+      description: 'Button group definitions with layout placement, size, icon and language specific names.'
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/DeviceButtonGroup'
+        grid:
+          description: Grid layout size.
+          type: object
+          properties:
+            width:
+              type: integer
+              minimum: 1
+            height:
+              type: integer
+              minimum: 1
+          required:
+            - width
+            - height
+        buttons:
+          type: array
+          items:
+            type: object
+            properties:
+              button:
+                description: Unique button identifier over all button groups.
+                type: string
+              icon:
+                $ref: '#/components/schemas/IconIdentifier'
+              name:
+                $ref: '#/components/schemas/LanguageText'
+              location:
+                $ref: '#/components/schemas/GridLocation'
+              size:
+                $ref: '#/components/schemas/GridItemSize'
+            required:
+              - button
+              - icon
+              - name
+              - location
+      required:
+        - type
+        - grid
+        - buttons
+    DeviceScreenLayout:
+      description: Screen layout definitions with usable grid sizes for custom UI pages.
+      type: object
+      properties:
+        grid:
+          type: object
+          properties:
+            default:
+              $ref: '#/components/schemas/DeviceButtonLayout/properties/grid'
+            min:
+              $ref: '#/components/schemas/DeviceButtonLayout/properties/grid'
+            max:
+              $ref: '#/components/schemas/DeviceButtonLayout/properties/grid'
+          required:
+            - default
+            - min
+            - max
+      required:
+        - grid
+    DeviceButtonMapping:
+      type: object
+      properties:
+        button:
+          $ref: '#/components/schemas/ButtonId'
+        short_press:
+          $ref: '#/components/schemas/EntityCommand'
+        long_press:
+          $ref: '#/components/schemas/EntityCommand'
+      required:
+        - button
+    DeviceButtonMappings:
+      description: |
+        Physical button mapping to entity commands. The `entity_id` in the EntityCommand object is a required
+        property for an activity and ignored for a remote-entity.
+      type: array
+      items:
+        $ref: '#/components/schemas/DeviceButtonMapping'
+    DeviceId:
+      type: string
+      format: '^[a-zA-Z0-9\-_]+$'
+      minLength: 1
+      maxLength: 36
+      description: Device identifier for multi-device integrations only.
+    DeviceState:
+      type: string
+      enum:
+        - UNKNOWN
+        - CONNECTING
+        - CONNECTED
+        - DISCONNECTED
+        - ERROR
+    DeviceType:
+      type: string
+      enum:
+        - audio
+        - radio
+        - cd_player
+        - receiver
+        - soundbar
+        - hdmi_switch
+        - television
+        - projector
+        - set_top_box
+        - media_player
+        - dvd_player
+        - bluray_player
+        - climate
+        - light
+        - various
+    DiscoveryType:
+      type: string
+      description: |
+        Device discovery type:
+        - `BT`: Bluetooth
+        - `NET`: LAN or WAN network
+      enum:
+        - BT
+        - NET
+    DockConfiguration:
+      type: object
+      properties:
+        dock_id:
+          $ref: '#/components/schemas/DockId'
+        name:
+          $ref: '#/components/schemas/DockName'
+        custom_ws_url:
+          $ref: '#/components/schemas/DockUrl'
+        resolved_ws_url:
+          type: string
+          maxLength: 64
+          description: Resolved WebSocket URL from the service name in `dock_id` if no `custom_ws_url` is used.
+        active:
+          type: boolean
+          description: |
+            Enable flag: active docks are automatically connected when network is available.
+        model:
+          type: string
+          description: Dock model number.
+        revision:
+          type: string
+          description: Dock revision.
+        serial:
+          type: string
+          description: Dock serial number.
+        led_brightness:
+          type: integer
+          minimum: 0
+          maximum: 100
+        eth_led_brightness:
+          type: integer
+          minimum: 0
+          maximum: 100
+        connection_type:
+          type: string
+          description: |
+            Network connection of the dock: `Ethernet` or `WiFi`.
+        version:
+          type: string
+          description: Firmware version
+        state:
+          $ref: '#/components/schemas/DockState'
+        learning_active:
+          type: boolean
+          description: Dock is in IR learning mode.
+        description:
+          $ref: '#/components/schemas/Description'
+      required:
+        - dock_id
+        - active
+    DockConfigurations:
+      type: array
+      items:
+        $ref: '#/components/schemas/DockConfiguration'
+    DockConfigurationRequest:
+      type: object
+      properties:
+        dock_id:
+          $ref: '#/components/schemas/DockId'
+        name:
+          $ref: '#/components/schemas/DockName'
+        custom_ws_url:
+          $ref: '#/components/schemas/DockUrl'
+        token:
+          $ref: '#/components/schemas/DockToken'
+        active:
+          type: boolean
+          description: |
+            Enable flag: active docks are automatically connected when network is available.
+        model:
+          type: string
+          description: Dock model number.
+        description:
+          $ref: '#/components/schemas/Description'
+      required:
+        - dock_id
+        - active
+    DockUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 40
+          description: User assignable friendly name to use instead of dock_id (service name).
+        custom_ws_url:
+          $ref: '#/components/schemas/DockUrl'
+        token:
+          type: string
+          maxLength: 40
+          description: Access token to connect to the dock.
+        active:
+          type: boolean
+          description: Auto connect to dock when network is available.
+        description:
+          type: string
+          description: Optional description.
+        wifi:
+          type: object
+          properties:
+            ssid:
+              description: Network name (Service Set IDentifier)
+              type: string
+              maxLength: 32
+            password:
+              type: string
+              maxLength: 63
+    DockDiscovery:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/DockId'
+        configured:
+          description: |
+            Dock configuration flag for this remote:
+            - true: device has already been configured
+            - false: device has not yet been configured
+          type: boolean
+        friendly_name:
+          $ref: '#/components/schemas/DockName'
+        address:
+          description: Resolved device network address.
+          type: string
+        model:
+          description: Detected dock model.
+          type: string
+        version:
+          description: Detected firmware version.
+          type: string
+        discovery_type:
+          $ref: '#/components/schemas/DiscoveryType'
+        timestamp:
+          description: Timestamp of dock discovery.
+          type: string
+          format: date-time
+        bt:
+          type: object
+          description: Optional Bluetooth discovery information. Not present for network device.
+          properties:
+            signal:
+              description: 'Bluetooth signal strength. 0 = min, 5 = max.'
+              type: integer
+              minimum: 0
+              maximum: 5
+            last_seen_sec:
+              description: |
+                Last time the device was seen on a Bluetooth scan. Values over 15 sec indicate that the device is no longer
+                reachable.
+              type: integer
+              format: int32
+      required:
+        - id
+        - configured
+        - discovery_type
+    DockDiscoveryStatus:
+      type: object
+      properties:
+        active:
+          description: |
+            Dock discovery still active or not.
+          type: boolean
+        docks:
+          type: array
+          items:
+            $ref: '#/components/schemas/DockDiscovery'
+      required:
+        - discovery_active
+        - docks
+    DockFirmwareUpdate:
+      type: object
+      description: Dock firmware information
+      properties:
+        model:
+          description: Dock model
+          type: string
+        description:
+          $ref: '#/components/schemas/LanguageText'
+        version:
+          type: string
+        channel:
+          $ref: '#/components/schemas/UpdateChannel'
+        release_date:
+          type: string
+          format: date
+        size:
+          type: integer
+          format: int64
+        release_notes_url:
+          type: string
+          format: uri
+        download:
+          $ref: '#/components/schemas/UpdateDownloadState'
+      required:
+        - model
+        - description
+        - version
+    DockId:
+      type: string
+      format: '^[a-zA-Z0-9\-\.]+$'
+      minLength: 1
+      maxLength: 64
+      description: Dock identifier
+    DockName:
+      type: string
+      minLength: 1
+      maxLength: 40
+      description: User assignable friendly name to use instead of dock_id (service name).
+    DockSystemInfo:
+      type: object
+      properties:
+        name:
+          type: string
+        hostname:
+          type: string
+        model:
+          type: string
+        revision:
+          type: string
+        version:
+          type: string
+        serial:
+          type: string
+        ir_learning:
+          type: boolean
+        ethernet:
+          type: boolean
+        wifi:
+          type: boolean
+        ssid:
+          description: Network name (Service Set IDentifier)
+          type: string
+    CreateDockSetup:
+      type: object
+      oneOf:
+        - type: object
+          properties:
+            discovery:
+              $ref: '#/components/schemas/DockSetupFromDiscovery'
+          required:
+            - discovery
+        - type: object
+          properties:
+            manually:
+              $ref: '#/components/schemas/DockSetup'
+          required:
+            - manual
+    DockSetup:
+      type: object
+      description: Dock setup data
+      properties:
+        name:
+          $ref: '#/components/schemas/DockName'
+        token:
+          $ref: '#/components/schemas/DockToken'
+        custom_ws_url:
+          $ref: '#/components/schemas/DockUrl'
+        description:
+          $ref: '#/components/schemas/Description'
+        wifi:
+          description: |
+            Optional WiFi information if the dock should connect to (or be prepared for) WiFi instead of Ethernet.
+          type: object
+          properties:
+            ssid:
+              description: Network name (Service Set IDentifier)
+              type: string
+            password:
+              type: string
+              format: password
+          required:
+            - ssid
+            - password
+      required:
+        - name
+    DockSetupFromDiscovery:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/DockId'
+        friendly_name:
+          $ref: '#/components/schemas/DockName'
+        address:
+          description: Resolved device network address.
+          type: string
+        model:
+          description: Detected dock model.
+          type: string
+        version:
+          description: Detected firmware version.
+          type: string
+        discovery_type:
+          $ref: '#/components/schemas/DiscoveryType'
+      required:
+        - id
+        - discovery_type
+    DockSetupError:
+      type: string
+      enum:
+        - NONE
+        - NOT_FOUND
+        - CONNECTION_ERROR
+        - CONNECTION_REFUSED
+        - AUTHORIZATION_ERROR
+        - TIMEOUT
+        - ABORT
+        - PERSISTENCE_ERROR
+        - OTHER
+    DockSetupInfo:
+      type: object
+      description: Dock setup state
+      properties:
+        id:
+          type: string
+        name:
+          $ref: '#/components/schemas/DockName'
+        discovery_type:
+          $ref: '#/components/schemas/DiscoveryType'
+        state:
+          $ref: '#/components/schemas/DockSetupState'
+        error:
+          $ref: '#/components/schemas/DockSetupError'
+      required:
+        - id
+        - state
+    DockSetupState:
+      type: string
+      enum:
+        - NEW
+        - CONFIGURING
+        - UPLOADING
+        - RESTARTING
+        - OK
+        - ERROR
+    DockState:
+      type: string
+      description: Dock connection state
+      enum:
+        - IDLE
+        - CONNECTING
+        - ACTIVE
+        - RECONNECTING
+        - ERROR
+    DockToken:
+      type: string
+      format: password
+      minLength: 1
+      maxLength: 40
+      description: Access token
+    DockUpdateCheck:
+      type: object
+      description: Dock firmware update check information.
+      properties:
+        dock_id:
+          type: string
+        version:
+          description: Installed firmware version.
+          type: string
+        update_available:
+          description: Whether or not an update is available. An available update is set in the `firmware_update` object.
+          type: boolean
+        update_check_enabled:
+          description: |
+            Whether or not the online update check is enabled or not. If disabled, `update_available` will always be false.
+          type: boolean
+        firmware_update:
+          $ref: '#/components/schemas/DockFirmwareUpdate'
+        update_id:
+          description: Update identifier if an update is currently in progress.
+          type: string
+      required:
+        - dock_id
+        - version
+        - update_available
+        - update_check_enabled
+    DockUpdateProgress:
+      type: object
+      description: Dock firmware update progress
+      properties:
+        dock_id:
+          type: string
+        update_id:
+          description: Update identifier
+          type: string
+        version:
+          description: Firmware version being installed
+          type: string
+        progress:
+          description: Update progress in percent
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 100
+        state:
+          $ref: '#/components/schemas/DockSetupState'
+        error:
+          $ref: '#/components/schemas/DockSetupError'
+      required:
+        - dock_id
+        - update_id
+        - version
+        - state
+    DockUrl:
+      type: string
+      maxLength: 64
+      description: Dock WebSocket URL to override auto-discovery from the service name in `dock_id`.
+    DriverDeveloper:
+      type: object
+      description: Optional information about the integration developer.
+      properties:
+        name:
+          description: Optional developer information to display in UI / web-configurator.
+          type: string
+          maxLength: 100
+        url:
+          description: Optional developer home page.
+          type: string
+          format: uri
+          maxLength: 255
+        email:
+          description: Optional developer contact email.
+          type: string
+          format: email
+          maxLength: 100
+    DriverId:
+      type: string
+      format: '^[a-zA-Z0-9\-_]+$'
+      minLength: 1
+      maxLength: 36
+      description: 'Unique integration driver identifier, e.g. `homeassistant`, `homey`, etc.'
+    DriverState:
+      type: string
+      enum:
+        - NOT_CONFIGURED
+        - IDLE
+        - CONNECTING
+        - ACTIVE
+        - RECONNECTING
+        - ERROR
+    Entities:
+      type: array
+      items:
+        $ref: '#/components/schemas/Entity'
+    Entity:
+      description: |
+        Configured entity in the remote to be used in one or more profiles.
+      type: object
+      properties:
+        entity_id:
+          $ref: '#/components/schemas/EntityId'
+        entity_type:
+          $ref: '#/components/schemas/EntityType'
+        integration_id:
+          $ref: '#/components/schemas/IntegrationId'
+        device_class:
+          description: |
+            Optional device type. This can be used by the UI to represent the entity with a different
+            icon, behaviour etc. See entity documentation for available device classes.
+          type: string
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        features:
+          description: |
+            Supported features of the entity. See entity documentation for available features.
+          type: array
+          items:
+            type: string
+        options:
+          description: |
+            Feature options. See entity documentation for available options.
+          type: object
+        description:
+          $ref: '#/components/schemas/LanguageText'
+        attributes:
+          description: |
+            Dynamic entity attributes set by the integration driver. These are key/value pairs, see [integration entity
+            documentation](https://github.com/unfoldedcircle/core-api/tree/main/doc/entities) for detailed information.
+          type: object
+      required:
+        - entity_id
+        - entity_type
+        - integration_id
+        - name
+    EntityId:
+      type: string
+      format: '^[a-zA-Z0-9\-_\.]+$'
+      minLength: 5
+      maxLength: 110
+      description: Unique UC Remote Two identifier over all entities and integrations.
+    EntityCommand:
+      description: |
+        Entity command object. The `entity_id` only has to be specified if it's not already included as a parameter in the URL.
+      type: object
+      properties:
+        entity_id:
+          $ref: '#/components/schemas/EntityId'
+        cmd_id:
+          description: |
+            Entity command identifier, as returned in the entity command metadata.
+
+            This identifier may change at any time and may not be used for logic decisions in a client!
+            If entity specific information is required, the entity object must be loaded from the `entity_id`.
+          type: string
+        params:
+          description: |
+            Optional command parameters as key / value pairs. See entity documentation for available parameters.
+          type: object
+      required:
+        - cmd_id
+      example:
+        entity_id: hass.main.light.living-room
+        cmd_id: light.on
+        params:
+          hue: 180
+          saturation: 90
+    EntityCmdParamBool:
+      type: object
+      description: Boolean value parameter.
+    EntityCmdParamNumber:
+      type: object
+      description: |
+        Number value parameter with optional limits.   
+      properties:
+        default:
+          description: 'Default value to use, e.g. in a UI editor.'
+        min:
+          description: Minimal allowed value (inclusive).
+          type: number
+          default: 0
+        max:
+          description: Maximal allowed value (inclusive).
+          type: number
+        step:
+          description: Step size between values.
+          type: number
+          default: 1
+        unit:
+          description: Optional unit label of the value.
+          type: string
+      example:
+        default: 22
+        min: 0
+        max: 100
+        step: 1
+        unit: '%'
+    EntityCmdParamRegex:
+      type: object
+      description: Text value parameter with optional regex validation.
+      properties:
+        regex:
+          description: Validation regex.
+          type: string
+    EntityCmdParamEnum:
+      type: object
+      description: Enumeration parameter. Only the defined values are allowed as parameter value.
+      properties:
+        values:
+          type: array
+          items:
+            type: string
+        default:
+          description: Default value for a new command. Must be a value defined in `values`
+          type: string
+      required:
+        - values
+      example:
+        values:
+          - Option 1
+          - Option 2
+          - Option 3
+        default: Option 1
+    EntityCmdParamSelection:
+      type: object
+      description: Text value parameter with a selection list from another entity field.
+      properties:
+        items:
+          description: Validation regex.
+          type: object
+          properties:
+            source:
+              description: Where to load the selection list from.
+              type: string
+              enum:
+                - attributes
+                - options
+            field:
+              description: |
+                Field name in the source object containing an array of strings for the parameter selection
+              type: string
+          required:
+            - source
+            - field
+      required:
+        - items
+      example:
+        items:
+          source: attributes
+          field: source_list
+    EntityCommandMetadata:
+      type: object
+      properties:
+        id:
+          description: |
+            Entity command identifier to be used in activity and macro commands (button mappings, UI elements and sequences).
+
+            This identifier may change at any time and may not be used for logic decisions in a client!
+            If entity specific information is required, the entity object must be used.
+          type: string
+        cmd_id:
+          description: |
+            Entity command as specified in the [entity documentation](https://github.com/unfoldedcircle/core-api/tree/main/doc/entities).
+            This is the command identifier being sent to integration drivers.
+          type: string
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        params:
+          description: |
+            Metadata describing the optional parameters of the command. Simple "button like" commands
+            don't have any parameters, whereas e.g. a light entity can also dim the light, change color or color
+            temperature.
+          type: array
+          items:
+            type: object
+            allOf:
+              - properties:
+                  name:
+                    $ref: '#/components/schemas/LanguageText'
+                  param:
+                    description: Parameter name.
+                    type: string
+                  type:
+                    description: Parameter type.
+                    type: string
+                    enum:
+                      - number
+                      - bool
+                      - regex
+                      - enum
+                required:
+                  - name
+                  - param
+                  - type
+              - oneOf:
+                  - $ref: '#/components/schemas/EntityCmdParamNumber'
+                  - $ref: '#/components/schemas/EntityCmdParamBool'
+                  - $ref: '#/components/schemas/EntityCmdParamRegex'
+                  - $ref: '#/components/schemas/EntityCmdParamEnum'
+                  - $ref: '#/components/schemas/EntityCmdParamSelection'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    number: '#/components/schemas/EntityCmdParamNumber'
+                    bool: '#/components/schemas/EntityCmdParamBool'
+                    regex: '#/components/schemas/EntityCmdParamRegex'
+                    enum: '#/components/schemas/EntityCmdParamEnum'
+                    selection: '#/components/schemas/EntityCmdParamSelection'
+      required:
+        - id
+        - cmd_id
+        - name
+    EntityUpdateRequest:
+      type: object
+      description: |
+        Update model for an entity.
+
+        - Specified properties will update the current values.
+        - An empty value will delete the currently set property.
+      properties:
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        description:
+          $ref: '#/components/schemas/LanguageText'
+    EntityDeleteRequest:
+      type: object
+      description: |
+        Delete request model for multiple entities. Either specify `integration_id` or `entity_ids`.
+      properties:
+        integration_id:
+          type: string
+        entity_ids:
+          type: array
+          items:
+            type: string
+    EntityType:
+      type: string
+      description: Entity type
+      enum:
+        - button
+        - climate
+        - cover
+        - light
+        - media_player
+        - sensor
+        - switch
+        - activity
+        - macro
+        - remote
+    ExternalSystems:
+      type: array
+      items:
+        $ref: '#/components/schemas/ExternalSystem'
+    ExternalSystem:
+      type: object
+      properties:
+        system:
+          $ref: '#/components/schemas/ExternalSystemId'
+        name:
+          $ref: '#/components/schemas/ExternalSystemName'
+    ExternalSystemId:
+      type: string
+      format: '^[a-zA-Z0-9\-_]+$'
+      minLength: 1
+      maxLength: 50
+      description: Unique external system identifier registered by an R2 integration to interact with the API.
+    ExternalSystemName:
+      type: string
+      minLength: 1
+      maxLength: 50
+      description: |
+        Friendly name of the external system to display to the user within the app. This name must be unique for an external
+        system and should be as short and concise as possible.
+        Use the description field for more information.
+    ExternalAccessTokens:
+      type: array
+      items:
+        type: object
+        properties:
+          system:
+            $ref: '#/components/schemas/ExternalSystemName'
+          token_id:
+            type: string
+          name:
+            type: string
+          description:
+            type: string
+            maxLength: 2048
+            description: Optional description of the external access token.
+          url:
+            type: string
+            maxLength: 2048
+            description: Optional URL of the external system.
+          data:
+            type: string
+            maxLength: 2048
+            description: Optional data from the external system for the R2 integration.
+          creation_date:
+            type: string
+            format: date-time
+    ExternalAccessToken:
+      type: object
+      properties:
+        system:
+          $ref: '#/components/schemas/ExternalSystemName'
+        token_id:
+          type: string
+        name:
+          type: string
+        token:
+          type: string
+          minLength: 1
+          maxLength: 2048
+          description: |
+            The token to access the external system with the corresponding R2 integration.
+            This could be a UUID, a JWT or any other representation required for the integration to authenticate on the
+            system.
+        description:
+          type: string
+          maxLength: 2048
+          description: Optional description of the external access token.
+        url:
+          type: string
+          maxLength: 2048
+          description: Optional URL of the external system.
+        data:
+          type: string
+          maxLength: 2048
+          description: Optional data from the external system for the R2 integration.
+        creation_date:
+          type: string
+          format: date-time
+    ExternalAccessTokenRequest:
+      type: object
+      properties:
+        token_id:
+          type: string
+          format: '^[a-zA-Z0-9\-_]+$'
+          minLength: 1
+          maxLength: 36
+          description: |
+            Unique token identifier, used for later token management through the external system or management ui.
+            This identifier can be provided by the external system. If omitted, an UUID is generated and returned in the
+            ExternalAccessToken response.
+        name:
+          $ref: '#/components/schemas/ExternalSystemName'
+        token:
+          type: string
+          minLength: 1
+          maxLength: 2048
+          description: |
+            The token to access the external system with the corresponding R2 integration.
+            This could be a UUID, a JWT or any other representation required for the integration to authenticate on the
+            system.
+        description:
+          type: string
+          maxLength: 2048
+          description: Optional description of the external access token.
+        url:
+          type: string
+          maxLength: 2048
+          description: Optional URL of the external system.
+        data:
+          type: string
+          maxLength: 2048
+          description: Optional data from the external system for the R2 integration.
+      required:
+        - name
+        - token
+      example:
+        token_id: 1-2-3
+        name: My smart home
+        token: secret-sauce-42!
+        description: Any other informative message about the external system
+        url: 'ws://smart.home'
+        data: 'optional: true, foo: bar, free: text'
+    FriendlyName:
+      type: string
+      maxLength: 64
+    GridItemSize:
+      description: 'Item size in the button grid. Default size if not specified: 1 x 1'
+      type: object
+      properties:
+        width:
+          type: integer
+          minimum: 1
+          default: 1
+        height:
+          type: integer
+          minimum: 1
+          default: 1
+    GridLocation:
+      description: Button placement in the grid with 0-based coordinates.
+      type: object
+      properties:
+        x:
+          type: integer
+          minimum: 0
+        'y':
+          type: integer
+          minimum: 0
+      required:
+        - x
+        - 'y'
+    Group:
+      type: object
+      description: |
+        The shown group switch in the UI is automatically determined by the capabilities of the group's entities.
+      properties:
+        group_id:
+          $ref: '#/components/schemas/SimpleId'
+        profile_id:
+          $ref: '#/components/schemas/SimpleId'
+        name:
+          $ref: '#/components/schemas/Name'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        entities:
+          type: array
+          description: Entity identifiers belonging to the group
+          items:
+            $ref: '#/components/schemas/EntityId'
+        description:
+          $ref: '#/components/schemas/Description'
+      required:
+        - group_id
+        - profile_id
+        - name
+        - entities
+    GroupUpdate:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/Name'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        entities:
+          type: array
+          description: |
+            Changed or re-ordered group entities.
+            An empty array remove all entities.
+            If the property is not specified the defined entities will not be changed.
+          items:
+            $ref: '#/components/schemas/EntityId'
+        description:
+          $ref: '#/components/schemas/Description'
+    Groups:
+      type: array
+      items:
+        $ref: '#/components/schemas/Group'
+    HealthStatus:
+      type: string
+      enum:
+        - Healthy
+        - Degraded
+        - Unhealthy
+    IconIdentifier:
+      type: string
+      format: '^[a-z0-9]+:[a-zA-Z0-9\-_\.]+$'
+      maxLength: 255
+      description: |
+        Optional icon identifier. The identifier consists of a prefix and a resource identifier, separated by `:`.  
+        Available prefixes:
+        - `uc:` - integrated icon font 
+        - `custom:` - custom resource
+
+        An empty identifier, while updating the object, removes the existing icon.
+    ImageIdentifier:
+      type: string
+      format: '^[a-z0-9]+:[a-zA-Z0-9\-_\.]+$'
+      maxLength: 255
+      description: |
+        Optional image identifier. The identifier consists of a prefix and a resource identifier, separated by `:`.  
+        Available prefixes:
+        - `custom:` - custom resource
+
+        An empty identifier, while updating the object, removes the existing image.
+    IncludedEntities:
+      description: |
+        Included entities in an activity or macro. This object is writable from the client and persisted when saving.
+
+        Notes:
+        - Entities can be included without being used in a sequence.  
+          This allows to edit the activity or macro in multiple sessions without having to reselect the desired entities.
+        - Every used entity in a sequence must be included, otherwise the activity or macro  cannot be saved.
+        - If the client removes an entity which is included in an activity or macro, it must make sure to also remove all
+          entity references the sequence(s), button mapping and user interface.
+      type: array
+      items:
+        $ref: '#/components/schemas/IncludedEntity'
+    IncludedEntity:
+      description: |
+        When saving an activity only the `entity_id` is persisted. When retrieving an activity all other fields
+        will be retrieved from the real entities to make sure they are up to date. I.e. the entity name or icon
+        might change between saving an activity and retrieving it again!
+      type: object
+      properties:
+        entity_id:
+          $ref: '#/components/schemas/EntityId'
+        entity_type:
+          $ref: '#/components/schemas/EntityType'
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        integration:
+          description: |
+            Optional integration information. Regular entities will have at least the integration name. Special
+            entities like activities and macros might omit the integration object.
+          type: object
+          properties:
+            name:
+              $ref: '#/components/schemas/LanguageText'
+            icon:
+              $ref: '#/components/schemas/IconIdentifier'
+        entity_commands:
+          description: |
+            Supported entity command identifiers. A command identifier refers to the common entity command
+            definitions, which describe all required parameters to set for calling the entity command. This
+            includes the mandatory `cmd_id` attribute and optional parameters.
+          type: array
+          items:
+            type: string
+        simple_commands:
+          description: |
+            Simple commands are additional commands supported by the entity, which are not included in the
+            common entity command definitions. A typical example are remote-entity commands like `VOLUME_UP` etc
+            which don't have additional parameters. A simple command relates directly to the `cmd_id` attribute
+            when calling a command.
+          type: array
+          items:
+            type: string
+        available:
+          description: |
+            State of the entity: True / missing = entity is available as configured entity and can be used.  
+            False = entity has been removed and must be corrected by the user.
+
+            If an entity is no longer available then all usages in the sequences are still present in case the
+            entity is re-configured. The execution of the on- or off-sequence will then simply skip the actions
+            of the no longer available entity.
+          type: boolean
+      required:
+        - entity_id
+    IntgAuthMethod:
+      type: string
+      description: |
+        Integration driver authentication method if a token is required.
+
+        The JSON `auth` message is used if a token is configured but no authentication method is set.
+      enum:
+        - HEADER
+        - MESSAGE
+    CreateIntegrationSetup:
+      type: object
+      properties:
+        driver_id:
+          $ref: '#/components/schemas/DriverId'
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        setup_data:
+          $ref: '#/components/schemas/SettingsValues'
+        reconfigure:
+          description: Reconfigure an already configured integration.
+          type: boolean
+      required:
+        - driver_id
+    IntegrationSetupError:
+      type: string
+      enum:
+        - NONE
+        - NOT_FOUND
+        - CONNECTION_REFUSED
+        - AUTHORIZATION_ERROR
+        - TIMEOUT
+        - OTHER
+    IntegrationSetupInfo:
+      type: object
+      description: Integration setup state
+      properties:
+        id:
+          type: string
+        state:
+          $ref: '#/components/schemas/IntegrationSetupState'
+        error:
+          $ref: '#/components/schemas/IntegrationSetupError'
+        require_user_action:
+          description: 'If set, the setup process waits for the specified user action.'
+          oneOf:
+            - type: object
+              properties:
+                input:
+                  $ref: '#/components/schemas/SettingsPage'
+              required:
+                - input
+            - type: object
+              properties:
+                confirmation:
+                  $ref: '#/components/schemas/ConfirmationPage'
+              required:
+                - confirmation
+      required:
+        - id
+        - state
+    IntegrationSetupState:
+      type: string
+      enum:
+        - SETUP
+        - WAIT_USER_ACTION
+        - OK
+        - ERROR
+    IntegrationDiscovery:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/DriverId'
+        configured:
+          description: |
+            Integration configuration flag:
+            - true: driver has already been configured
+            - false: driver has not yet been configured
+          type: boolean
+        name:
+          type: string
+        developer_name:
+          type: string
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        driver_url:
+          description: Resolved driver url.
+          type: string
+        pwd_protected:
+          description: Driver requires a connection password.
+          type: boolean
+        version:
+          description: Detected driver version.
+          type: string
+        timestamp:
+          description: Timestamp of integration discovery.
+          type: string
+          format: date-time
+      required:
+        - id
+        - configured
+        - name
+        - driver_url
+    IntegrationDiscoveryStatus:
+      type: object
+      properties:
+        active:
+          description: |
+            Integration discovery still active or not.
+          type: boolean
+        integrations:
+          type: array
+          items:
+            $ref: '#/components/schemas/IntegrationDiscovery'
+      required:
+        - discovery_active
+        - integrations
+    IntegrationDriver:
+      type: object
+      description: |
+        Integration driver model.
+
+        A driver represents the communication aspect of an integration. E.g. how one can connect to it
+        and which API version it supports.
+
+        One driver can provide multiple `Integration` instances. In the integration API they are
+        referred to as `multi-device integrations` and use the optional `device_id` property where
+        required. If a driver only provides a single instance, which is usually the default use case,
+        then the `device_id` is not used (or set to the default value `main`).
+      properties:
+        driver_id:
+          $ref: '#/components/schemas/DriverId'
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        driver_type:
+          $ref: '#/components/schemas/IntegrationDriverType'
+        driver_url:
+          description: WebSocket URL of the driver. Only optional for integration driver metadata.
+          type: string
+          format: uri
+          maxLength: 2048
+        token:
+          description: |
+            Optional driver authentication token.
+
+            Note: the token will not be returned to external clients!
+          type: string
+          maxLength: 2048
+        auth_method:
+          $ref: '#/components/schemas/IntgAuthMethod'
+        pwd_protected:
+          description: Driver requires a connection password.
+          type: boolean
+        version:
+          description: 'Driver version, [SemVer](https://semver.org/) preferred.'
+          type: string
+          maxLength: 20
+        min_core_api:
+          description: |
+            Optional version check: minimum required core API version in the remote.
+          type: string
+          maxLength: 20
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        enabled:
+          description: |
+            Enables or disables driver communication. For development use only!  
+            If disabled, all integration instances won't be activated, even if the instance is enabled.
+          type: boolean
+        description:
+          $ref: '#/components/schemas/LanguageText'
+        developer:
+          $ref: '#/components/schemas/DriverDeveloper'
+        home_page:
+          description: Optional home page url for more information.
+          type: string
+          format: uri
+          maxLength: 255
+        device_discovery:
+          description: Driver supports multi-device discovery. **Not yet supported**.
+          type: boolean
+        setup_data_schema:
+          $ref: '#/components/schemas/SettingsPage'
+        release_date:
+          description: Release date of the driver.
+          type: string
+          format: date
+        driver_state:
+          $ref: '#/components/schemas/DriverState'
+      required:
+        - driver_id
+        - name
+        - version
+    IntegrationDriverInfo:
+      type: object
+      description: |
+        Summary data of an integration driver intended for overview screens.
+      properties:
+        driver_id:
+          $ref: '#/components/schemas/DriverId'
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        developer_name:
+          type: string
+        driver_type:
+          $ref: '#/components/schemas/IntegrationDriverType'
+        driver_url:
+          description: WebSocket URL of external driver
+          type: string
+          format: uri
+          maxLength: 255
+        version:
+          type: string
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        enabled:
+          type: boolean
+        driver_state:
+          $ref: '#/components/schemas/DriverState'
+      required:
+        - driver_id
+        - name
+        - driver_type
+        - version
+        - enabled
+    IntegrationDrivers:
+      type: array
+      items:
+        $ref: '#/components/schemas/IntegrationDriverInfo'
+    IntegrationDriverRequest:
+      type: object
+      description: |
+        Integration driver creation model. 
+
+        - The only required property is `driver_url` to contact the driver and fetch all driver data.
+        - If the driver requires an access token, the `token` needs to be specified and optionally the authentication method
+          in `auth_method`.
+        - The `driver_id` identifier can be specified by the client, but it needs to be unique among
+          all drivers. If omitted, the driver identifier returned by the driver will be used.  
+          A manually assigned, short, human-readable identifier is recommended for better recognizability.
+      properties:
+        driver_id:
+          $ref: '#/components/schemas/DriverId'
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        driver_url:
+          description: WebSocket URL of the driver
+          type: string
+          format: uri
+          maxLength: 2048
+        token:
+          description: Optional driver authentication token.
+          type: string
+          maxLength: 2048
+        auth_method:
+          $ref: '#/components/schemas/IntgAuthMethod'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        enabled:
+          description: |
+            Enables or disables driver communication. For development use only!  
+            If disabled, all integration instances won't be activated, even if the instance is enabled.
+          type: boolean
+      required:
+        - driver_url
+    IntegrationDriverType:
+      type: string
+      enum:
+        - LOCAL
+        - EXTERNAL
+    IntegrationDriverUpdate:
+      type: object
+      description: |
+        Integration driver update model. This model corresponds to the `IntegrationDriverRequest` model except there are
+        no required properties to allow patch updates. 
+
+        - Specified properties will update the current values.
+        - An empty value will delete the currently set property.
+      properties:
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        driver_url:
+          description: WebSocket URL of the driver
+          type: string
+          format: uri
+          maxLength: 2048
+        token:
+          description: Optional driver authentication token.
+          type: string
+          maxLength: 2048
+        auth_method:
+          $ref: '#/components/schemas/IntgAuthMethod'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        enabled:
+          description: |
+            Enables or disables driver communication.  
+            If disabled, all integration instances won't be activated, even if the instance is enabled.
+          type: boolean
+    Integration:
+      type: object
+      description: |
+        Integration instance model.
+      properties:
+        integration_id:
+          $ref: '#/components/schemas/IntegrationId'
+        driver_id:
+          $ref: '#/components/schemas/DriverId'
+        device_id:
+          $ref: '#/components/schemas/DeviceId'
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        enabled:
+          description: Enable / disable flag. For development use only!
+          type: boolean
+        setup_data:
+          description: Instance configuration object
+          type: object
+        device_state:
+          $ref: '#/components/schemas/DeviceState'
+      required:
+        - integration_id
+        - driver_id
+        - name
+        - enabled
+    IntegrationId:
+      type: string
+      format: '^[a-zA-Z0-9\-_\.]+$'
+      minLength: 1
+      maxLength: 73
+      description: |
+        Unique integration instance identifier. Automatically created by the system when creating a new instance from a driver.
+    Integrations:
+      type: array
+      items:
+        $ref: '#/components/schemas/Integration'
+    IntegrationUpdate:
+      type: object
+      description: |
+        Integration instance update model. This model corresponds to the `Integration` model except there are no required
+        properties to allow patch updates. 
+
+        - Specified properties will update the current values.
+        - An empty value will delete a set property.
+        - `device_id` is only required for multi-device integrations.
+      properties:
+        device_id:
+          $ref: '#/components/schemas/DeviceId'
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        enabled:
+          description: Enable / disable flag. For development use only!
+          type: boolean
+        setup_data:
+          description: Instance configuration object.
+          type: object
+    IntegrationState:
+      type: string
+      enum:
+        - NOT_CONFIGURED
+        - UNKNOWN
+        - IDLE
+        - CONNECTING
+        - CONNECTED
+        - DISCONNECTED
+        - RECONNECTING
+        - ACTIVE
+        - ERROR
+    IntegrationStatus:
+      type: object
+      description: |
+        Integration status information. Intended to be used in a general overview of the integration drivers and instances.
+      properties:
+        driver_id:
+          $ref: '#/components/schemas/DriverId'
+        integration_id:
+          $ref: '#/components/schemas/IntegrationId'
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        driver_type:
+          $ref: '#/components/schemas/IntegrationDriverType'
+        state:
+          $ref: '#/components/schemas/IntegrationState'
+      required:
+        - name
+        - driver_type
+    CodeSet:
+      type: object
+      properties:
+        manufacturer_id:
+          type: string
+        manufacturer:
+          type: string
+        device_id:
+          type: string
+        device:
+          type: string
+        device_type:
+          type: string
+        codes:
+          type: array
+          items:
+            $ref: '#/components/schemas/IrCode'
+      required:
+        - manufacturer
+        - manufacturer_id
+        - device_id
+        - device
+        - device_type
+        - codes
+    CodeSetCreate:
+      type: object
+      properties:
+        manufacturer:
+          description: |
+            Optional manufacturer name. If not specified: the codeset will be linked to the custom manufacturer entry
+            for self learned codes.
+          type: string
+          minLength: 1
+          maxLength: 100
+        device:
+          type: string
+          minLength: 1
+          maxLength: 100
+        device_type:
+          $ref: '#/components/schemas/DeviceType'
+        code_format:
+          $ref: '#/components/schemas/IrCodeFormat'
+        codes:
+          type: array
+          items:
+            $ref: '#/components/schemas/IrCodeCreate'
+      required:
+        - device
+        - device_type
+    CodeSetInfo:
+      type: object
+      properties:
+        manufacturer_id:
+          type: string
+        manufacturer:
+          type: string
+        device_id:
+          type: string
+        device:
+          type: string
+        device_type:
+          type: string
+      required:
+        - manufacturer_id
+        - manufacturer
+        - device_id
+        - device
+        - device_type
+    CodeSetUpdate:
+      type: object
+      properties:
+        device:
+          type: string
+          minLength: 1
+          maxLength: 100
+        device_type:
+          $ref: '#/components/schemas/DeviceType'
+    CodeSetUploadResult:
+      type: object
+      properties:
+        processed:
+          type: integer
+        added:
+          type: integer
+        updated:
+          type: integer
+    IrCode:
+      type: object
+      properties:
+        key:
+          type: string
+        format:
+          $ref: '#/components/schemas/IrCodeFormat'
+        value:
+          type: string
+      required:
+        - key
+        - format
+        - value
+    IrCodeCreate:
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/IrCodeKey'
+        value:
+          $ref: '#/components/schemas/IrCodeValue'
+      required:
+        - key
+        - value
+    IrCodeFormat:
+      description: |
+        Supported IR code formats:
+        - `HEX`: Unfolded Circle HEX codes, `<protocol>;<hex-ir-code>;<bits>;<repeat-count>` (based on
+          [IRremoteESP8266 Hex](https://github.com/unfoldedcircle/IRremoteESP8266) format).
+          - protocol: numeric value from supported and enabled protocols. See: [decode_type_t](https://github.com/unfoldedcircle/IRremoteESP8266/blob/v2.8.5-ucd2.2/src/IRremoteESP8266.h#L1011)
+          - hex-ir-code: HEX value prefixed with `0x`
+          - bits: number of bits in hex value
+          - repeat-count: number of repeats
+        - `PRONTO`: PRONTO hex codes
+          - Only raw codes are supported. First number must be `0000`.
+      type: string
+      enum:
+        - HEX
+        - PRONTO
+    IrCodeKey:
+      description: IR command key identifier
+      type: string
+      format: '^[a-zA-Z0-9\-_\.:+#*°@%/()?]{1,50}$'
+    IrCodeSetType:
+      description: 'Type of codeset, either a manufacturer codeset or a custom codeset.'
+      type: string
+      enum:
+        - manufacturer
+        - custom
+    IrCodeUpdate:
+      type: object
+      properties:
+        format:
+          $ref: '#/components/schemas/IrCodeFormat'
+        value:
+          $ref: '#/components/schemas/IrCodeValue'
+      required:
+        - format
+        - value
+    IrCodeValue:
+      description: |
+        IR code value, either in HEX or PRONTO format as defined in the format field.
+
+        - Multiple IR codes in a sequence can be specified with a plus character `+` as divider.
+          - For example: `3;0x20F0A956;32;0 + 3;0x20F02956;32;0`
+          - This works for HEX and PRONTO
+        - PRONTO only: 2 toggling codes can be specified with a pipe character `|` as divider.
+          - Only two codes toggling codes are valid. 
+          - For example: `0000 0068 0001 0000 0002 0800 | 0000 0068 0001 0000 8002 0800`
+        - ⚠️ Sequence and toggle divider cannot be mixed.
+      type: string
+      format: '^(?:(?:\d{1,3};0x[a-fA-F0-9]{1,16};\d{1,2};\d{1,2}(?:\s*\+\s*\d{1,3};0x[a-fA-F0-9]{1,16};\d{1,2};\d{1,2})*)|(?:0000(?:[, ][a-fA-F0-9]{4}){5,}(?:(?:\s*\+\s*0000(?:[, ][a-fA-F0-9]{4}){5,})*|\s*\|\s*0000(?:[, ][a-fA-F0-9]{4}){5,})))$'
+    IrRawCode:
+      type: object
+      properties:
+        raw:
+          type: array
+          items:
+            type: integer
+            minimum: 0
+        frequency:
+          type: integer
+          minimum: 0
+        duty_cycle:
+          type: integer
+          minimum: 0
+          maximum: 100
+      required:
+        - raw
+        - frequency
+    IrEmitter:
+      type: object
+      properties:
+        device_id:
+          description: IR emitter device identifier.
+          type: string
+        type:
+          $ref: '#/components/schemas/IrEmitterType'
+        name:
+          description: Friendly name of the IR emitter device.
+          type: string
+        active:
+          description: Emitter device is active or currently not available.
+          type: boolean
+        capabilities:
+          description: Optional capabilities of the emitter.
+          type: object
+          properties:
+            learning:
+              $ref: '#/components/schemas/IrEmitterLearningCapability'
+        ports:
+          description: |
+            Available output ports of the emitter. A simple emitter might only have one IR output, whereas the Remote Two dock
+            has 4 individual outputs.
+          type: array
+          items:
+            type: object
+            properties:
+              port_id:
+                description: IR emitter output port identifier.
+                type: string
+              name:
+                description: Friendly name of the output port.
+                type: string
+            required:
+              - port_id
+              - name
+      required:
+        - device_id
+        - type
+        - name
+        - active
+        - ports
+    IrEmitterLearnStatus:
+      type: object
+      properties:
+        device_id:
+          description: IR emitter device identifier.
+          type: string
+        learning_active:
+          description: |
+            Device is in IR learning mode. Usually an emitter can't send IR commands while it is in learning mode.
+          type: boolean
+        codes:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearnedIrCode'
+      required:
+        - device_id
+        - learning_active
+        - codes
+    IrEmitterLearningCapability:
+      type: object
+      description: Emitter can also be used for learning IR codes.
+      properties:
+        description:
+          type: string
+        instruction:
+          type: string
+        formats:
+          type: array
+          items:
+            type: string
+        send_while_learn:
+          description: Emitter is able to send IR codes while in learn mode.
+          type: boolean
+          default: false
+      required:
+        - formats
+    IrEmitters:
+      type: array
+      items:
+        $ref: '#/components/schemas/IrEmitter'
+    IrEmitterType:
+      type: string
+      description: |
+        The type of the IR emitter device:
+        - `DOCK`: a Remote Two docking station
+        - `INTERNAL`: internal IR
+        - `IR_BLASTER`: a network based IR blaster
+        - `OTHER`: something else
+      enum:
+        - DOCK
+        - INTERNAL
+        - IR_BLASTER
+        - OTHER
+    IrStatus:
+      type: object
+      properties:
+        dock_id:
+          $ref: '#/components/schemas/DockId'
+        learning_active:
+          description: Dock is in IR learning mode
+          type: boolean
+        state:
+          $ref: '#/components/schemas/DockState'
+        codes:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearnedIrCode'
+    LanguageCode:
+      description: |
+        Language culture code: starting with the two-letter [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+        code, followed by an optional [ISO-3166 country code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes),
+        separated by an underscore.
+        Examples: `en`, `en_UK`, `en_US`, `de`, `de_DE`, `de_CH` etc.
+      type: string
+      pattern: '^[a-z]{2}(_\w+)?$'
+    LanguageText:
+      type: object
+      description: |
+        Key value pairs of language texts. Key: ISO 639-1 code with optional country suffix to represent a `culture code`.
+        Examples: `en`, `en_UK`, `en_US`, `de`, `de_CH`.
+
+        If we need to support more regional differences within a country, then the
+        [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag) might be a solution. This would even
+        support the various Swiss German dialects!
+      additionalProperties:
+        type: string
+    LearnedIrCode:
+      type: object
+      properties:
+        code:
+          type: string
+        format:
+          $ref: '#/components/schemas/IrCodeFormat'
+        timestamp:
+          type: string
+          format: date-time
+    LoginRequest:
+      type: object
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+      required:
+        - username
+        - password
+      example:
+        username: admin
+        password: '1234'
+    Macro:
+      description: |
+        The macro entity executes a sequence of commands.
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Entity'
+        - properties:
+            entity_type:
+              type: string
+              enum:
+                - macro
+            features:
+              description: |
+                Supported features of the macro.
+              type: array
+              items:
+                type: string
+                enum:
+                  - start
+            options:
+              type: object
+              properties:
+                editable:
+                  description: |
+                    - `true` / property missing: macro was created by Remote Two and can be edited.
+                    - `false`: macro was provided by an integration and cannot be edited.
+                  type: boolean
+                  default: true
+                included_entities:
+                  $ref: '#/components/schemas/IncludedEntities'
+                sequence:
+                  $ref: '#/components/schemas/CommandSequence'
+          required:
+            - options
+    Macros:
+      type: array
+      items:
+        $ref: '#/components/schemas/MacroOverview'
+    MacroCreate:
+      description: |
+        Dedicated request object to create a new macro.  
+      type: object
+      allOf:
+        - properties:
+            name:
+              $ref: '#/components/schemas/LanguageText'
+            icon:
+              $ref: '#/components/schemas/IconIdentifier'
+            description:
+              $ref: '#/components/schemas/LanguageText'
+        - oneOf:
+            - type: object
+              properties:
+                clone_from:
+                  $ref: '#/components/schemas/EntityId'
+              required:
+                - clone_from
+            - type: object
+              properties:
+                options:
+                  type: object
+                  properties:
+                    entity_ids:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/EntityId'
+                  required:
+                    - entity_ids
+      required:
+        - name
+    MacroOverview:
+      description: |
+        The macro entity executes a sequence of commands.
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Entity'
+        - properties:
+            entity_type:
+              type: string
+              enum:
+                - macro
+            features:
+              description: |
+                Supported features of the macro.
+              type: array
+              items:
+                type: string
+                enum:
+                  - start
+            options:
+              type: object
+              properties:
+                editable:
+                  description: |
+                    - `true` / property missing: macro was created by Remote Two and can be edited.
+                    - `false`: macro was provided by an integration and cannot be edited.
+                  type: boolean
+                  default: true
+    MacroUpdate:
+      description: |
+        Dedicated request object to update an existing macro.  
+        All root properties are optional and only the provided objects are updated in the macro. Omitted objects are
+        ignored and not deleted from the macro.
+
+        The `entity_ids` object must be managed by the client and is persisted when updating a macro.
+
+        Notes:
+        - Entities can be included in `entity_ids` without being used in `sequence`.  
+          This allows to edit the macro in multiple sessions without having to reselect the desired entities.
+        - Every referenced entity in `sequence` must be included in `entity_ids`, otherwise the macro cannot be saved.
+        - If the client removes a configured entity from the system which is included in a macro, it must make sure to also
+          remove all references in the macro. See `available` property in the included entities object when retrieving a macro.
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        description:
+          $ref: '#/components/schemas/LanguageText'
+        options:
+          type: object
+          properties:
+            entity_ids:
+              type: array
+              items:
+                $ref: '#/components/schemas/EntityId'
+            sequence:
+              $ref: '#/components/schemas/CommandSequence'
+    MeasurementUnit:
+      type: string
+      enum:
+        - METRIC
+        - US
+        - UK
+    Name:
+      type: string
+      minLength: 1
+      maxLength: 50
+    Page:
+      type: object
+      properties:
+        page_id:
+          $ref: '#/components/schemas/SimpleId'
+        profile_id:
+          $ref: '#/components/schemas/SimpleId'
+        name:
+          $ref: '#/components/schemas/Name'
+        image:
+          type: string
+          description: Optional image identifier
+        items:
+          type: array
+          description: Page items
+          items:
+            $ref: '#/components/schemas/PageItem'
+        pos:
+          type: integer
+          format: int32
+          minimum: 0
+          description: Position of the page within the profile
+      required:
+        - page_id
+        - profile_id
+        - name
+        - items
+        - pos
+    PageCreate:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/Name'
+        image:
+          $ref: '#/components/schemas/ImageIdentifier'
+        items:
+          type: array
+          description: |
+            Optional page items.
+          items:
+            $ref: '#/components/schemas/PageItem'
+        pos:
+          type: integer
+          format: int32
+          minimum: 1
+          description: |
+            Optional 1-based position of the page within the profile. Default: last position
+      required:
+        - name
+    PageItem:
+      type: object
+      properties:
+        entity_id:
+          $ref: '#/components/schemas/EntityId'
+        group_id:
+          $ref: '#/components/schemas/SimpleId'
+        pos:
+          type: integer
+          format: int32
+          minimum: 0
+          description: |
+            Position of the item within the page. Returned on retrieval, ignored for page updates where the position is taken
+            from the page array position.
+      oneOf:
+        - required:
+            - entity_id
+        - required:
+            - group_id
+    PageUpdate:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/Name'
+        image:
+          $ref: '#/components/schemas/ImageIdentifier'
+        items:
+          type: array
+          description: |
+            Changed or re-ordered page items.
+            An empty array removes all items.
+            If the property is not specified the defined items will not be changed.
+          items:
+            $ref: '#/components/schemas/PageItem'
+    Pages:
+      type: array
+      items:
+        $ref: '#/components/schemas/Page'
+    PowerMode:
+      type: string
+      enum:
+        - NORMAL
+        - IDLE
+        - LOW_POWER
+        - SUSPEND
+    PowerModeResponse:
+      type: object
+      properties:
+        mode:
+          $ref: '#/components/schemas/PowerMode'
+      required:
+        - mode
+    Profile:
+      type: object
+      properties:
+        profile_id:
+          $ref: '#/components/schemas/SimpleId'
+        name:
+          $ref: '#/components/schemas/Name'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        restricted:
+          description: A restricted profile cannot change settings and switching profiles requires the admin PIN.
+          type: boolean
+        description:
+          $ref: '#/components/schemas/Description'
+      required:
+        - profile_id
+        - name
+        - restricted
+    ProfileRequest:
+      type: object
+      properties:
+        profile_id:
+          $ref: '#/components/schemas/SimpleId'
+        name:
+          $ref: '#/components/schemas/Name'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        restricted:
+          description: Create a restricted profile which cannot change settings. Switching profiles requires the admin pin.
+          type: boolean
+        description:
+          $ref: '#/components/schemas/Description'
+      required:
+        - name
+    ProfileUpdate:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/Name'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        restricted:
+          description: A restricted profile cannot change settings. Switching profiles requires the admin pin.
+          type: boolean
+        description:
+          $ref: '#/components/schemas/Description'
+        pages:
+          description: |
+            Used for update only: modify page order or delete pages in profile.
+            - An empty `pages` array will delete all pages and containing groups!
+            - If the property is missing, the existing page configuration will not be changed.
+          type: array
+          items:
+            $ref: '#/components/schemas/SimpleId'
+    Profiles:
+      type: array
+      items:
+        $ref: '#/components/schemas/Profile'
+    Remote:
+      description: |
+        The remote entity executes a sequence of commands and at the end displays a user interface (similar to remote entity)
+        to the user. If the entity has an off sequence, it can be turned off.
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Entity'
+        - properties:
+            entity_type:
+              type: string
+              enum:
+                - remote
+            features:
+              description: |
+                Supported features of the remote. If the remote has an `off` sequence, it supports the common `on_off`
+                feature, otherwise only `start`.
+              type: array
+              items:
+                type: string
+                enum:
+                  - on_off
+                  - send
+            options:
+              type: object
+              properties:
+                editable:
+                  description: |
+                    - `true` / property missing: remote was created by Remote Two and can be edited.
+                    - `false`: remote was provided by an integration and cannot be edited.
+                  type: boolean
+                  default: true
+                ir:
+                  description: |
+                    Infrared settings: codeset name und used infrared emitter to send commands.
+                  type: object
+                  properties:
+                    cmd_delay:
+                      description: |
+                        Delay in milliseconds between sending IR commands, if a command contains multiple IR codes.
+                      type: integer
+                      minimum: 0
+                    repeat:
+                      description: |
+                        Repeat each IR command in the dataset n times. Defaults to 0 (no repeat) if not specified.  
+                        This setting is intended mainly for PRONTO codes with certain devices requiring the same command being
+                        sent twice (e.g. Sony and Epson devices).
+                      type: integer
+                      minimum: 0
+                      maximum: 20
+                    codeset:
+                      description: "Read-only information about the infrared codeset. \U0001F477 **TODO** Use `/remotes/entities/:entityId/ir`\nendpoints to manage infrared codes.\n"
+                      type: object
+                      properties:
+                        id:
+                          description: |
+                            Codeset identifier, either a custom codeset id or a manufacturer codeset id depending on `type`.
+                          type: string
+                        name:
+                          description: |
+                            User friendly name of the used codeset (custom or manufacturer) to show in a user interface.
+                          type: string
+                        type:
+                          $ref: '#/components/schemas/IrCodeSetType'
+                    output:
+                      description: |
+                        Infrared output device settings. Use `/ir/emitter` endpoints to retrieve further information.
+                      type: object
+                      properties:
+                        device_id:
+                          description: |
+                            IR emitter device identifier.
+                          type: string
+                        port_id:
+                          description: |
+                            IR emitter output port identifier.
+                          type: string
+                simple_commands:
+                  description: |
+                    All available commands of the infrared codeset for the button mapping and user interface.  
+                    These simple commands relate directly to the `cmd_id` attribute when defining or calling an entity command.
+
+                    The commands are read-only and updated automatically based on the infrared codeset.
+                  type: array
+                  items:
+                    type: string
+                button_mapping:
+                  $ref: '#/components/schemas/DeviceButtonMappings'
+                user_interface:
+                  $ref: '#/components/schemas/ActivityUserInterface'
+          required:
+            - options
+    Remotes:
+      type: array
+      items:
+        $ref: '#/components/schemas/RemoteOverview'
+    RemoteCreate:
+      description: |
+        Dedicated request object to create a new remote.
+      type: object
+      allOf:
+        - properties:
+            name:
+              $ref: '#/components/schemas/LanguageText'
+            icon:
+              $ref: '#/components/schemas/IconIdentifier'
+            description:
+              $ref: '#/components/schemas/LanguageText'
+        - oneOf:
+            - type: object
+              properties:
+                clone_from:
+                  $ref: '#/components/schemas/EntityId'
+              required:
+                - clone_from
+            - type: object
+              properties:
+                codeset_id:
+                  $ref: '#/components/schemas/SimpleId'
+              required:
+                - codeset_id
+            - type: object
+              properties:
+                custom_codeset:
+                  type: object
+                  properties:
+                    manufacturer_id:
+                      type: string
+                      default: custom
+                    device_name:
+                      type: string
+                    device_type:
+                      $ref: '#/components/schemas/DeviceType'
+                  required:
+                    - device_name
+              required:
+                - custom_codeset
+      required:
+        - name
+    RemoteOverview:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Entity'
+        - properties:
+            entity_type:
+              type: string
+              enum:
+                - remote
+            features:
+              description: |
+                Supported features of the remote.
+              type: array
+              items:
+                type: string
+                enum:
+                  - send
+            options:
+              type: object
+              properties:
+                editable:
+                  description: |
+                    - `true` / property missing: remote was created by Remote Two and can be edited.
+                    - `false`: remote was provided by an integration and cannot be edited.
+                  type: boolean
+                  default: true
+    RemoteUpdate:
+      description: |
+        Dedicated request object to update an existing remote.  
+        All root properties are optional and only the provided objects are updated in the remote-entity. Omitted objects are
+        ignored and not deleted from the remote-entity.
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        description:
+          $ref: '#/components/schemas/LanguageText'
+        options:
+          type: object
+          properties:
+            ir:
+              type: object
+              properties:
+                cmd_delay:
+                  description: |
+                    Delay in milliseconds between sending IR commands, if a command contains multiple IR codes.
+                  type: integer
+                  minimum: 0
+                repeat:
+                  description: |
+                    Repeat each IR command in the dataset n times. Defaults to 0 (no repeat) if not specified.  
+                    This setting is intended mainly for PRONTO codes with certain devices requiring the same command being
+                    sent twice (e.g. Sony and Epson devices).
+                  type: integer
+                  minimum: 0
+                  maximum: 20
+                codeset:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                  required:
+                    - id
+                output:
+                  type: object
+                  properties:
+                    device_id:
+                      type: string
+                    port_id:
+                      type: string
+                  required:
+                    - device_id
+                    - port_id
+    RemoteIrDataSet:
+      type: object
+      properties:
+        id:
+          description: |
+            Codeset identifier, either a custom codeset id or a manufacturer codeset id depending on `type`.
+          type: string
+        name:
+          description: User friendly name of the codeset (custom or manufacturer).
+          type: string
+        type:
+          $ref: '#/components/schemas/IrCodeSetType'
+        codes:
+          type: array
+          items:
+            $ref: '#/components/schemas/RemoteIrCode'
+    RemoteIrCode:
+      type: object
+      properties:
+        cmd_id:
+          $ref: '#/components/schemas/SimpleId'
+        code:
+          description: |
+            Custom infrared code. Only set for custom codeset or if a manufacturer codeset has been modified or enhanced.
+          type: object
+          properties:
+            value:
+              type: string
+            format:
+              $ref: '#/components/schemas/IrCodeFormat'
+        custom:
+          description: |
+            Flag indicating if this code is a custom code in a manufacturer codeset. This is a manually added code which
+            was not present in the codeset. Custom codes can be deleted or edited by the user. The modified code is
+            stored in the `code` object.
+          type: boolean
+        modified:
+          description: |
+            Flag indicating if a manufacturer code has been replaced with a user code. The modified code is stored in
+            the `code` object. Modified codes can be edited by the user.
+          type: boolean
+      required:
+        - cmd_id
+    ResourceType:
+      type: string
+      format: '^[a-zA-Z]+$'
+      minLength: 1
+      maxLength: 32
+    ResourceItems:
+      type: array
+      items:
+        $ref: '#/components/schemas/ResourceItem'
+    ResourceItem:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ResourceType'
+        id:
+          type: string
+          description: Resource identifier (normalized filename)
+        size:
+          type: integer
+          format: int32
+          description: Size in bytes
+    ConfirmationPage:
+      description: |
+        Confirmation screen.
+        - `message1`: Message to display between title and image (if supplied). Supports Markdown formatting.
+        - `message2`: Message to display below message1 or image (if supplied). Supports Markdown formatting.
+      type: object
+      properties:
+        title:
+          $ref: '#/components/schemas/LanguageText'
+        message1:
+          $ref: '#/components/schemas/LanguageText'
+        image:
+          description: |
+            Optional base64-encoded image.
+
+            TODO maximum encoded length to avoid WebSocket continuation frames, supported image formats
+            (png & svg?), max height & width
+          type: string
+          format: byte
+          maxLength: 32768
+        message2:
+          $ref: '#/components/schemas/LanguageText'
+      required:
+        - title
+    SettingsPage:
+      description: 'Settings definition page, e.g. to configure an integration driver.'
+      type: object
+      properties:
+        title:
+          $ref: '#/components/schemas/LanguageText'
+        settings:
+          description: 'One or multiple input field definitions, with optional pre-set values.'
+          type: array
+          items:
+            $ref: '#/components/schemas/Setting'
+      required:
+        - title
+        - settings
+    Setting:
+      description: |
+        An input setting is of a specific type defined in `field.type` which defines how it is presented to the user.
+
+        Inspired by the [Homey SDK settings](https://apps.developer.homey.app/the-basics/devices/settings) concept.
+      type: object
+      properties:
+        id:
+          description: Unique identifier of the setting to be returned with the entered value.
+          type: string
+          maximum: 50
+        label:
+          $ref: '#/components/schemas/LanguageText'
+        field:
+          oneOf:
+            - $ref: '#/components/schemas/SettingTypeNumber'
+            - $ref: '#/components/schemas/SettingTypeText'
+            - $ref: '#/components/schemas/SettingTypeTextArea'
+            - $ref: '#/components/schemas/SettingTypePassword'
+            - $ref: '#/components/schemas/SettingTypeCheckbox'
+            - $ref: '#/components/schemas/SettingTypeDropdown'
+            - $ref: '#/components/schemas/SettingTypeLabel'
+      required:
+        - id
+        - label
+        - field
+    SettingTypeNumber:
+      description: |
+        Number input with optional `min`, `max`, `steps` and `decimals` properties. The default value must be specified
+        in `value`. An optional unit of the number setting can be specified in `unit`, which will be displayed next to
+        the input field.
+      type: object
+      properties:
+        number:
+          type: object
+          properties:
+            value:
+              description: Default value for input field.
+              type: number
+            min:
+              description: 'Optional validation: minimum allowed value (inclusive).'
+              type: number
+            max:
+              description: 'Optional validation: maximum allowed value (inclusive).'
+              type: number
+            steps:
+              description: |
+                Optional validation: allowed step increment between values. Might also be used in the UI for input helpers.
+              type: number
+            decimals:
+              description: Number of decimal places. 0 = integer value
+              type: integer
+              minimum: 0
+              default: 0
+            unit:
+              $ref: '#/components/schemas/LanguageText'
+          required:
+            - value
+      required:
+        - number
+    SettingTypeText:
+      description: |
+        Single line of text input.
+
+        TODO: format specifier for e.g. email, url, date, datetime etc.?
+      type: object
+      properties:
+        text:
+          type: object
+          properties:
+            value:
+              description: Optional default value.
+              type: string
+            regex:
+              description: Optional regex validation pattern for the input value.
+              type: string
+      required:
+        - text
+    SettingTypeTextArea:
+      description: 'Multi-line text input, e.g. for providing a description.'
+      type: object
+      properties:
+        textarea:
+          type: object
+          properties:
+            value:
+              description: Optional default value.
+              type: string
+      required:
+        - textarea
+    SettingTypePassword:
+      description: |
+        Password or pin entry field with the input text hidden from the user. Otherwise the same as text input.
+      type: object
+      properties:
+        password:
+          type: object
+          properties:
+            value:
+              description: Optional default value.
+              type: string
+              format: password
+            regex:
+              description: Optional regex validation pattern for the input value.
+              type: string
+      required:
+        - password
+    SettingTypeCheckbox:
+      description: Checkbox setting with `true` / `false` values.
+      type: object
+      properties:
+        checkbox:
+          type: object
+          properties:
+            value:
+              description: Initial setting.
+              type: boolean
+          required:
+            - value
+      required:
+        - checkbox
+    SettingTypeDropdown:
+      description: Dropdown setting to pick a single value from a list. All values must be strings.
+      type: object
+      properties:
+        dropdown:
+          type: object
+          properties:
+            value:
+              description: Pre-selected dropdown id
+              type: string
+            items:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    description: Selection identifier.
+                    type: string
+                  label:
+                    $ref: '#/components/schemas/LanguageText'
+                required:
+                  - id
+                  - label
+          required:
+            - items
+      required:
+        - dropdown
+    SettingTypeLabel:
+      description: |
+        Additional read-only text for information purpose between other settings. Supports Markdown formatting.
+      type: object
+      properties:
+        label:
+          type: object
+          properties:
+            value:
+              $ref: '#/components/schemas/LanguageText'
+          required:
+            - value
+      required:
+        - label
+    SettingsValues:
+      description: |
+        User input result of a SettingsPage as key values.
+        - key: id of the field
+        - value: entered user value as string. This is either the entered text or number, selected checkbox state or the
+          selected dropdown item id.  
+          ⚠️ Non native string values as numbers or booleans are represented as string values!
+      type: object
+      additionalProperties:
+        type: string
+    Scopes:
+      type: array
+      items:
+        $ref: '#/components/schemas/Scope'
+    Scope:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/ScopeName'
+        description:
+          type: string
+          description: Permission scope description
+      required:
+        - name
+    ScopeName:
+      type: string
+      format: '^[a-zA-Z\-:]+$'
+      minLength: 1
+      maxLength: 36
+      description: Permission scope name
+    SimpleId:
+      type: string
+      format: '^[a-zA-Z0-9\-_\.]+$'
+      minLength: 1
+      maxLength: 36
+      description: 'Simple string identifier, also usable as URL parameter or file identifier'
+    SupportedResource:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ResourceType'
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        description:
+          $ref: '#/components/schemas/LanguageText'
+        file_formats:
+          description: 'Allowed file format extensions, e.g. `png`.'
+          type: array
+          items:
+            type: string
+        max_file_size:
+          description: Maximum file size in bytes.
+          type: integer
+        max_count:
+          description: Maximum number of custom resources.
+          type: integer
+        image:
+          description: Image specific restrictions. Only set for image resources.
+          type: object
+          properties:
+            sizes:
+              description: Allowed image sizes.
+              type: array
+              items:
+                type: object
+                properties:
+                  width:
+                    type: integer
+                  height:
+                    type: integer
+                required:
+                  - width
+                  - height
+          required:
+            - sizes
+        sound:
+          type: object
+          description: Sound file specific restrictions. Only set for sound resources.
+          properties:
+            bits:
+              type: array
+              items:
+                type: integer
+            channels:
+              type: array
+              items:
+                type: integer
+            sampling_rates:
+              type: array
+              items:
+                type: integer
+      required:
+        - type
+        - name
+        - file_formats
+        - max_file_size
+        - max_count
+    SupportedResources:
+      type: array
+      items:
+        $ref: '#/components/schemas/SupportedResource'
+    SystemInfo:
+      type: object
+      properties:
+        model_name:
+          type: string
+        model_number:
+          type: string
+        serial_number:
+          type: string
+        hw_revision:
+          type: string
+    SystemLogBoot:
+      type: object
+      properties:
+        index:
+          type: integer
+        boot_id:
+          description: Boot identifier usable for querying logs.
+          type: string
+        first_entry:
+          type: string
+          format: date-time
+        last_entry:
+          type: string
+          format: date-time
+    SystemLogService:
+      type: object
+      properties:
+        service:
+          description: Service identifier usable for querying logs.
+          type: string
+        active:
+          description: Service is active
+          type: boolean
+        name:
+          description: Human readable service name
+          type: string
+    SystemLogEntry:
+      type: object
+      properties:
+        ts:
+          description: Timestamp of log entry
+          type: string
+          format: date-time
+        service:
+          description: Service identifier
+          type: string
+        prio:
+          description: 'Priority, corresponds to [Syslog levels](https://en.wikipedia.org/wiki/Syslog#Severity_level)'
+          type: integer
+        msg:
+          description: Log message
+          type: string
+    UiId:
+      type: string
+      format: '^[a-zA-Z0-9\-_]+$'
+      minLength: 1
+      maxLength: 36
+      description: Unique user interface identifier.
+    UserInterfaceItem:
+      description: |
+        A user interface item is either an icon, text or media information from a media-player entity.
+        - Icon and text items can be static or linked to a command specified in the `command` field.
+        - Default size is 1x1 if not specified.
+      type: object
+      properties:
+        type:
+          description: |
+            Type of the user interface item:
+            - `icon`: show an icon, either a UC icon or a custom icon. Field `icon` must contain the icon identifier.
+            - `text`: show text only from field `text`.
+            - `media_player`: show media information from the specified media-player entity specified in `media_player_id`.  
+              The specified entity_id must be part of the included entities in the activity and of type media-player.
+          type: string
+          enum:
+            - icon
+            - text
+            - numpad
+            - media_player
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        text:
+          type: string
+        media_player_id:
+          $ref: '#/components/schemas/EntityId'
+        command:
+          $ref: '#/components/schemas/EntityCommand'
+        location:
+          $ref: '#/components/schemas/GridLocation'
+        size:
+          $ref: '#/components/schemas/GridItemSize'
+      required:
+        - type
+        - location
+    AvailableSystemUpdateResponse:
+      type: object
+      properties:
+        update_in_progress:
+          type: boolean
+        last_check_date:
+          description: Last update check timestamp.
+          type: string
+          format: date-time
+        next_check_date:
+          description: Next scheduled update check timestamp.
+          type: string
+          format: date-time
+        update_check_enabled:
+          type: boolean
+        installed_version:
+          description: Installed system version.
+          type: string
+        available:
+          type: array
+          items:
+            $ref: '#/components/schemas/AvailableSystemUpdate'
+      required:
+        - update_check_enabled
+        - installed_version
+        - available
+    AvailableSystemUpdate:
+      type: object
+      properties:
+        id:
+          description: Update identifier
+          type: string
+        title:
+          type: string
+        description:
+          $ref: '#/components/schemas/LanguageText'
+        version:
+          type: string
+        channel:
+          $ref: '#/components/schemas/UpdateChannel'
+        release_date:
+          type: string
+          format: date
+        size:
+          type: integer
+          format: int64
+        release_notes_url:
+          type: string
+          format: uri
+        download:
+          $ref: '#/components/schemas/UpdateDownloadState'
+      required:
+        - id
+        - title
+        - description
+        - version
+        - release_date
+        - size
+    UpdateChannel:
+      type: string
+      enum:
+        - STABLE
+        - TESTING
+        - DEVELOPMENT
+    UpdateDownloadState:
+      description: |
+        Download status:
+        - `PENDING`: update is scheduled to download
+        - `DOWNLOADING`: update is currently downloading
+        - `DOWNLOADED`: update has been downloaded and is ready to be installed
+        - `ERROR`: download failed
+      type: string
+      enum:
+        - PENDING
+        - DOWNLOADING
+        - DOWNLOADED
+        - ERROR
+    UploadSystemImageResponse:
+      type: object
+      properties:
+        id:
+          description: Update identifier
+          type: string
+      required:
+        - id
+    SystemUpdateResponse:
+      type: object
+      properties:
+        state:
+          $ref: '#/components/schemas/SystemUpdateState'
+        update_id:
+          description: Update identifier
+          type: string
+      required:
+        - state
+        - update_id
+    SystemUpdateProgress:
+      type: object
+      properties:
+        state:
+          $ref: '#/components/schemas/SystemUpdateState'
+        update_id:
+          description: Update identifier
+          type: string
+        download_percent:
+          description: Percent of download
+          type: integer
+        download_bytes:
+          description: Total of bytes to be downloaded
+          type: integer
+          format: int64
+        total_steps:
+          description: Total number of update steps
+          type: integer
+        current_step:
+          description: Current installation step index
+          type: integer
+        current_percent:
+          description: Percent in current step
+          type: integer
+      required:
+        - state
+        - update_id
+    SystemUpdateState:
+      type: string
+      enum:
+        - IDLE
+        - START
+        - RUN
+        - SUCCESS
+        - FAILURE
+        - DOWNLOAD
+        - DONE
+        - SUB_PROCESS
+        - PROGRESS
+    ValidationErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Error code
+        message:
+          type: string
+          description: Message describing the validation error. This message is intended for error analysis and should not directly shown to the end user.
+        errors:
+          description: Optional validation errors
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+    ValidationError:
+      type: object
+      properties:
+        field:
+          description: Field identifier with an invalid value.
+          type: string
+        field_errors:
+          description: |
+            Optional field validation error descriptions. A field can have multiple validation rules with an error.
+          type: array
+          items:
+            $ref: '#/components/schemas/FieldValidationError'
+      required:
+        - field
+    FieldValidationError:
+      type: object
+      properties:
+        code:
+          description: |
+            Validation error code. This can be a custom code or one of the common pre-defined codes:
+            - `LENGTH`: String is either too short or too long.
+            - `RANGE`: Number is not in valid range.
+            - `REGEX`: Regex validation failed.
+            - `INVALID_FORMAT`: value is in an invalid format.
+          type: string
+        message:
+          description: Validation rule message.
+          type: string
+        params:
+          description: 'Optional code related parameters. E.g. `min`, `max` for string-length or number-range validation.'
+          type: object
+      required:
+        - message
+    VersionInfo:
+      type: object
+      properties:
+        device_name:
+          description: Custom name of the remote
+          type: string
+        api:
+          description: API version
+          type: string
+        core:
+          description: Core app version
+          type: string
+        ui:
+          description: Frontend app version
+          type: string
+        os:
+          description: Operating system version
+          type: string
+        integrations:
+          description: 'Versions of the available integrations. Map of (integration_name, version).'
+          type: object
+          additionalProperties:
+            type: string
+    ApScanStatus:
+      type: object
+      properties:
+        active:
+          type: boolean
+        scan:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccessPointScan'
+      required:
+        - active
+        - scan
+    AccessPointScan:
+      type: object
+      properties:
+        bssid:
+          description: MAC physical address of the access point (basic service set identifier)
+          type: string
+        frequency:
+          description: 'Frequency of the channel in MHz (e.g., 2412 = channel 1)'
+          type: string
+        signal_level:
+          description: Signal level (dBm)
+          type: integer
+        auth:
+          description: Authentication method
+          type: string
+        ssid:
+          description: |
+            SSID network name as friendly UTF-8 representation. Use this name to present the network to users, but not for
+            adding a new network configuration. This is a lossy conversion from the native SSID byte array.
+          type: string
+        ssid_hex:
+          description: |
+            Hex encoded string of the native SSID byte array.
+
+            Always use this representation, when connecting to a network from a scan result.
+          type: string
+      required:
+        - bssid
+        - ssid
+        - ssid_hex
+    WifiStatus:
+      type: object
+      properties:
+        wpa_state:
+          $ref: '#/components/schemas/WpaState'
+        id:
+          description: Network identifier
+          type: integer
+        bssid:
+          description: MAC physical address of the access point (basic service set identifier)
+          type: string
+        ssid:
+          description: Network name (service set identifier)
+          type: string
+        ssid_hex:
+          description: Hex encoded string of the native SSID byte array.
+          type: string
+        freq:
+          description: 'Frequency of the channel in MHz (e.g., 2412 = channel 1)'
+          type: integer
+        address:
+          description: MAC physical address of the WiFi adapter
+          type: string
+        pairwise_cipher:
+          type: string
+        group_cipher:
+          type: string
+        key_mgmt:
+          type: string
+        ip_address:
+          description: Client IP address
+          type: string
+        noise:
+          description: Noise level (dBm)
+          type: integer
+        rssi:
+          description: Signal level (dBm)
+          type: integer
+        avg_rssi:
+          description: Average RSSI (dBm)
+          type: integer
+        est_throughput:
+          description: Estimated throughput in kbps
+          type: integer
+        snr:
+          description: Signal-to-noise ratio in dB
+          type: integer
+        linkspeed:
+          description: Link speed (Mbps)
+          type: integer
+      required:
+        - wpa_state
+    CreateWifiNetwork:
+      type: object
+      properties:
+        ssid:
+          description: |
+            Network name (service set identifier).
+
+            Only use for valid UTF-8 names, when creating a new configuration and not from a scan result.    
+            Always use `ssid_hex`, when adding a network configuration from a scan result! Otherwise it's not guaranteed,
+            that the correct network is configured. The SSID name can contain non-displayable characters.
+          type: string
+          minLength: 1
+          maxLength: 32
+        ssid_hex:
+          description: |
+            Hex encoded string of the native SSID byte array, returned from a network scan.
+          minLength: 2
+          maxLength: 64
+        password:
+          type: string
+          minLength: 1
+          maxLength: 63
+    ModifyWifiNetwork:
+      type: object
+      properties:
+        password:
+          type: string
+          minLength: 1
+          maxLength: 63
+      required:
+        - password
+    SavedNetworks:
+      type: array
+      items:
+        $ref: '#/components/schemas/SavedNetwork'
+    SavedNetwork:
+      description: A saved network configuration (known network)
+      type: object
+      properties:
+        id:
+          description: 'Network identification, used for further operations on this network'
+          type: integer
+        ssid:
+          description: Network name (service set identifier)
+          type: string
+        ssid_hex:
+          description: Hex encoded string of the native SSID byte array.
+          type: string
+        secured:
+          description: Secured or unsecured network
+          type: boolean
+        state:
+          type: string
+          enum:
+            - CONNECTED
+            - OUT_OF_RANGE
+            - DISABLED
+            - TEMPORARY_DISABLED
+      required:
+        - id
+        - ssid
+        - ssid_hex
+        - secured
+    WpaState:
+      description: |
+        - `UNKNOWN`: Unknown state. The driver returned a state which could not be handled.
+        - `ERROR`: Error retrieving state information.
+        - `DISCONNECTED`: This state indicates that client is not associated, but is likely to start looking for an access point. This state is entered when a connection is lost.
+        - `INTERFACE_DISABLED`: This state is entered if the network interface is disabled. The driver refuses any new operations that would use the radio until the interface has been enabled.
+        - `INACTIVE`: This state is entered if there are no enabled networks in the configuration. The driver is not trying to associate with a new network and external interaction (e.g. add or enable a network) is needed to start association.
+        - `SCANNING`: Scanning for a network.
+        - `AUTHENTICATED`: Trying to authenticate with a BSS/SSID.
+        - `ASSOCIATING`: Trying to associate with a BSS/SSID.
+        - `ASSOCIATED`: Association completed.
+        - `FOUR_WAY_HANDSHAKE`: WPA 4-Way Key Handshake in progress.
+        - `GROUP_HANDSHAKE`: WPA Group Key Handshake in progress.
+        - `COMPLETED`: All authentication completed.
+      type: string
+      enum:
+        - UNKNOWN
+        - ERROR
+        - DISCONNECTED
+        - INTERFACE_DISABLED
+        - INACTIVE
+        - SCANNING
+        - AUTHENTICATED
+        - ASSOCIATING
+        - ASSOCIATED
+        - FOUR_WAY_HANDSHAKE
+        - GROUP_HANDSHAKE
+        - COMPLETED
+    WifiCmd:
+      type: string
+      enum:
+        - DISCONNECT
+        - RECONNECT
+        - REASSOCIATE
+        - ENABLE_ALL_NETWORKS
+        - DISABLE_ALL_NETWORKS
+    WifiNetworkCmd:
+      type: string
+      enum:
+        - ENABLE
+        - DISABLE
+        - SELECT
+  responses:
+    SuccessMessage:
+      description: Successful operation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiResponse'
+    Err400BadRequest:
+      description: The server could not understand the request due to invalid syntax or missing data.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ValidationErrorResponse'
+    Err401Unauthorized:
+      description: Authentication credentials were missing or incorrect. The client must authenticate itself to get the requested response.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiResponse'
+    Err403Forbidden:
+      description: 'The request is understood, but the client does not have access rights to the content.'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiResponse'
+    Err409Conflict:
+      description: The request conflicts with the current state of the target resource.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiResponse'
+    Err404NotFound:
+      description: The resource does not exist or the URI is invalid.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiResponse'
+    Err413PayloadTooLarge:
+      description: Request entity is too large and not supported.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiResponse'
+    Err415UnsupportedMediaType:
+      description: The media format of the requested data is not supported.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiResponse'
+    Err422UnprocessableEntity:
+      description: The request was well-formed but cannot be processed. Used for already existing data which cannot be re-created.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiResponse'
+    Err429TooManyRequests:
+      description: The client has sent too many requests in a given amount of time.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiResponse'
+    Err500InternalServerError:
+      description: The server has encountered a situation it does not know how to handle. Retrying the same request will most likely result in the same error.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiResponse'
+    Err503ServiceUnavailable:
+      description: The server is not ready to handle the request. Try again later.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiResponse'
+    Err507InsufficientStorage:
+      description: There is insufficient storage to store the resource.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiResponse'
+  securitySchemes:
+    basicAuth:
+      type: http
+      description: Basic authentication. Please only use for single requests and testing with Swagger / OpenAPI.
+      scheme: basic
+    cookieAuth:
+      type: apiKey
+      description: Cookie based session authentication. Does not work with Swagger / OpenAPI testing.
+      in: cookie
+      name: id

--- a/core-api/rest/remote-core_rest-api.postman_collection.json
+++ b/core-api/rest/remote-core_rest-api.postman_collection.json
@@ -1,0 +1,14227 @@
+{
+	"info": {
+		"_postman_id": "67fe9789-d645-4a16-9336-2f90e9294fa7",
+		"name": "Remote Two Core-API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "9323728"
+	},
+	"item": [
+		{
+			"name": "public",
+			"item": [
+				{
+					"name": "version",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/pub/version",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"pub",
+								"version"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "status",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/pub/status",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"pub",
+								"status"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "health check",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/pub/health_check",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"pub",
+								"health_check"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"auth": {
+				"type": "noauth"
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "auth",
+			"item": [
+				{
+					"name": "login",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Session cookie is returned\", function () {",
+									"    pm.expect(pm.cookies.has('id')).to.be.true;",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"username\": \"{{apiUsername}}\",\n    \"password\": \"{{apiPassword}}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/pub/login",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"pub",
+								"login"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "logout",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/pub/logout",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"pub",
+								"logout"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "auth/scopes",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/auth/scopes",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"scopes"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"auth": {
+				"type": "noauth"
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "auth/api_keys",
+			"item": [
+				{
+					"name": "createApiKey: invalid scopes",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"Integration test\",\n  \"scopes\": [\n    \"admin\", \"admin2\"\n  ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/auth/api_keys",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"api_keys"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "createApiKey",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"pm.test(\"Response body data\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.name).to.eql(\"Me myself and I\");",
+									"    pm.expect(jsonData.active).to.eql(true);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"Me myself and I\",\n  \"scopes\": [\n    \"admin\"\n  ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/auth/api_keys",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"api_keys"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getApiKeyCount",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Pagination headers are present\", function () {",
+									"    pm.response.to.have.header(\"pagination-count\");",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "HEAD",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/auth/api_keys",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"api_keys"
+							],
+							"query": [
+								{
+									"key": "active",
+									"value": "true",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getApiKeys",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Check if response is a json array\", () => {",
+									"    pm.expect(jsonData).to.be.an(\"array\");",
+									"});",
+									"",
+									"pm.test(\"Check if response array size is at least 1\", () => {",
+									"    pm.expect(Object.keys(pm.response.json()).length).to.be.above(0);",
+									"",
+									"    pm.collectionVariables.set(\"apiKeyId\", jsonData[0].key_id);",
+									"});",
+									"",
+									"pm.test(\"Pagination headers are present\", function () {",
+									"    pm.response.to.have.header(\"pagination-limit\");",
+									"    pm.response.to.have.header(\"pagination-page\");",
+									"    pm.response.to.have.header(\"pagination-count\");",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/auth/api_keys?page=1&limit=10",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"api_keys"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "1"
+								},
+								{
+									"key": "limit",
+									"value": "10"
+								},
+								{
+									"key": "active",
+									"value": "true",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getApiKey",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/auth/api_keys/{{apiKeyId}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"api_keys",
+								"{{apiKeyId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateToken: name",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"Familiy administrator\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/auth/api_keys/{{apiKeyId}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"api_keys",
+								"{{apiKeyId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateToken: set active",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"active\": true,\n  \"valid_to\": \"2023-02-20T13:38:45+01:00\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/auth/api_keys/{{apiKeyId}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"api_keys",
+								"{{apiKeyId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteApiKey: non existing",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 404\", function () {",
+									"    pm.response.to.have.status(404);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/auth/api_keys/-",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"api_keys",
+								"-"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteApiKey",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/auth/api_keys/{{apiKeyId}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"api_keys",
+								"{{apiKeyId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteAllApiKeys",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/auth/api_keys",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"api_keys"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "auth/external - external tokens",
+			"item": [
+				{
+					"name": "getExternalSystems",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/auth/external",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"external"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "foobar",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteAllExternalAccessTokens",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"my-home5\",\n    \"token\": \"foobar\",\n    \"description\": \"Kusi's HomeAssistant Server\",\n    \"url\": \"http://foobar.local\",\n    \"data\": \"{\\\"whatever\\\": true}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/auth/external",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"external"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getExternalAccessTokenCount",
+					"request": {
+						"method": "HEAD",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/auth/external/{{externalSystem}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"external",
+								"{{externalSystem}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getExternalAccessTokens",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/auth/external/{{externalSystem}}?page=1",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"external",
+								"{{externalSystem}}"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "1"
+								},
+								{
+									"key": "limit",
+									"value": "3",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "addExternalAccessToken Validation Error",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"test-ha_12\",\n    \"token\": \"\",\n    \"description\": \"Kusi's HomeAssistant Server\",\n    \"url\": \"ws://foobar.local\",\n    \"data\": \"{\\\"whatever\\\": true}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/auth/external/{{externalSystem}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"external",
+								"{{externalSystem}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "addExternalAccessToken: auto-generate token_id",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"my-home\",\n    \"token\": \"foobar\",\n    \"description\": \"Kusi's HomeAssistant Server\",\n    \"url\": \"http://foobar.local\",\n    \"data\": \"{\\\"whatever\\\": true}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/auth/external/{{externalSystem}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"external",
+								"{{externalSystem}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "addExternalAccessToken",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"token_id\": \"{{extTokenID}}\",\n    \"name\": \"my-home\",\n    \"token\": \"foobar\",\n    \"description\": \"My HomeAssistant Server\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/auth/external/{{externalSystem}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"external",
+								"{{externalSystem}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "replaceExternalAccessToken",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"my-new-home\",\n    \"token\": \"foobar-2\",\n    \"description\": \"Kusi's new HomeAssistant Server\",\n    \"url\": \"http://foobar2.local\",\n    \"data\": \"{\\\"whatever\\\": false}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/auth/external/{{externalSystem}}/{{extTokenID}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"external",
+								"{{externalSystem}}",
+								"{{extTokenID}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteExternalAccessTokensBySystem",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/auth/external/{{externalSystem}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"external",
+								"{{externalSystem}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getExternalAccessToken",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/auth/external/{{externalSystem}}/{{extTokenID}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"external",
+								"{{externalSystem}}",
+								"{{extTokenID}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteExternalAccessToken",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/auth/external/{{externalSystem}}/{{extTokenID}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"external",
+								"{{externalSystem}}",
+								"{{extTokenID}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "resources",
+			"item": [
+				{
+					"name": "Icon",
+					"item": [
+						{
+							"name": "deleteResources",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "Icon"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "uploadFile",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"postman.setEnvironmentVariable(\"resource_id\", responseJson[0].id);",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/Users/mzehnder/Pictures/Icons/fox.jpg"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "Icon"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "uploadFile multiple",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"postman.setEnvironmentVariable(\"resource_id\", responseJson[0].id);",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/Users/mzehnder/Pictures/Icons/pizza.jpeg"
+										},
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/Users/mzehnder/Pictures/Icons/owl-logo.png"
+										},
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/Users/mzehnder/Pictures/Icons/fox2.jpeg"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "Icon"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getResourceTypeItemsCount",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "HEAD",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "Icon"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getResourceTypeItems",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson[0]) {",
+											"    postman.setEnvironmentVariable(\"resource_id\", responseJson[0].id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type?limit=100",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "5",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": "100"
+										}
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "Icon"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getResource",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type/:resource",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type",
+										":resource"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "Icon"
+										},
+										{
+											"key": "resource",
+											"value": "{{resource_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "deleteResource",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type/:resource",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type",
+										":resource"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "Icon"
+										},
+										{
+											"key": "resource",
+											"value": "{{resource_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "BackgroundImage",
+					"item": [
+						{
+							"name": "deleteResources",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "BackgroundImage"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "uploadFile",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"postman.setEnvironmentVariable(\"resource_id\", responseJson[0].id);",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/Users/mzehnder/Pictures/BackgroundImage/testpattern1.jpg"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "BackgroundImage"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "uploadFile multiple",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"postman.setEnvironmentVariable(\"resource_id\", responseJson[0].id);",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/Users/mzehnder/Pictures/BackgroundImage/testpattern2.jpg"
+										},
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/Users/mzehnder/Pictures/BackgroundImage/testpattern3.jpg"
+										},
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/Users/mzehnder/Pictures/BackgroundImage/ambilight.jpg"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "BackgroundImage"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getResourceTypeItemsCount",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "HEAD",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "BackgroundImage"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getResourceTypeItems",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson[0]) {",
+											"    postman.setEnvironmentVariable(\"resource_id\", responseJson[0].id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "5",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": "2",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "BackgroundImage"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getResource",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type/:resource",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type",
+										":resource"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "BackgroundImage"
+										},
+										{
+											"key": "resource",
+											"value": "{{resource_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "deleteResource",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type/:resource",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type",
+										":resource"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "BackgroundImage"
+										},
+										{
+											"key": "resource",
+											"value": "{{resource_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "TvChannelIcon",
+					"item": [
+						{
+							"name": "deleteResources",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "TvChannelIcon"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "uploadFile",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"postman.setEnvironmentVariable(\"resource_id\", responseJson[0].id);",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/Users/mzehnder/Pictures/TvChannelIcons/bbc_world_news.png"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "TvChannelIcon"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "uploadFile multiple",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/Users/mzehnder/Pictures/TvChannelIcons/mtv.png"
+										},
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/Users/mzehnder/Pictures/TvChannelIcons/cnn.png"
+										},
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/Users/mzehnder/Pictures/TvChannelIcons/euronews.png"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "TvChannelIcon"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getResourceTypeItemsCount",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "HEAD",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "TvChannelIcon"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getResourceTypeItems",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson[0]) {",
+											"    postman.setEnvironmentVariable(\"resource_id\", responseJson[0].id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "5",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": "2",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "TvChannelIcon"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getResource",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type/:resource",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type",
+										":resource"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "TvChannelIcon"
+										},
+										{
+											"key": "resource",
+											"value": "{{resource_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "deleteResource",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type/:resource",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type",
+										":resource"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "TvChannelIcon"
+										},
+										{
+											"key": "resource",
+											"value": "{{resource_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Sound",
+					"item": [
+						{
+							"name": "deleteResources",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "Sound"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "uploadFile",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"postman.setEnvironmentVariable(\"resource_id\", responseJson[0].id);",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/Users/mzehnder/Downloads/test.wav"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "Sound"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getResourceTypeItemsCount",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "HEAD",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "Sound"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getResourceTypeItems",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"postman.setEnvironmentVariable(\"resource_id\", responseJson[0].id);",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "5",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": "2",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "Sound"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getResource",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type/:resource",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type",
+										":resource"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "Sound"
+										},
+										{
+											"key": "resource",
+											"value": "{{resource_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "deleteResource",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/resources/:type/:resource",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"resources",
+										":type",
+										":resource"
+									],
+									"variable": [
+										{
+											"key": "type",
+											"value": "Sound"
+										},
+										{
+											"key": "resource",
+											"value": "{{resource_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "getResourceTypes",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/resources",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"resources"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteAllResources",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/resources",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"resources"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "mdns",
+			"item": [
+				{
+					"name": "mdns browse all",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/test/mdns/discover",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"test",
+								"mdns",
+								"discover"
+							],
+							"query": [
+								{
+									"key": "timeout_browse",
+									"value": "1",
+									"disabled": true
+								},
+								{
+									"key": "timeout_browse1",
+									"value": "1",
+									"disabled": true
+								},
+								{
+									"key": "timeout_resolve",
+									"value": "1",
+									"disabled": true
+								},
+								{
+									"key": "timeout_address",
+									"value": "1",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "mdns browse yio-dock-api",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/test/mdns/discover/:query",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"test",
+								"mdns",
+								"discover",
+								":query"
+							],
+							"variable": [
+								{
+									"key": "query",
+									"value": "_yio-dock-api._tcp"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "mdns browse sonos",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/test/mdns/discover/:query?timeout_browse=1",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"test",
+								"mdns",
+								"discover",
+								":query"
+							],
+							"query": [
+								{
+									"key": "timeout_browse",
+									"value": "1"
+								},
+								{
+									"key": "timeout_browse1",
+									"value": "1",
+									"disabled": true
+								},
+								{
+									"key": "timeout_resolve",
+									"value": "1",
+									"disabled": true
+								},
+								{
+									"key": "timeout_address",
+									"value": "1",
+									"disabled": true
+								}
+							],
+							"variable": [
+								{
+									"key": "query",
+									"value": "_sonos._tcp"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "mdns browse yio-remote",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/test/mdns/discover/:query?timeout_browse=1&timeout_browse1=1&timeout_resolve=1&timeout_address=1",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"test",
+								"mdns",
+								"discover",
+								":query"
+							],
+							"query": [
+								{
+									"key": "timeout_browse",
+									"value": "1"
+								},
+								{
+									"key": "timeout_browse1",
+									"value": "1"
+								},
+								{
+									"key": "timeout_resolve",
+									"value": "1"
+								},
+								{
+									"key": "timeout_address",
+									"value": "1"
+								}
+							],
+							"variable": [
+								{
+									"key": "query",
+									"value": "_yio-remote._tcp"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "mdns publish",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"reg_type\": \"_yio-test._tcp\",\n    \"port\": 1234,\n    \"txt\": {\n        \"foo\": \"bar\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/test/mdns/publish",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"test",
+								"mdns",
+								"publish"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "mdns unpublish",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/test/mdns/publish/:name",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"test",
+								"mdns",
+								"publish",
+								":name"
+							],
+							"variable": [
+								{
+									"key": "name",
+									"value": "_yio-test._tcp:1234"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "docks",
+			"item": [
+				{
+					"name": "devices",
+					"item": [
+						{
+							"name": "command",
+							"item": [
+								{
+									"name": "SetLedBrightness",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"command\": \"SET_LED_BRIGHTNESS\",\n    \"value\": \"66\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/command",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"command"
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Identify",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"command\": \"IDENTIFY\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/command",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"command"
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "RemoteLowBattery",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"command\": \"REMOTE_LOW_BATTERY\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/command",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"command"
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "RemoteCharged",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"command\": \"REMOTE_CHARGED\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/command",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"command"
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "RemoteNormal",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"command\": \"REMOTE_NORMAL\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/command",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"command"
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "SetFriendlyName",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"command\": \"SET_FRIENDLY_NAME\",\n    \"value\": \"Ethernet dock 5.3\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/command",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"command"
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Reboot",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"command\": \"REBOOT\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/command",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"command"
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Reset",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"command\": \"RESET\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/command",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"command"
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "infrared",
+							"item": [
+								{
+									"name": "learn",
+									"item": [
+										{
+											"name": "irLearningStatus",
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{SERVER}}/api/docks/devices/:dock_id/ir/learn",
+													"host": [
+														"{{SERVER}}"
+													],
+													"path": [
+														"api",
+														"docks",
+														"devices",
+														":dock_id",
+														"ir",
+														"learn"
+													],
+													"variable": [
+														{
+															"key": "dock_id",
+															"value": "YIO-Dock-3"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "startIrLearning",
+											"request": {
+												"method": "POST",
+												"header": [],
+												"url": {
+													"raw": "{{SERVER}}/api/docks/devices/:dock_id/ir/learn?timeout=10",
+													"host": [
+														"{{SERVER}}"
+													],
+													"path": [
+														"api",
+														"docks",
+														"devices",
+														":dock_id",
+														"ir",
+														"learn"
+													],
+													"query": [
+														{
+															"key": "timeout",
+															"value": "10"
+														}
+													],
+													"variable": [
+														{
+															"key": "dock_id",
+															"value": "YIO-Dock-3"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "stopIrLearning",
+											"request": {
+												"method": "DELETE",
+												"header": [],
+												"url": {
+													"raw": "{{SERVER}}/api/docks/devices/:dock_id/ir/learn",
+													"host": [
+														"{{SERVER}}"
+													],
+													"path": [
+														"api",
+														"docks",
+														"devices",
+														":dock_id",
+														"ir",
+														"learn"
+													],
+													"variable": [
+														{
+															"key": "dock_id",
+															"value": "YIO-Dock-3"
+														}
+													]
+												}
+											},
+											"response": []
+										}
+									]
+								},
+								{
+									"name": "sendIrTest",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/ir/send?base=true&hex=17;0x221C;14;0",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"ir",
+												"send"
+											],
+											"query": [
+												{
+													"key": "base",
+													"value": "true"
+												},
+												{
+													"key": "ext1",
+													"value": "true",
+													"disabled": true
+												},
+												{
+													"key": "hex",
+													"value": "17;0x221C;14;0"
+												}
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "sendIrTest Copy 2",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/ir/send?base=true&ext1=true&format=PRONTO&code=0000,0070,0000,0032,0080,0040,0010,0010,0010,0010,0010,0030,0010,0010,0010,0030,0010,0010,0010,0030,0010,0010,0010,0010,0010,0030,0010,0010,0010,0010,0010,0030,0010,0030,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0030,0010,0010,0010,0030,0010,0010,0010,0030,0010,0010,0010,0010,0010,0010,0010,0030,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0030,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0030,0010,0010,0010,0ace",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"ir",
+												"send"
+											],
+											"query": [
+												{
+													"key": "base",
+													"value": "true"
+												},
+												{
+													"key": "ext1",
+													"value": "true"
+												},
+												{
+													"key": "format",
+													"value": "PRONTO"
+												},
+												{
+													"key": "code",
+													"value": "0000,0070,0000,0032,0080,0040,0010,0010,0010,0010,0010,0030,0010,0010,0010,0030,0010,0010,0010,0030,0010,0010,0010,0010,0010,0030,0010,0010,0010,0010,0010,0030,0010,0030,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0030,0010,0010,0010,0030,0010,0010,0010,0030,0010,0010,0010,0010,0010,0010,0010,0030,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0030,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0010,0030,0010,0010,0010,0ace"
+												}
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "sendIrTest hex",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/ir/send?base=true&ext1=true&hex=3;0x20F0B54A;32;0",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"ir",
+												"send"
+											],
+											"query": [
+												{
+													"key": "base",
+													"value": "true"
+												},
+												{
+													"key": "ext1",
+													"value": "true"
+												},
+												{
+													"key": "hex",
+													"value": "3;0x20F0B54A;32;0"
+												}
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "sendIrTest pronto",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/ir/send?base=true&ext1=true&pronto=0001,0002,0002,affe,cafe,beef,dead",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"ir",
+												"send"
+											],
+											"query": [
+												{
+													"key": "base",
+													"value": "true"
+												},
+												{
+													"key": "ext1",
+													"value": "true"
+												},
+												{
+													"key": "pronto",
+													"value": "0001,0002,0002,affe,cafe,beef,dead"
+												},
+												{
+													"key": "hex",
+													"value": "3;0x20F0B54A;32;0",
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "sendIr pronto",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"int1\": true,\n    \"int2\": false,\n    \"ext1\": true,\n    \"ext2\": false,\n    \"pronto\":\"0001,0002,0002,affe,cafe,beef,dead\",\n    \"hex2\": \"3;0x20F0B54A;32;0\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/ir/send",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"ir",
+												"send"
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "update",
+							"item": [
+								{
+									"name": "progress",
+									"item": [
+										{
+											"name": "getUpdateProgress",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{SERVER}}/api/docks/devices/:dock_id/update/:update_id",
+													"host": [
+														"{{SERVER}}"
+													],
+													"path": [
+														"api",
+														"docks",
+														"devices",
+														":dock_id",
+														"update",
+														":update_id"
+													],
+													"variable": [
+														{
+															"key": "dock_id",
+															"value": "{{dock_id}}"
+														},
+														{
+															"key": "update_id",
+															"value": "{{dock_update_id}}"
+														}
+													]
+												}
+											},
+											"response": []
+										}
+									]
+								},
+								{
+									"name": "checkDockFirmwareUpdate",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"const responseJson = pm.response.json();",
+													"postman.setEnvironmentVariable(\"dock_update_id\", responseJson.update_id);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/update",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"update"
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "updateDockFirmware",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"});",
+													"",
+													"const responseJson = pm.response.json();",
+													"postman.setEnvironmentVariable(\"dock_update_id\", responseJson.update_id);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/update",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"update"
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "stopUpdate",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/docks/devices/:dock_id/update",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"devices",
+												":dock_id",
+												"update"
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "getDock",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/docks/devices/:dock_id",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"docks",
+										"devices",
+										":dock_id"
+									],
+									"variable": [
+										{
+											"key": "dock_id",
+											"value": "{{dock_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "connectDock",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/docks/devices/:dock_id?cmd=CONNECT",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"docks",
+										"devices",
+										":dock_id"
+									],
+									"query": [
+										{
+											"key": "cmd",
+											"value": "CONNECT"
+										}
+									],
+									"variable": [
+										{
+											"key": "dock_id",
+											"value": "{{dock_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "disconnectDock",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/docks/devices/:dock_id?cmd=DISCONNECT",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"docks",
+										"devices",
+										":dock_id"
+									],
+									"query": [
+										{
+											"key": "cmd",
+											"value": "DISCONNECT"
+										}
+									],
+									"variable": [
+										{
+											"key": "dock_id",
+											"value": "{{dock_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateDock",
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"UC-Dock-246F283FCDCC\",\n    \"custom_ws_url\": \"ws://172.16.16.176:946\",\n    \"active\": true,\n    \"description\": \"testing3\"\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/docks/devices/:dock_id",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"docks",
+										"devices",
+										":dock_id"
+									],
+									"variable": [
+										{
+											"key": "dock_id",
+											"value": "{{dock_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateDock set active",
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"active\": true\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/docks/devices/:dock_id",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"docks",
+										"devices",
+										":dock_id"
+									],
+									"variable": [
+										{
+											"key": "dock_id",
+											"value": "{{dock_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateDock set active Copy",
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"active\": true\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/docks/devices/:dock_id",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"docks",
+										"devices",
+										":dock_id"
+									],
+									"variable": [
+										{
+											"key": "dock_id",
+											"value": "{{dock_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "deleteDock",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/docks/devices/:dock_id",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"docks",
+										"devices",
+										":dock_id"
+									],
+									"variable": [
+										{
+											"key": "dock_id",
+											"value": "{{dock_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "discover",
+					"item": [
+						{
+							"name": "device",
+							"item": [
+								{
+									"name": "getDiscoveredDevice",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/docks/discover/:dock_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"discover",
+												":dock_id"
+											],
+											"query": [
+												{
+													"key": "timeout",
+													"value": "5",
+													"disabled": true
+												},
+												{
+													"key": "bt",
+													"value": "false",
+													"disabled": true
+												},
+												{
+													"key": "net",
+													"value": "false",
+													"disabled": true
+												},
+												{
+													"key": "new",
+													"value": "false",
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{discovered_dock_device_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "discoveredDockConnectionTest",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"token\": \"0000\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/discover/:dock_id?cmd=CONNECTION_TEST",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"discover",
+												":dock_id"
+											],
+											"query": [
+												{
+													"key": "timeout",
+													"value": "5",
+													"disabled": true
+												},
+												{
+													"key": "bt",
+													"value": "false",
+													"disabled": true
+												},
+												{
+													"key": "net",
+													"value": "false",
+													"disabled": true
+												},
+												{
+													"key": "new",
+													"value": "false",
+													"disabled": true
+												},
+												{
+													"key": "cmd",
+													"value": "CONNECTION_TEST"
+												}
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{discovered_dock_device_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "discoveredDockIdentify",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"token\": \"0000\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/discover/:dock_id?cmd=IDENTIFY",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"discover",
+												":dock_id"
+											],
+											"query": [
+												{
+													"key": "timeout",
+													"value": "5",
+													"disabled": true
+												},
+												{
+													"key": "bt",
+													"value": "false",
+													"disabled": true
+												},
+												{
+													"key": "net",
+													"value": "false",
+													"disabled": true
+												},
+												{
+													"key": "new",
+													"value": "false",
+													"disabled": true
+												},
+												{
+													"key": "cmd",
+													"value": "IDENTIFY"
+												}
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{discovered_dock_device_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "getDockDiscoveryStatus",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson.docks && responseJson.docks[0]) {",
+											"    postman.setEnvironmentVariable(\"discovered_dock_device\", JSON.stringify(responseJson.docks[0]));",
+											"    postman.setEnvironmentVariable(\"discovered_dock_device_id\", responseJson.docks[0].id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/docks/discover",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"docks",
+										"discover"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "startDockDiscovery",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/docks/discover",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"docks",
+										"discover"
+									],
+									"query": [
+										{
+											"key": "timeout",
+											"value": "5",
+											"disabled": true
+										},
+										{
+											"key": "bt",
+											"value": "false",
+											"disabled": true
+										},
+										{
+											"key": "net",
+											"value": "false",
+											"disabled": true
+										},
+										{
+											"key": "new",
+											"value": "false",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "stopDockDiscovery",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/docks/discover",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"docks",
+										"discover"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "setup",
+					"item": [
+						{
+							"name": "device",
+							"item": [
+								{
+									"name": "getDockSetupStatus",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"const responseJson = pm.response.json();",
+													"if (responseJson.id && responseJson.state == \"OK\") {",
+													"    postman.setEnvironmentVariable(\"dock_id\", responseJson.id);",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/docks/setup/:dock_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"setup",
+												":dock_id"
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "startDockSetup",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"name\": \"Living room\",\n  \"token\": \"1234\",\n  \"custom_ws_url2\": \"ws://test-station.local:1946\",\n  \"description\": \"Setup test\",\n  \"wifi\": {\n    \"ssid\": \"My Network\",\n    \"password\": \"0123456789\"\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/docks/setup/:dock_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"setup",
+												":dock_id"
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "stopDockSetup",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/docks/setup/:dock_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"docks",
+												"setup",
+												":dock_id"
+											],
+											"variable": [
+												{
+													"key": "dock_id",
+													"value": "{{dock_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "getDockSetupProcesses",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/docks/setup",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"docks",
+										"setup"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "setupDock",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson.id) {",
+											"    postman.setEnvironmentVariable(\"dock_setup_id\", responseJson.id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"discovery\": {\n        \"id\": \"UC-Dock-E831CDD012A8\",\n        \"configured\": true,\n        \"friendly_name\": \"My new dock\",\n        \"address\": \"172.1.1.106:946\",\n        \"model\": \"UCD2\",\n        \"version\": \"0.1.0\",\n        \"discovery_type\": \"NET\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/docks/setup",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"docks",
+										"setup"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "setupDock manually",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson.id) {",
+											"    postman.setEnvironmentVariable(\"dock_setup_id\", responseJson.id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"manually\": {\n        \"name\": \"Test manual setup\",\n        \"custom_ws_url\": \"172.1.1.106\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/docks/setup",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"docks",
+										"setup"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "setupDock from discovery",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"",
+											"pm.test(\"Check response\", () => {",
+											"  pm.expect(responseJson).to.be.an(\"object\");",
+											"  pm.expect(responseJson.id).to.be.a(\"string\");",
+											"  pm.expect(responseJson.discovery_type).to.be.a(\"string\");",
+											"});",
+											"",
+											"if (responseJson.id) {",
+											"    postman.setEnvironmentVariable(\"dock_setup_id\", responseJson.id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"discovery\":\n        {{discovered_dock_device}}\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/docks/setup",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"docks",
+										"setup"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "stopAllDockSetups",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/docks/setup",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"docks",
+										"setup"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "getDockCount",
+					"request": {
+						"method": "HEAD",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/docks",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"docks"
+							],
+							"query": [
+								{
+									"key": "active",
+									"value": "false",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getDocks",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"const responseJson = pm.response.json();",
+									"if (responseJson[0] && responseJson[0].dock_id) {",
+									"    postman.setEnvironmentVariable(\"dock_id\", responseJson[0].dock_id);",
+									"}",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/docks",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"docks"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "2",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "1",
+									"disabled": true
+								},
+								{
+									"key": "active",
+									"value": "false",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "connectAllDocks",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/docks?cmd=CONNECT",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"docks"
+							],
+							"query": [
+								{
+									"key": "cmd",
+									"value": "CONNECT"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "disconnectAllDocks",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/docks?cmd=DISCONNECT",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"docks"
+							],
+							"query": [
+								{
+									"key": "cmd",
+									"value": "DISCONNECT"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "createDock",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"const responseJson = pm.response.json();",
+									"if (responseJson.dock_id) {",
+									"    postman.setEnvironmentVariable(\"dock_id\", responseJson.dock_id);",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"dock_id\": \"manual-test.1\",\n    \"custom_ws_url\": \"ws://172.16.16.106:946\",\n    \"token\": \"0000\",\n    \"active\": true,\n    \"description\": \"Testing only\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/docks",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"docks"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteAllDocks",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/docks",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"docks"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "integrations",
+			"item": [
+				{
+					"name": "discover",
+					"item": [
+						{
+							"name": "driver",
+							"item": [
+								{
+									"name": "getDiscoveredDriver",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"const responseJson = pm.response.json();",
+													"if (responseJson.integrations && responseJson.integrations[0]) {",
+													"    postman.setEnvironmentVariable(\"discovered_integration\", JSON.stringify(responseJson.integrations[0]));",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/intg/discover/:driverId",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"discover",
+												":driverId"
+											],
+											"variable": [
+												{
+													"key": "driverId",
+													"value": "{{discovered_integration_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "connectionTest",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"const responseJson = pm.response.json();",
+													"if (responseJson.integrations && responseJson.integrations[0]) {",
+													"    postman.setEnvironmentVariable(\"discovered_integration\", JSON.stringify(responseJson.integrations[0]));",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"connection\": {\n    \"driver_url\": \"ws://my-integration.local:8080\",\n    \"token\": \"0000\"\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/intg/discover/:driverId?cmd=CONNECTION_TEST",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"discover",
+												":driverId"
+											],
+											"query": [
+												{
+													"key": "cmd",
+													"value": "CONNECTION_TEST"
+												}
+											],
+											"variable": [
+												{
+													"key": "driverId",
+													"value": "{{discovered_integration_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "configureDiscoveredDriver",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/intg/discover/:driverId",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"discover",
+												":driverId"
+											],
+											"variable": [
+												{
+													"key": "driverId",
+													"value": "{{discovered_integration_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "getDiscoveryStatus",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson.integrations && responseJson.integrations[0]) {",
+											"    postman.setEnvironmentVariable(\"discovered_integration\", JSON.stringify(responseJson.integrations[0]));",
+											"    postman.setEnvironmentVariable(\"discovered_integration_id\", responseJson.integrations[0].id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/discover",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"discover"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "startDiscovery",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/discover",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"discover"
+									],
+									"query": [
+										{
+											"key": "timeout",
+											"value": "5",
+											"disabled": true
+										},
+										{
+											"key": "new",
+											"value": "false",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "stopDiscovery",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/discover",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"discover"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "setup",
+					"item": [
+						{
+							"name": "driver",
+							"item": [
+								{
+									"name": "getIntegrationSetupStatus",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"const responseJson = pm.response.json();",
+													"if (responseJson.id && responseJson.state == \"OK\") {",
+													"    postman.setEnvironmentVariable(\"dock_id\", responseJson.id);",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/intg/setup/:driver_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"setup",
+												":driver_id"
+											],
+											"variable": [
+												{
+													"key": "driver_id",
+													"value": "{{intg_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "updateIntegrationSetup",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"input_values\": {\n        \"name\": \"Living room\",\n        \"token\": \"123\",\n        \"custom_ws_url2\": \"ws://test-station.local:1946\",\n        \"description\": \"Setup test\"\n    }\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/intg/setup/:driver_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"setup",
+												":driver_id"
+											],
+											"variable": [
+												{
+													"key": "driver_id",
+													"value": "{{intg_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "stopIntegrationSetup",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/intg/setup/:driver_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"setup",
+												":driver_id"
+											],
+											"variable": [
+												{
+													"key": "driver_id",
+													"value": "{{intg_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "getIntegrationSetupProcesses",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson) {",
+											"    postman.setEnvironmentVariable(\"intg_setup_id\", responseJson[0]);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/setup",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"setup"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "setupIntegration",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson.id) {",
+											"    postman.setEnvironmentVariable(\"intg_setup_id\", responseJson.id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"driver_id\": \"homey\",\n    \"name\": {\n        \"en\": \"My test integration\"\n    },\n    \"setup_data\": {\n        \"url\": \"ws://test-station.local:1946\",\n        \"token\": \"123\",\n        \"ssl\": \"false\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/intg/setup",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"setup"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "stopAllIntegrationSetups",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/setup",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"setup"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "setup sim-intg",
+					"item": [
+						{
+							"name": "driver",
+							"item": [
+								{
+									"name": "getIntegrationSetupStatus",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"const responseJson = pm.response.json();",
+													"if (responseJson.id && responseJson.state == \"OK\") {",
+													"    postman.setEnvironmentVariable(\"dock_id\", responseJson.id);",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/intg/setup/:driver_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"setup",
+												":driver_id"
+											],
+											"variable": [
+												{
+													"key": "driver_id",
+													"value": "{{intg_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "updateIntegrationSetup",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"input_values\": {\n        \"choice\": \"blue\",\n        \"upper_case_text\": \"ABC\",\n        \"ip4\": \"192.168.2.33\",\n        \"integer\": \"44\",\n        \"number\": \"1.25\"\n    }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/intg/setup/:driver_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"setup",
+												":driver_id"
+											],
+											"variable": [
+												{
+													"key": "driver_id",
+													"value": "{{intg_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "stopIntegrationSetup",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/intg/setup/:driver_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"setup",
+												":driver_id"
+											],
+											"variable": [
+												{
+													"key": "driver_id",
+													"value": "{{intg_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "setupIntegration sim-intg",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson.id) {",
+											"    postman.setEnvironmentVariable(\"intg_setup_id\", responseJson.id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"driver_id\": \"sim-intg\",\n    \"name\": {\n        \"en\": \"My simulated integration\"\n    },\n    \"setup_data\": {}\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/intg/setup",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"setup"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "setup sim-test",
+					"item": [
+						{
+							"name": "driver",
+							"item": [
+								{
+									"name": "getIntegrationSetupStatus",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"const responseJson = pm.response.json();",
+													"if (responseJson.id && responseJson.state == \"OK\") {",
+													"    postman.setEnvironmentVariable(\"dock_id\", responseJson.id);",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/intg/setup/:driver_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"setup",
+												":driver_id"
+											],
+											"variable": [
+												{
+													"key": "driver_id",
+													"value": "{{intg_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "updateIntegrationSetup",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"input_values\": {\n        \"code\": \"BLUEZZ\"\n    }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/intg/setup/:driver_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"setup",
+												":driver_id"
+											],
+											"variable": [
+												{
+													"key": "driver_id",
+													"value": "{{intg_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "stopIntegrationSetup",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/intg/setup/:driver_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"setup",
+												":driver_id"
+											],
+											"variable": [
+												{
+													"key": "driver_id",
+													"value": "{{intg_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "setupIntegration sim-test",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson.id) {",
+											"    postman.setEnvironmentVariable(\"intg_setup_id\", responseJson.id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"driver_id\": \"sim-test\",\n    \"name\": {\n        \"en\": \"My simulated demo integration\"\n    },\n    \"setup_data\": {}\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/intg/setup",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"setup"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "setup uc:bo",
+					"item": [
+						{
+							"name": "driver",
+							"item": [
+								{
+									"name": "getIntegrationSetupStatus",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"const responseJson = pm.response.json();",
+													"if (responseJson.id && responseJson.state == \"OK\") {",
+													"    postman.setEnvironmentVariable(\"dock_id\", responseJson.id);",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/intg/setup/:driver_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"setup",
+												":driver_id"
+											],
+											"variable": [
+												{
+													"key": "driver_id",
+													"value": "{{intg_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "setupIntegration uc:bo",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson.id) {",
+											"    postman.setEnvironmentVariable(\"intg_setup_id\", responseJson.id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"driver_id\": \"uc:bo\",\n    \"name\": {\n        \"en\": \"My simulated B&O integration\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/intg/setup",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"setup"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "setup uc:homey",
+					"item": [
+						{
+							"name": "driver",
+							"item": [
+								{
+									"name": "getIntegrationSetupStatus",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"const responseJson = pm.response.json();",
+													"if (responseJson.id && responseJson.state == \"OK\") {",
+													"    postman.setEnvironmentVariable(\"dock_id\", responseJson.id);",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/intg/setup/:driver_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"setup",
+												":driver_id"
+											],
+											"variable": [
+												{
+													"key": "driver_id",
+													"value": "{{intg_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "setupIntegration uc:homey",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson.id) {",
+											"    postman.setEnvironmentVariable(\"intg_setup_id\", responseJson.id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"driver_id\": \"uc:homey\",\n    \"name\": {\n        \"en\": \"My simulated Homey integration\"\n    },\n    \"setup_data\": {\n        \"choice\": \"red\",\n        \"input\": \"1\",\n        \"integer\": \"66\",\n        \"number\": \"0.34\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/intg/setup",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"setup"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "setup uc:hue",
+					"item": [
+						{
+							"name": "driver",
+							"item": [
+								{
+									"name": "getIntegrationSetupStatus",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"const responseJson = pm.response.json();",
+													"if (responseJson.id && responseJson.state == \"OK\") {",
+													"    postman.setEnvironmentVariable(\"dock_id\", responseJson.id);",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/intg/setup/:driver_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"setup",
+												":driver_id"
+											],
+											"variable": [
+												{
+													"key": "driver_id",
+													"value": "{{intg_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "updateIntegrationSetup",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"confirm\": true\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/intg/setup/:driver_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"setup",
+												":driver_id"
+											],
+											"variable": [
+												{
+													"key": "driver_id",
+													"value": "{{intg_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "stopIntegrationSetup",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/intg/setup/:driver_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"setup",
+												":driver_id"
+											],
+											"variable": [
+												{
+													"key": "driver_id",
+													"value": "{{intg_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "setupIntegration uc:hue",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson.id) {",
+											"    postman.setEnvironmentVariable(\"intg_setup_id\", responseJson.id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"driver_id\": \"uc:hue\",\n    \"name\": {\n        \"en\": \"My simulated Hue integration\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/intg/setup",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"setup"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "setup sim-foobar",
+					"item": [
+						{
+							"name": "driver",
+							"item": [
+								{
+									"name": "getIntegrationSetupStatus",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"const responseJson = pm.response.json();",
+													"if (responseJson.id && responseJson.state == \"OK\") {",
+													"    postman.setEnvironmentVariable(\"dock_id\", responseJson.id);",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/intg/setup/:driver_id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"intg",
+												"setup",
+												":driver_id"
+											],
+											"variable": [
+												{
+													"key": "driver_id",
+													"value": "{{intg_setup_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "setupIntegration sim-foobar",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson.id) {",
+											"    postman.setEnvironmentVariable(\"intg_setup_id\", responseJson.id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"driver_id\": \"sim-foobar\",\n    \"name\": {\n        \"en\": \"My simulated FooBar integration\"\n    },\n    \"setup_data\": {\n        \"address\": \"test-host.local\",\n        \"port\": \"65535\",\n        \"token\": \"\",\n        \"ssl\": \"false\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/intg/setup",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"setup"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "driver",
+					"item": [
+						{
+							"name": "getIntegrationDriversCount",
+							"request": {
+								"method": "HEAD",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/drivers?enabled=true",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"drivers"
+									],
+									"query": [
+										{
+											"key": "driver_type",
+											"value": "EXTERNAL",
+											"disabled": true
+										},
+										{
+											"key": "enabled",
+											"value": "true"
+										},
+										{
+											"key": "instantiable",
+											"value": "true",
+											"disabled": true
+										},
+										{
+											"key": "single_instance",
+											"value": "true",
+											"disabled": true
+										},
+										{
+											"key": "has_instances",
+											"value": "true",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getIntegrationDrivers",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/drivers?instantiable=true&page=1&limit=10",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"drivers"
+									],
+									"query": [
+										{
+											"key": "driver_type",
+											"value": "LOCAL",
+											"disabled": true
+										},
+										{
+											"key": "enabled",
+											"value": "true",
+											"disabled": true
+										},
+										{
+											"key": "instantiable",
+											"value": "true"
+										},
+										{
+											"key": "single_device",
+											"value": "false",
+											"disabled": true
+										},
+										{
+											"key": "has_instances",
+											"value": "false",
+											"disabled": true
+										},
+										{
+											"key": "page",
+											"value": "1"
+										},
+										{
+											"key": "limit",
+											"value": "10"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "registerIntegrationDriver",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"driver_id2\": \"test\",\n    \"name\": {\n        \"de\": \"Testtreiber\",\n        \"en\": \"Test driver\"\n    },\n    \"driver_url\": \"ws://none\",\n    \"version\": \"0.0.1\",\n    \"icon\": \"yio:test\",\n    \"enabled\": true,\n    \"description\": {\n        \"en\": \"Only for testing\",\n        \"de\": \"Nur zum testen\"\n    },\n    \"device_discovery\": false,\n    \"setup_data_schema\": {},\n    \"release_date\": \"2022-04-02\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/intg/drivers",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"drivers"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getIntegrationDriver",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/drivers/:driverId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"drivers",
+										":driverId"
+									],
+									"variable": [
+										{
+											"key": "driverId",
+											"value": "hass"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateIntegrationDriver",
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"driver_id\": \"test\",\n    \"name\": {\n        \"en\": \"Test Driver\"\n    },\n    \"driver_url\": \"ws://localhost:8000/ws\",\n    \"version\": \"0.0.1\",\n    \"description\": {\n        \"en\": \"Only for testing\"\n    },\n    \"device_discovery\": false,\n    \"setup_data_schema\": {\n        \"foobar\": \"bar3\",\n        \"foo\": \"bar\",\n        \"bar\": true\n    },\n    \"developer\": {\n        \"name\": \"kusi\"\n    },\n    \"release_date\": \"2022-01-01\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/intg/drivers/:driverId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"drivers",
+										":driverId"
+									],
+									"variable": [
+										{
+											"key": "driverId",
+											"value": "test"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "deleteIntegrationDriver",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/drivers/:driverId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"drivers",
+										":driverId"
+									],
+									"variable": [
+										{
+											"key": "driverId",
+											"value": "8f7e16af-4092-496f-b90e-2676866aeb09"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "startIntegrationDriver",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/drivers/:driverId?cmd=START",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"drivers",
+										":driverId"
+									],
+									"query": [
+										{
+											"key": "cmd",
+											"value": "START"
+										}
+									],
+									"variable": [
+										{
+											"key": "driverId",
+											"value": "hass"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "stopIntegrationDriver",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/drivers/:driverId?cmd=STOP",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"drivers",
+										":driverId"
+									],
+									"query": [
+										{
+											"key": "cmd",
+											"value": "STOP"
+										}
+									],
+									"variable": [
+										{
+											"key": "driverId",
+											"value": "hass"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "createIntegrationInstance",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"device_id\": \"ä\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/intg/drivers/:driverId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"drivers",
+										":driverId"
+									],
+									"variable": [
+										{
+											"key": "driverId",
+											"value": "simple"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "instances",
+					"item": [
+						{
+							"name": "getIntegrationsCount",
+							"request": {
+								"method": "HEAD",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/instances?enabled=true&page=1&limit=1",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"instances"
+									],
+									"query": [
+										{
+											"key": "enabled",
+											"value": "true"
+										},
+										{
+											"key": "page",
+											"value": "1"
+										},
+										{
+											"key": "limit",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getIntegrations",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/instances?page=1",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"instances"
+									],
+									"query": [
+										{
+											"key": "enabled",
+											"value": "true",
+											"disabled": true
+										},
+										{
+											"key": "page",
+											"value": "1"
+										},
+										{
+											"key": "limit",
+											"value": "1",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getIntegration",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/instances/:intgId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"instances",
+										":intgId"
+									],
+									"variable": [
+										{
+											"key": "intgId",
+											"value": "hass.main"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "deleteIntegration",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/instances/:intgId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"instances",
+										":intgId"
+									],
+									"variable": [
+										{
+											"key": "intgId",
+											"value": "test.2"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getAvailableEntitiesFromIntegration",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/instances/:intgId/entities?page=1&limit=100&reload=true",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"instances",
+										":intgId",
+										"entities"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "1"
+										},
+										{
+											"key": "limit",
+											"value": "100"
+										},
+										{
+											"key": "reload",
+											"value": "true"
+										}
+									],
+									"variable": [
+										{
+											"key": "intgId",
+											"value": "hass.main"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "configureEntityFromIntegration",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/intg/instances/:intgId/entities/:entityId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"instances",
+										":intgId",
+										"entities",
+										":entityId"
+									],
+									"variable": [
+										{
+											"key": "intgId",
+											"value": "hass.main"
+										},
+										{
+											"key": "entityId",
+											"value": "sensor.uptime"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "connect",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/instances/:intgId?cmd=CONNECT",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"instances",
+										":intgId"
+									],
+									"query": [
+										{
+											"key": "cmd",
+											"value": "CONNECT"
+										}
+									],
+									"variable": [
+										{
+											"key": "intgId",
+											"value": "hass.main"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "disconnect",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/intg/instances/:intgId?cmd=DISCONNECT",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"intg",
+										"instances",
+										":intgId"
+									],
+									"query": [
+										{
+											"key": "cmd",
+											"value": "DISCONNECT"
+										}
+									],
+									"variable": [
+										{
+											"key": "intgId",
+											"value": "hass.main"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "getIntegrationStatusCount",
+					"request": {
+						"method": "HEAD",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/intg",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"intg"
+							],
+							"query": [
+								{
+									"key": "enabled",
+									"value": "true",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getIntegrationStatus",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/intg?page=1&limit=100",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"intg"
+							],
+							"query": [
+								{
+									"key": "enabled",
+									"value": "true",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": "1"
+								},
+								{
+									"key": "limit",
+									"value": "100"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "entities",
+			"item": [
+				{
+					"name": "getEntities",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/entities?page=1&limit=100",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"entities"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "1"
+								},
+								{
+									"key": "limit",
+									"value": "100"
+								},
+								{
+									"key": "entity_type",
+									"value": "light",
+									"disabled": true
+								},
+								{
+									"key": "intg_id",
+									"value": "hass.main",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getEntityCount",
+					"request": {
+						"method": "HEAD",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/entities?entity_type=light&intg_id=hass.main",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"entities"
+							],
+							"query": [
+								{
+									"key": "entity_type",
+									"value": "light"
+								},
+								{
+									"key": "intg_id",
+									"value": "hass.main"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getEntity",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/entities/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"entities",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{light_entity_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateEntity",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": { \"en\": \"light {{$randomProductAdjective}}\" },\n    \"icon\": \"uc:{{$randomProductMaterial}}\",\n    \"features\": [\"{{$randomProductAdjective}}\"],\n    \"description\": { \"en\": \"{{$randomLoremSentence}}\"}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/entities/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"entities",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{light_entity_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "executeEntityCommand",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"cmd_id\": \"toggle\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/entities/:entityId/command",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"entities",
+								":entityId",
+								"command"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{light_entity_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteEntity",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/entities/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"entities",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "hass.main.sensor.uptime"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "activities",
+			"item": [
+				{
+					"name": "buttons",
+					"item": [
+						{
+							"name": "getActivityButtonMappings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"postman.setEnvironmentVariable(\"button\", responseJson[0].button);",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/activities/:entityId/buttons",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"activities",
+										":entityId",
+										"buttons"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{activity_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "resetActivityButtonMappings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/activities/:entityId/buttons",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"activities",
+										":entityId",
+										"buttons"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{activity_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getActivityButtonMapping",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/activities/:entityId/buttons/:button",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"activities",
+										":entityId",
+										"buttons",
+										":button"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{activity_id}}"
+										},
+										{
+											"key": "button",
+											"value": "{{button}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateActivityButtonMapping",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"long_press\": {\n    \"entity_id\": \"05ba8c78-3104-4d38-945d-02f602ba632c\",\n    \"cmd_id\": \"VOLUME_DOWN\"\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/activities/:entityId/buttons/:button",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"activities",
+										":entityId",
+										"buttons",
+										":button"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{activity_id}}"
+										},
+										{
+											"key": "button",
+											"value": "{{button}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "deleteActivityButtonMapping",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/activities/:entityId/buttons/:button",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"activities",
+										":entityId",
+										"buttons",
+										":button"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{activity_id}}"
+										},
+										{
+											"key": "button",
+											"value": "{{button}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "ui",
+					"item": [
+						{
+							"name": "pages",
+							"item": [
+								{
+									"name": "page",
+									"item": [
+										{
+											"name": "getActivityUiPage",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{SERVER}}/api/activities/:entityId/ui/pages/:page",
+													"host": [
+														"{{SERVER}}"
+													],
+													"path": [
+														"api",
+														"activities",
+														":entityId",
+														"ui",
+														"pages",
+														":page"
+													],
+													"variable": [
+														{
+															"key": "entityId",
+															"value": "{{activity_id}}"
+														},
+														{
+															"key": "page",
+															"value": "main"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "updateActivityUiPage",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PATCH",
+												"header": [],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"name\": \"Test page\",\n    \"items\": [\n        {\n            \"type\": \"icon\",\n            \"icon\": \"uc:star\",\n            \"location\": {\n                \"x\": 2,\n                \"y\": 5\n            },\n            \"size\": {\n                \"width\": 2,\n                \"height\": 1\n            }\n        },\n        {\n            \"type\": \"text\",\n            \"text\": \"TEST\",\n            \"command\": {\n                \"entity_id\": \"05ba8c78-3104-4d38-945d-02f602ba632c\",\n                \"cmd_id\": \"VOLUME_UP\"\n            },\n            \"location\": {\n                \"x\": 0,\n                \"y\": 0\n            }\n        },\n        {\n            \"type\": \"text\",\n            \"text\": \"Toggle\",\n            \"command\": {\n                \"cmd_id\": \"light.toggle\",\n                \"entity_id\": \"hass.main.light.study_reading_light\"\n            },\n            \"location\": {\n                \"x\": 0,\n                \"y\": 0\n            },\n            \"size2\":{\"height\":6,\"width\":4}\n        }\n    ]\n}",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{SERVER}}/api/activities/:entityId/ui/pages/:page",
+													"host": [
+														"{{SERVER}}"
+													],
+													"path": [
+														"api",
+														"activities",
+														":entityId",
+														"ui",
+														"pages",
+														":page"
+													],
+													"variable": [
+														{
+															"key": "entityId",
+															"value": "{{activity_id}}"
+														},
+														{
+															"key": "page",
+															"value": "main"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "deleteActivityUiPage",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [],
+												"url": {
+													"raw": "{{SERVER}}/api/activities/:entityId/ui/pages/:page",
+													"host": [
+														"{{SERVER}}"
+													],
+													"path": [
+														"api",
+														"activities",
+														":entityId",
+														"ui",
+														"pages",
+														":page"
+													],
+													"variable": [
+														{
+															"key": "entityId",
+															"value": "{{activity_id}}"
+														},
+														{
+															"key": "page",
+															"value": "main"
+														}
+													]
+												}
+											},
+											"response": []
+										}
+									]
+								},
+								{
+									"name": "createActivityUiPage",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"name\": \"Test\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/activities/:entityId/ui/pages",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"activities",
+												":entityId",
+												"ui",
+												"pages"
+											],
+											"variable": [
+												{
+													"key": "entityId",
+													"value": "{{activity_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "getActivityUiPages",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/activities/:entityId/ui/pages",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"activities",
+												":entityId",
+												"ui",
+												"pages"
+											],
+											"variable": [
+												{
+													"key": "entityId",
+													"value": "{{activity_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "updateActivityUiPageOrder",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PATCH",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"page_order\": [\"b99a3a0a-6859-4810-aae9-eff31043b980\", \"main\"]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/activities/:entityId/ui/pages",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"activities",
+												":entityId",
+												"ui",
+												"pages"
+											],
+											"variable": [
+												{
+													"key": "entityId",
+													"value": "{{activity_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "resetActivityUiPages",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/activities/:entityId/ui/pages",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"activities",
+												":entityId",
+												"ui",
+												"pages"
+											],
+											"variable": [
+												{
+													"key": "entityId",
+													"value": "{{activity_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "getActivityUi",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/activities/:entityId/ui",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"activities",
+										":entityId",
+										"ui"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{activity_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "deleteActivityUi",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/activities/:entityId/ui",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"activities",
+										":entityId",
+										"ui"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{activity_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "getActivityCount",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.test(\"pagination-count header is present\", function () {",
+									"    pm.response.to.have.header(\"pagination-count\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "HEAD",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/activities",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"activities"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getActivities",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"const responseJson = pm.response.json();",
+									"postman.setEnvironmentVariable(\"activity_id\", responseJson[0].entity_id);",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/activities?page=1&limit=100",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"activities"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "1"
+								},
+								{
+									"key": "limit",
+									"value": "100"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "createActivity",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Successful POST request\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([201, 202]);",
+									"});",
+									"",
+									"const responseJson = pm.response.json();",
+									"postman.setEnvironmentVariable(\"activity_id\", responseJson.entity_id);",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": {\n        \"en\": \"{{$randomFirstName}} starts home office\"\n    },\n    \"icon\": \"uc:{{$randomColor}}\",\n    \"description\": {\n        \"en\": \"{{$randomCatchPhrase}}\"\n    }\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/activities",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"activities"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteAllActivities",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/activities",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"activities"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getActivity",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/activities/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"activities",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{activity_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateActivity with included entities",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"options\": {\n        \"entity_ids\": [\n            \"hass.main.sensor.uptime\",\n            \"hass.main.light.study_reading_light\"\n        ]\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/activities/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"activities",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{activity_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateActivity with included entities Copy",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"options\": {\n        \"entity_ids\": [\n            \"hass.main.sensor.uptime\",\n            \"hass.main.light.study_reading_light\",\n            \"05ba8c78-3104-4d38-945d-02f602ba632c\"\n        ],\n        \"sequences\": {\n            \"off\": [],\n            \"on\": [\n                {\n                    \"type\": \"command\",\n                    \"command\": {\n                        \"entity_id\": \"hass.main.light.study_reading_light\",\n                        \"cmd_id\": \"light.on\"\n                    }\n                },\n                {\n                    \"type\": \"delay\",\n                    \"delay\": 400\n                },\n                {\n                    \"command\": {\n                        \"cmd_id\": \"light.off\",\n                        \"entity_id\": \"hass.main.light.study_reading_light\"\n                    },\n                    \"type\": \"command\"\n                },\n                {\n                    \"command\": {\n                        \"cmd_id\": \"CHANNEL_DOWN\",\n                        \"entity_id\": \"05ba8c78-3104-4d38-945d-02f602ba632c\"\n                    },\n                    \"type\": \"command\"\n                }\n            ]\n        }\n\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/activities/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"activities",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{activity_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateActivity",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name2\": {\n        \"en\": \"light {{$randomProductAdjective}}\"\n    },\n    \"icon\": \"uc:{{$randomProductMaterial}}\",\n    \"description\": {\n        \"en\": \"{{$randomLoremSentence}}\"\n    },\n    \"options\": {\n        \"entity_ids\": [\n            \"hass.main.light.study_reading_light\"\n        ],\n        \"sequences\": {\n            \"off\": [],\n            \"on\": [\n                {\n                    \"type\": \"command\",\n                    \"command\": {\n                        \"entity_id\": \"hass.main.light.study_reading_light\",\n                        \"cmd_id\": \"light.on\"\n                    }\n                },\n                {\n                    \"type\": \"delay\",\n                    \"delay\": 400\n                }\n            ]\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/activities/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"activities",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{activity_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteActivity",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/activities/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"activities",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{activity_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "macros",
+			"item": [
+				{
+					"name": "getMacroCount",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.test(\"pagination-count header is present\", function () {",
+									"    pm.response.to.have.header(\"pagination-count\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "HEAD",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/macros",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"macros"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getMacros",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"const responseJson = pm.response.json();",
+									"postman.setEnvironmentVariable(\"macro_id\", responseJson[0].entity_id);",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/macros?page=1&limit=100",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"macros"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "1"
+								},
+								{
+									"key": "limit",
+									"value": "100"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "createMacro",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Successful POST request\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([201, 202]);",
+									"});",
+									"",
+									"const responseJson = pm.response.json();",
+									"postman.setEnvironmentVariable(\"macro_id\", responseJson.entity_id);",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": {\n        \"en\": \"{{$randomFirstName}} comes home\"\n    },\n    \"icon\": \"uc:{{$randomColor}}\",\n    \"description\": {\n        \"en\": \"{{$randomCatchPhrase}}\"\n    }\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/macros",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"macros"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "createMacro with entities",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Successful POST request\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([201, 202]);",
+									"});",
+									"",
+									"const responseJson = pm.response.json();",
+									"postman.setEnvironmentVariable(\"macro_id\", responseJson.entity_id);",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": {\n        \"en\": \"{{$randomFirstName}} comes home\"\n    },\n    \"icon\": \"uc:{{$randomColor}}\",\n    \"description\": {\n        \"en\": \"{{$randomCatchPhrase}}\"\n    },\n    \"options\": {\n        \"entity_ids\": [ \"88567410-e60a-496d-9e2f-53abd2eba81e\" ]\n    }\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/macros",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"macros"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteAllMacros",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/macros",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"macros"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getMacro",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/macros/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"macros",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{macro_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateMacro",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": { \"en\": \"macro {{$randomProductAdjective}}\" },\n    \"icon\": \"uc:{{$randomProductMaterial}}\",\n    \"description\": { \"en\": \"{{$randomLoremSentence}}\"}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/macros/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"macros",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{macro_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateMacro sequence invalid entity",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"options\": {\n        \"sequence\": [\n            {\n                \"type\": \"command\",\n                \"command\": {\n                    \"entity_id\": \"foobar\",\n                    \"cmd_id\": \"stop\"\n                }\n            }\n        ]\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/macros/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"macros",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{macro_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateMacro sequence",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"options\": {\n        \"sequence\": [\n            {\n                \"type\": \"command\",\n                \"command\": {\n                    \"entity_id\": \"{{remote_id}}\",\n                    \"cmd_id\": \"remote.on\"\n                }\n            },\n            {\n                \"type\": \"delay\",\n                \"delay\": 400\n            }\n        ]\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/macros/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"macros",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{macro_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateMacro included_entities",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"options\": {\n        \"entity_ids\": [\"{{remote_id}}\"]\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/macros/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"macros",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{macro_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteMacro",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/macros/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"macros",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{macro_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "remotes",
+			"item": [
+				{
+					"name": "ir",
+					"item": [
+						{
+							"name": "getRemoteIrDataSet",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/remotes/:entityId/ir",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"remotes",
+										":entityId",
+										"ir"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{remote_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getRemoteIrCode",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/remotes/:entityId/ir/:cmdId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"remotes",
+										":entityId",
+										"ir",
+										":cmdId"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{remote_id}}"
+										},
+										{
+											"key": "cmdId",
+											"value": "BACK"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateRemoteIrCode",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"value\": \"0000,006e,0022,0002,0155,00ac,0015,0015,0015,0041,0015,0041,0015,0041,0015,0015,0015,0041,0015,0041,0015,0041,0015,0041,0015,0041,0015,0041,0015,0015,0015,0015,0015,0015,0015,0015,0015,0041,0015,0041,0015,0041,0015,0015,0015,0015,0015,0015,0015,0015,0015,0015,0015,0015,0015,0041,0015,0041,0015,0015,0015,0015,0015,0015,0015,0041,0015,0015,0015,0015,0015,05e4,0155,0055,0015,0e40\",\n    \"format\": \"PRONTO\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/remotes/:entityId/ir/:cmdId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"remotes",
+										":entityId",
+										"ir",
+										":cmdId"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{remote_id}}"
+										},
+										{
+											"key": "cmdId",
+											"value": "BACK"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "addRemoteIrCode",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"value\": \"0000,006e,0022,0002,0155,00ac,0015,0015,0015,0041,0015,0041,0015,0041,0015,0015,0015,0041,0015,0041,0015,0041,0015,0041,0015,0041,0015,0041,0015,0015,0015,0015,0015,0015,0015,0015,0015,0041,0015,0041,0015,0041,0015,0015,0015,0015,0015,0015,0015,0015,0015,0015,0015,0015,0015,0041,0015,0041,0015,0015,0015,0015,0015,0015,0015,0041,0015,0015,0015,0015,0015,05e4,0155,0055,0015,0e40\",\n    \"format\": \"PRONTO\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/remotes/:entityId/ir/:cmdId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"remotes",
+										":entityId",
+										"ir",
+										":cmdId"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{remote_id}}"
+										},
+										{
+											"key": "cmdId",
+											"value": "TEST"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "deleteOrResetRemoteIrCode",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/remotes/:entityId/ir/:cmdId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"remotes",
+										":entityId",
+										"ir",
+										":cmdId"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{remote_id}}"
+										},
+										{
+											"key": "cmdId",
+											"value": "BACK"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "buttons",
+					"item": [
+						{
+							"name": "getRemoteButtonMappings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"postman.setEnvironmentVariable(\"button\", responseJson[0].button);",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/remotes/:entityId/buttons",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"remotes",
+										":entityId",
+										"buttons"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{remote_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "resetRemoteButtonMappings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/remotes/:entityId/buttons",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"remotes",
+										":entityId",
+										"buttons"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{remote_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getRemoteButtonMapping",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/remotes/:entityId/buttons/:button",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"remotes",
+										":entityId",
+										"buttons",
+										":button"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{remote_id}}"
+										},
+										{
+											"key": "button",
+											"value": "{{button}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateRemoteButtonMapping",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"short_press\": {\n    \"cmd_id\": \"BACK\"\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/remotes/:entityId/buttons/:button",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"remotes",
+										":entityId",
+										"buttons",
+										":button"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{remote_id}}"
+										},
+										{
+											"key": "button",
+											"value": "{{button}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "deleteRemoteButtonMapping",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/remotes/:entityId/buttons/:button",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"remotes",
+										":entityId",
+										"buttons",
+										":button"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{remote_id}}"
+										},
+										{
+											"key": "button",
+											"value": "{{button}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "ui",
+					"item": [
+						{
+							"name": "pages",
+							"item": [
+								{
+									"name": "page",
+									"item": [
+										{
+											"name": "getRemoteUiPage",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{SERVER}}/api/remotes/:entityId/ui/pages/:page",
+													"host": [
+														"{{SERVER}}"
+													],
+													"path": [
+														"api",
+														"remotes",
+														":entityId",
+														"ui",
+														"pages",
+														":page"
+													],
+													"variable": [
+														{
+															"key": "entityId",
+															"value": "{{remote_id}}"
+														},
+														{
+															"key": "page",
+															"value": "main"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "updateRemoteUiPage",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PATCH",
+												"header": [],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"name\": \"Test page\",\n    \"items\": [\n        {\n            \"type\": \"icon\",\n            \"icon\": \"uc:star\",\n            \"location\": {\n                \"x\": 1,\n                \"y\": 0\n            },\n            \"size\": {\n                \"width\": 2\n            }\n        },\n        {\n            \"type\": \"text\",\n            \"text\": \"OK\",\n            \"command\": {\n                \"cmd_id\": \"BACK\"\n            },\n            \"location\": {\n                \"x\": 3,\n                \"y\": 5\n            },\n            \"size\": {\n                \"width\": 1,\n                \"height\": 1\n            }\n        }\n    ]\n}",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{SERVER}}/api/remotes/:entityId/ui/pages/:page",
+													"host": [
+														"{{SERVER}}"
+													],
+													"path": [
+														"api",
+														"remotes",
+														":entityId",
+														"ui",
+														"pages",
+														":page"
+													],
+													"variable": [
+														{
+															"key": "entityId",
+															"value": "{{remote_id}}"
+														},
+														{
+															"key": "page",
+															"value": "main"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "deleteRemoteUiPage",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [],
+												"url": {
+													"raw": "{{SERVER}}/api/remotes/:entityId/ui/pages/:page",
+													"host": [
+														"{{SERVER}}"
+													],
+													"path": [
+														"api",
+														"remotes",
+														":entityId",
+														"ui",
+														"pages",
+														":page"
+													],
+													"variable": [
+														{
+															"key": "entityId",
+															"value": "{{remote_id}}"
+														},
+														{
+															"key": "page",
+															"value": "main"
+														}
+													]
+												}
+											},
+											"response": []
+										}
+									]
+								},
+								{
+									"name": "createRemoteUiPage",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"name\": \"Test\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/remotes/:entityId/ui/pages",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"remotes",
+												":entityId",
+												"ui",
+												"pages"
+											],
+											"variable": [
+												{
+													"key": "entityId",
+													"value": "{{remote_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "getRemoteUiPages",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/remotes/:entityId/ui/pages",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"remotes",
+												":entityId",
+												"ui",
+												"pages"
+											],
+											"variable": [
+												{
+													"key": "entityId",
+													"value": "{{remote_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "updateRemoteUiPageOrder",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PATCH",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"page_order\": [\"b99a3a0a-6859-4810-aae9-eff31043b980\", \"main\"]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/remotes/:entityId/ui/pages",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"remotes",
+												":entityId",
+												"ui",
+												"pages"
+											],
+											"variable": [
+												{
+													"key": "entityId",
+													"value": "{{remote_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "resetRemoteUiPages",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/remotes/:entityId/ui/pages",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"remotes",
+												":entityId",
+												"ui",
+												"pages"
+											],
+											"variable": [
+												{
+													"key": "entityId",
+													"value": "{{remote_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "getRemoteUi",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/remotes/:entityId/ui",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"remotes",
+										":entityId",
+										"ui"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{remote_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "deleteRemoteUi",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/remotes/:entityId/ui",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"remotes",
+										":entityId",
+										"ui"
+									],
+									"variable": [
+										{
+											"key": "entityId",
+											"value": "{{remote_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "getRemoteCount",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.test(\"pagination-count header is present\", function () {",
+									"    pm.response.to.have.header(\"pagination-count\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "HEAD",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/remotes",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"remotes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getRemotes",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"const responseJson = pm.response.json();",
+									"postman.setEnvironmentVariable(\"remote_id\", responseJson[0].entity_id);",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/remotes?page=1&limit=100",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"remotes"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "1"
+								},
+								{
+									"key": "limit",
+									"value": "100"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "createRemote with IR codeset",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Successful POST request\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([201, 202]);",
+									"});",
+									"",
+									"const responseJson = pm.response.json();",
+									"postman.setEnvironmentVariable(\"remote_id\", responseJson.entity_id);",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": {\n        \"en\": \"{{$randomFirstName}} super remote\"\n    },\n    \"icon\": \"uc:{{$randomColor}}\",\n    \"description\": {\n        \"en\": \"{{$randomCatchPhrase}}\"\n    },\n    \"codeset_id\": \"lg1\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/remotes",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"remotes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "createRemote with custom IR codeset",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Successful POST request\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([201, 202]);",
+									"});",
+									"",
+									"const responseJson = pm.response.json();",
+									"postman.setEnvironmentVariable(\"remote_id\", responseJson.entity_id);",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": {\n        \"en\": \"{{$randomFirstName}} super remote\"\n    },\n    \"icon\": \"uc:{{$randomColor}}\",\n    \"description\": {\n        \"en\": \"{{$randomCatchPhrase}}\"\n    },\n    \"codeset_id\": \"4bb87320-2025-4483-83e9-7aac07a26943\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/remotes",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"remotes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "createRemote with custom codeset - minimal",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Successful POST request\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([201, 202]);",
+									"});",
+									"",
+									"const responseJson = pm.response.json();",
+									"postman.setEnvironmentVariable(\"remote_id\", responseJson.entity_id);",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": {\n        \"en\": \"{{$randomFirstName}} super remote\"\n    },\n    \"icon\": \"uc:{{$randomColor}}\",\n    \"description\": {\n        \"en\": \"{{$randomCatchPhrase}}\"\n    },\n    \"custom_codeset\": {\n        \"device_name\": \"My device\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/remotes",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"remotes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "createRemote with custom codeset",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Successful POST request\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([201, 202]);",
+									"});",
+									"",
+									"const responseJson = pm.response.json();",
+									"postman.setEnvironmentVariable(\"remote_id\", responseJson.entity_id);",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": {\n        \"en\": \"{{$randomFirstName}} super remote\"\n    },\n    \"icon\": \"uc:{{$randomColor}}\",\n    \"description\": {\n        \"en\": \"{{$randomCatchPhrase}}\"\n    },\n    \"custom_codeset\": {\n        \"manufacturer_id\": \"custom\",\n        \"device_name\": \"My new TV\",\n        \"device_type\": \"television\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/remotes",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"remotes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "createRemote clone",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Successful POST request\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([201, 202]);",
+									"});",
+									"",
+									"const responseJson = pm.response.json();",
+									"//postman.setEnvironmentVariable(\"remote_id\", responseJson.entity_id);",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"pm.collectionVariables.set(\"remote\", pm.environment.get(\"remote_id\"));",
+									";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": {\n        \"en\": \"{{$randomFirstName}} clone remote\"\n    },\n    \"clone_from\": \"{{remote}}\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/remotes",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"remotes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteAllRemotes",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/remotes",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"remotes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getRemote",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/remotes/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"remotes",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{remote_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateRemote",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": {\n        \"en\": \"macro {{$randomProductAdjective}}\"\n    },\n    \"icon\": \"uc:{{$randomProductMaterial}}\",\n    \"description\": {\n        \"en\": \"{{$randomLoremSentence}}\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/remotes/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"remotes",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{remote_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateRemote Emitter output",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"options\": {\n        \"ir\": {\n            \"output\": {\n                \"device_id\": \"sim.1\",\n                \"port_id\": \"4\"\n            }\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/remotes/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"remotes",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{remote_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateRemote IR codeset",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"options\": {\n        \"ir\": {\n            \"codeset\": {\n                \"id\": \"lg1\"\n            }\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/remotes/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"remotes",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{remote_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteRemote",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/remotes/:entityId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"remotes",
+								":entityId"
+							],
+							"variable": [
+								{
+									"key": "entityId",
+									"value": "{{remote_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "profiles",
+			"item": [
+				{
+					"name": "groups - default profile",
+					"item": [
+						{
+							"name": "getGroupsInProfile",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const responseJson = pm.response.json();",
+											"postman.setEnvironmentVariable(\"group_id\", responseJson[0].group_id);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/groups?pin=1",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"groups"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1"
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "default"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "createGroup",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const responseJson = pm.response.json();",
+											"postman.setEnvironmentVariable(\"group_id\", responseJson.group_id);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"{{$randomCity}}\",\n    \"icon\": \"yio:test\",\n    \"entities\": [\n        \"light40\",\n        \"light41\",\n        \"light42\"\n    ],\n    \"description\": \"Just a test\"\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/groups",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"groups"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "default"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "createGroup duplicate entity_id",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"Unique entity_id test\",\n    \"icon\": \"yio:test\",\n    \"entities\": [\n        \"light40\",\n        \"light40\",\n        \"light42\"\n    ]\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/groups",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"groups"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "default"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateGroup",
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"Renamed\",\n    \"icon\": \"yio:owl\",\n    \"description\": \"This is a description\"\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/groups/:group_id",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"groups",
+										":group_id"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "default"
+										},
+										{
+											"key": "group_id",
+											"value": "{{group_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateGroup with Entities",
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"icon\": \"yio:owl\",\n    \"entities\": [\n        \"light43\",\n        \"light42\",\n        \"light41\"\n    ]\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/groups/:group_id",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"groups",
+										":group_id"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "default"
+										},
+										{
+											"key": "group_id",
+											"value": "{{group_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "pages - default profile",
+					"item": [
+						{
+							"name": "getPagesInProfile",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson[0].page_id) {",
+											"    postman.setEnvironmentVariable(\"page_id\", responseJson[0].page_id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/pages?pin=1",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"pages"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1"
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "default"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "createPage",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"postman.setEnvironmentVariable(\"page_id\", responseJson.page_id);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"{{$randomCity}}\",\n    \"items\": [\n        {\n            \"entity_id\": \"switch1\"\n        },\n        {\n            \"entity_id\": \"mediaplayer1\"\n        },\n        {\n            \"entity_id\": \"blind1\"\n        },\n        {\n            \"entity_id\": \"light10\"\n        },\n        {\n            \"group_id\": \"def:g3\"\n        },\n        {\n            \"group_id\": \"def:g2\"\n        },\n        {\n            \"group_id\": \"def:g1\"\n        }\n    ]\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/pages",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"pages"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "default"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getPage",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/pages/:pageId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"pages",
+										":pageId"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "default"
+										},
+										{
+											"key": "pageId",
+											"value": "{{page_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updatePage",
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"{{$randomBsBuzz}}\",\n    \"image\": \"img:bedroom\",\n    \"items\": [\n        {\n            \"entity_id\": \"switch1\"\n        },\n        {\n            \"group_id\": \"def:g3\"\n        },\n        {\n            \"entity_id\": \"blind1\"\n        },\n        {\n            \"entity_id\": \"light10\"\n        },\n        {\n            \"group_id\": \"def:g2\"\n        },\n        {\n            \"entity_id\": \"mediaplayer1\"\n        },\n        {\n            \"group_id\": \"def:g1\"\n        }\n    ]\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/pages/:pageId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"pages",
+										":pageId"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "default"
+										},
+										{
+											"key": "pageId",
+											"value": "{{page_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "deletePage",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/pages/:pageId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"pages",
+										":pageId"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "default"
+										},
+										{
+											"key": "pageId",
+											"value": "{{page_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "groups",
+					"item": [
+						{
+							"name": "getGroupsInProfile",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/groups?pin=1",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"groups"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1"
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "{{profile_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "createGroup",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"postman.setEnvironmentVariable(\"group_id\", responseJson.group_id);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"Test\",\n    \"icon\": \"yio:test\",\n    \"entities\": [\n        \"light40\",\n        \"light41\",\n        \"light42\"\n    ]\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/groups",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"groups"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "{{profile_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "createGroup duplicate entity_id",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"Unique entity_id test\",\n    \"icon\": \"yio:test\",\n    \"entities\": [\n        \"light40\",\n        \"light40\",\n        \"light42\"\n    ]\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/groups",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"groups"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "{{profile_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateGroup",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"{{$randomBsBuzz}}\",\n    \"icon\": \"yio:owl\",\n   \"entities\": [\n        \"light43\",\n        \"light42\",\n        \"light41\"\n    ]\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/groups/:group_id",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"groups",
+										":group_id"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "{{profile_id}}"
+										},
+										{
+											"key": "group_id",
+											"value": "{{group_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateGroup with duplicate entities",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"icon\": \"yio:owl\",\n    \"entities\": [\n        \"light43\",\n        \"light42\",\n        \"light42\"\n    ]\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/groups/:group_id",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"groups",
+										":group_id"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "{{profile_id}}"
+										},
+										{
+											"key": "group_id",
+											"value": "{{group_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "pages",
+					"item": [
+						{
+							"name": "getPagesInProfile",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"if (responseJson[0].page_id) {",
+											"    postman.setEnvironmentVariable(\"profile_id\", responseJson[0].page_id);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/pages?pin=1",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"pages"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1"
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "{{profile_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "createPage",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"postman.setEnvironmentVariable(\"page_id\", responseJson.page_id);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"{{$randomProductName}}\",\n    \"items\": [\n        {\n            \"entity_id\": \"switch1\"\n        },\n        {\n            \"entity_id\": \"mediaplayer1\"\n        },\n        {\n            \"group_id\": \"{{group_id}}\"\n        },\n        {\n            \"entity_id\": \"blind1\"\n        },\n        {\n            \"entity_id\": \"{{light_entity_id}}\"\n        }\n    ]\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/pages",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"pages"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "{{profile_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getPage",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/pages/:pageId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"pages",
+										":pageId"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "{{profile_id}}"
+										},
+										{
+											"key": "pageId",
+											"value": "{{page_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updatePage",
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"{{$randomBsBuzz}}\",\n    \"items\": [\n        {\n            \"entity_id\": \"switch1\"\n        },\n        {\n            \"entity_id\": \"mediaplayer1\"\n        },\n        {\n            \"entity_id\": \"blind1\"\n        },\n        {\n            \"entity_id\": \"{{light_entity_id}}\"\n        },\n        {\n            \"group_id\": \"{{group_id}}\"\n        }\n    ]\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/pages/:pageId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"pages",
+										":pageId"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "{{profile_id}}"
+										},
+										{
+											"key": "pageId",
+											"value": "{{page_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "deletePage",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/profiles/:profile/pages/:pageId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"profiles",
+										":profile",
+										"pages",
+										":pageId"
+									],
+									"query": [
+										{
+											"key": "pin",
+											"value": "1",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "profile",
+											"value": "{{profile_id}}"
+										},
+										{
+											"key": "pageId",
+											"value": "{{page_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "getProfiles",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"const responseJson = pm.response.json();",
+									"if (responseJson[0].profile_id) {",
+									"    postman.setEnvironmentVariable(\"profile_id\", responseJson[0].profile_id);",
+									"}",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/profiles",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"profiles"
+							],
+							"query": [
+								{
+									"key": "active",
+									"value": "false",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "switchProfiles",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/profiles?active_profile_id=default",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"profiles"
+							],
+							"query": [
+								{
+									"key": "active_profile_id",
+									"value": "default"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "createProfile",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"const responseJson = pm.response.json();",
+									"postman.setEnvironmentVariable(\"profile_id\", responseJson.profile_id);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"{{$randomFirstName}}\",\n    \"icon\": \"yio:{{$randomColor}}\",\n    \"description\": \"{{$randomCatchPhrase}}\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/profiles",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"profiles"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getProfile",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"Test\",\n    \"icon\": \"yio:rocket\",\n    \"description\": \"just testing\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/profiles/:profile",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"profiles",
+								":profile"
+							],
+							"variable": [
+								{
+									"key": "profile",
+									"value": "{{profile_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateProfile",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"{{$randomFirstName}}\",\n    \"icon\": \"uc:panda\",\n    \"update_pin\": false,\n    \"description\": \"update test\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/profiles/:profileId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"profiles",
+								":profileId"
+							],
+							"variable": [
+								{
+									"key": "profileId",
+									"value": "{{profile_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateProfile page order",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"Kusi\",\n  \"update_pin\": false,\n  \"pages\": [\n    \"33f0c925-8af6-4a98-a145-2ab17d73475c\",\n    \"2f713a9c-2baf-4f75-96e6-393a4dfce5b1\",\n    \"68cafdfb-45f0-4c98-929d-bafc5f0dd878\",\n    \"c897877b-547c-4a9c-ac25-9462c7aa47f1\",\n    \"2c4cb919-7d32-40bf-b9bd-d5619dd1367d\"\n  ]\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/profiles/:profileId",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"profiles",
+								":profileId"
+							],
+							"variable": [
+								{
+									"key": "profileId",
+									"value": "{{profile_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteProfile",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"Test\",\n    \"icon\": \"yio:rocket\",\n    \"description\": \"just testing\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SERVER}}/api/profiles/:profile",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"profiles",
+								":profile"
+							],
+							"variable": [
+								{
+									"key": "profile",
+									"value": "{{profile_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteAllProfiles !!! WARNING !!!",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/profiles",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"profiles"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "cfg",
+			"item": [
+				{
+					"name": "button",
+					"item": [
+						{
+							"name": "getButtonSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/button",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"button"
+									],
+									"query": [
+										{
+											"key": "default",
+											"value": "true",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateButtonSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"brightness\": 33,\n    \"auto_brightness\": false\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/button",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"button"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "device",
+					"item": [
+						{
+							"name": "getDeviceSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/device",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"device"
+									],
+									"query": [
+										{
+											"key": "default",
+											"value": "true",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateDeviceSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"Test device\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/device",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"device"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getDeviceButtonLayout",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/device/button_layout",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"device",
+										"button_layout"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getDeviceIconMapping",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/device/icon_mapping",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"device",
+										"icon_mapping"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "display",
+					"item": [
+						{
+							"name": "getDisplaySettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/display",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"display"
+									],
+									"query": [
+										{
+											"key": "default",
+											"value": "true",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateDisplaySettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"brightness\": 30,\n    \"auto_brightness\": false\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/display",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"display"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "entity",
+					"item": [
+						{
+							"name": "getEntityCommandMetadata",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/entity/commands",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"entity",
+										"commands"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "haptic",
+					"item": [
+						{
+							"name": "getHapticSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/haptic",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"haptic"
+									],
+									"query": [
+										{
+											"key": "default",
+											"value": "true",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateHapticSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"enabled\": false\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/haptic",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"haptic"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "localization",
+					"item": [
+						{
+							"name": "getLocalizationSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/localization",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"localization"
+									],
+									"query": [
+										{
+											"key": "default",
+											"value": "true",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getTimeZoneNames",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/localization/tz_names",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"localization",
+										"tz_names"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getLocalizationCountries",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/localization/countries",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"localization",
+										"countries"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getTranslations",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/localization/translations",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"localization",
+										"translations"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateLocalizationSettings",
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"language_code\": \"de_CH\",\n    \"country_code\": \"CH\",\n    \"time_zone\": \"Europe/Zurich\",\n    \"time_format_24h\": true,\n    \"measurement_unit\": \"METRIC\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/localization",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"localization"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "network",
+					"item": [
+						{
+							"name": "getNetworkSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/network",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"network"
+									],
+									"query": [
+										{
+											"key": "default",
+											"value": "true",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateNetworkSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"bt_enabled\": true,\n    \"wifi_enabled\": true\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/network",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"network"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "power_saving",
+					"item": [
+						{
+							"name": "getPowerSavingSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/power_saving",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"power_saving"
+									],
+									"query": [
+										{
+											"key": "default",
+											"value": "true",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updatePowerSavingSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"wakeup_sensitivity\": 2,\n    \"display_off_sec\": 5,\n    \"standby_sec\": 100\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/power_saving",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"power_saving"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "software_update",
+					"item": [
+						{
+							"name": "getSoftwareUpdateSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/software_update",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"software_update"
+									],
+									"query": [
+										{
+											"key": "default",
+											"value": "true",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateSoftwareUpdateSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"check_for_updates\": false,\n    \"auto_update\": false\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/software_update",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"software_update"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "sound",
+					"item": [
+						{
+							"name": "getSoundSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/sound",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"sound"
+									],
+									"query": [
+										{
+											"key": "default",
+											"value": "true",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateSoundSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"enabled\": false,\n    \"volume\": 30\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/sound",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"sound"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "voice_control",
+					"item": [
+						{
+							"name": "getVoiceControlSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/voice_control",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"voice_control"
+									],
+									"query": [
+										{
+											"key": "default",
+											"value": "true",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getVoiceAssistants",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/voice_control/voice_assistants",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"voice_control",
+										"voice_assistants"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "updateVoiceControlSettings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"microphone\": true,\n    \"enabled\": true,\n    \"voice_assistant\": \"None\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{SERVER}}/api/cfg/voice_control",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"cfg",
+										"voice_control"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "getAllSettings",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/cfg",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"cfg"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "resetAllSettings",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/cfg",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"cfg"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "system",
+			"item": [
+				{
+					"name": "wifi",
+					"item": [
+						{
+							"name": "scan",
+							"item": [
+								{
+									"name": "getScan",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/system/wifi/scan",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"system",
+												"wifi",
+												"scan"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "startScan",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/system/wifi/scan",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"system",
+												"wifi",
+												"scan"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "stopScan",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/system/wifi/scan",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"system",
+												"wifi",
+												"scan"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "networks",
+							"item": [
+								{
+									"name": "id",
+									"item": [
+										{
+											"name": "getWifiNetwork",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{SERVER}}/api/system/wifi/networks/:id",
+													"host": [
+														"{{SERVER}}"
+													],
+													"path": [
+														"api",
+														"system",
+														"wifi",
+														"networks",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "0"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "wifiNetworkCommand",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [],
+												"url": {
+													"raw": "{{SERVER}}/api/system/wifi/networks/:id?cmd=ENABLE",
+													"host": [
+														"{{SERVER}}"
+													],
+													"path": [
+														"api",
+														"system",
+														"wifi",
+														"networks",
+														":id"
+													],
+													"query": [
+														{
+															"key": "cmd",
+															"value": "ENABLE"
+														}
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "0"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "modifyWifiNetwork",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PATCH",
+												"header": [],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"password\": \"123\"\n}",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{SERVER}}/api/system/wifi/networks/:id",
+													"host": [
+														"{{SERVER}}"
+													],
+													"path": [
+														"api",
+														"system",
+														"wifi",
+														"networks",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "0"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "deleteWifiNetwork",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [],
+												"url": {
+													"raw": "{{SERVER}}/api/system/wifi/networks/:id",
+													"host": [
+														"{{SERVER}}"
+													],
+													"path": [
+														"api",
+														"system",
+														"wifi",
+														"networks",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "0"
+														}
+													]
+												}
+											},
+											"response": []
+										}
+									]
+								},
+								{
+									"name": "getAllWifiNetworks",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/system/wifi/networks",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"system",
+												"wifi",
+												"networks"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "addWifiNetwork",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"ssid\": \"My network\",\n    \"password\": \"secret1234\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/system/wifi/networks",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"system",
+												"wifi",
+												"networks"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "addWifiNetwork Guest",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"ssid\": \"Guest\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/system/wifi/networks",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"system",
+												"wifi",
+												"networks"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "deleteAllWifiNetworks",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/system/wifi/networks",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"system",
+												"wifi",
+												"networks"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "getWifiStatus",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/system/wifi",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"system",
+										"wifi"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "wifiCommand",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/system/wifi?cmd=ENABLE_ALL_NETWORKS",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"system",
+										"wifi"
+									],
+									"query": [
+										{
+											"key": "cmd",
+											"value": "ENABLE_ALL_NETWORKS"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "update",
+					"item": [
+						{
+							"name": "image",
+							"item": [
+								{
+									"name": "updateSystem",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/system/update/:id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"system",
+												"update",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "ucr2_rev1-v0.5.0-13-g95540365"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "getUpdateProgress",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/system/update/:id",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"system",
+												"update",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "ucr2_rev1-v0.5.0-13-g95540365"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "checkSystemUpdate",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/system/update",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"system",
+										"update"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "forceSystemUpdateCheck",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/system/update",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"system",
+										"update"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "getSystemInformation",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/system",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"system"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "executeSystemCommand",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/system?cmd=RESTART",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"system"
+							],
+							"query": [
+								{
+									"key": "cmd",
+									"value": "RESTART"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getFactoryResetToken",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/system/factory_reset",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"system",
+								"factory_reset"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "performFactoryReset",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{SERVER}}/api/system/factory_reset?token=1.2.3",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"system",
+								"factory_reset"
+							],
+							"query": [
+								{
+									"key": "token",
+									"value": "1.2.3"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "ir",
+			"item": [
+				{
+					"name": "codes",
+					"item": [
+						{
+							"name": "manufacturers",
+							"item": [
+								{
+									"name": "search",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/ir/codes/manufacturers?q=lg",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"codes",
+												"manufacturers"
+											],
+											"query": [
+												{
+													"key": "q",
+													"value": "lg"
+												},
+												{
+													"key": "page",
+													"value": "1",
+													"disabled": true
+												},
+												{
+													"key": "limit",
+													"value": "100",
+													"disabled": true
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "codeSetSearch",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/ir/codes/manufacturers/:manufacturer_id?q=tv",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"codes",
+												"manufacturers",
+												":manufacturer_id"
+											],
+											"query": [
+												{
+													"key": "q",
+													"value": "tv"
+												},
+												{
+													"key": "page",
+													"value": "1",
+													"disabled": true
+												},
+												{
+													"key": "limit",
+													"value": "1",
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "manufacturer_id",
+													"value": "lg"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "getCodeSet",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/ir/codes/manufacturers/:manufacturer_id/:codeset",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"codes",
+												"manufacturers",
+												":manufacturer_id",
+												":codeset"
+											],
+											"variable": [
+												{
+													"key": "manufacturer_id",
+													"value": "lg"
+												},
+												{
+													"key": "codeset",
+													"value": "lg1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "custom",
+							"item": [
+								{
+									"name": "getCodeSetCount",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "HEAD",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/ir/codes/custom",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"codes",
+												"custom"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "getCodeSets",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"const responseJson = pm.response.json();",
+													"postman.setEnvironmentVariable(\"device_id\", responseJson[0].device_id);",
+													"postman.setEnvironmentVariable(\"device_name\", responseJson[0].device);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/ir/codes/custom?page=1&limit=10",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"codes",
+												"custom"
+											],
+											"query": [
+												{
+													"key": "page",
+													"value": "1"
+												},
+												{
+													"key": "limit",
+													"value": "10"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "createCodeSet",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"});",
+													"",
+													"const responseJson = pm.response.json();",
+													"postman.setEnvironmentVariable(\"device_id\", responseJson.device_id);",
+													"postman.setEnvironmentVariable(\"device_name\", responseJson.device);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"manufacturer\": \"Denon\",\n    \"device\": \"AVR-X2700\",\n    \"device_type\": \"receiver\",\n    \"code_format\": \"PRONTO\",\n    \"codes\": [\n        {\n            \"key\": \"POWER_ON\",\n            \"value\": \"0000 006d 0000 0024 0157 00ac 0015,0015,0015,0015,0015,0040,0015,0015,0015,0015,0015,0015,0015,0015,0015,0015,0015,0040,0015,0040,0015,0015,0015,0040,0015,0040,0015,0040,0015,0040,0015,0040,0015,0015,0015,0015,0015,0040,0015,0015,0015,0015,0015,0015,0015,0040,0015,0040,0015,0040,0015,0040,0015,0015,0015,0040,0015,0040,0015,0040,0015,0015,0015,0015,0015,0689,0157,0056,0015,0e94\"\n        },\n        {\n            \"key\": \"POWER_OFF\",\n            \"value\": \"0000,006d,0000,0024,0157,00ab,0015,0015,0016,0015,0016,003f,0016,0015,0015,0016,0015,0015,0016,0015,0016,0015,0015,0040,0015,0040,0015,0015,0016,003f,0016,003f,0016,003f,0016,003f,0016,003f,0016,003f,0016,0015,0016,003f,0016,0015,0015,0015,0016,0015,0016,003f,0016,003f,0016,0015,0015,0040,0015,0015,0016,003f,0016,003f,0016,003f,0016,0015,0016,0015,0015,05fd,0156,0055,0016,0ee1\"\n        },\n        {\n            \"key\": \"VOLUME_UP\",\n            \"value\": \"0000,006c,0022,0002,015b,00ad,0016,0016,0016,0016,0016,0041,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0041,0016,0041,0016,0016,0016,0041,0016,0041,0016,0041,0016,0041,0016,0041,0016,0016,0016,0041,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0041,0016,0016,0016,0041,0016,0041,0016,0041,0016,0041,0016,0041,0016,0041,0016,05f7,015b,0057,0016,0e6c\"\n        },\n        {\n            \"key\": \"VOLUME_DOWN\",\n            \"value\": \"0000,006c,0022,0002,015b,00ad,0016,0016,0016,0016,0016,0041,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0041,0016,0041,0016,0016,0016,0041,0016,0041,0016,0041,0016,0041,0016,0041,0016,0041,0016,0041,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0016,0041,0016,0041,0016,0041,0016,0041,0016,0041,0016,0041,0016,05f7,015b,0057,0016,0e6c\"\n        }\n    ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/ir/codes/custom",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"codes",
+												"custom"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "updateCodeSet",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PATCH",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"device\": \"AVR-X2700\",\n    \"device_type\": \"receiver\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/ir/codes/custom/:codeset",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"codes",
+												"custom",
+												":codeset"
+											],
+											"variable": [
+												{
+													"key": "codeset",
+													"value": "{{device_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "getCodeSet",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/ir/codes/custom/:codeset",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"codes",
+												"custom",
+												":codeset"
+											],
+											"variable": [
+												{
+													"key": "codeset",
+													"value": "{{device_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "deleteCodeSet",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/ir/codes/custom/:codeset",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"codes",
+												"custom",
+												":codeset"
+											],
+											"variable": [
+												{
+													"key": "codeset",
+													"value": "{{device_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "deleteAllCodeSets",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/ir/codes/custom",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"codes",
+												"custom"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "addKey",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"format\": \"PRONTO\",\n    \"value\": \"0000,0068,0000,0010,0060,0018,0018,0018,0018,0018,0030,0018,0030,0018,0030,0018,0030,0018,0018,0018,0030,0018,0030,0018,0018,0018,0018,0018,0030,0018,0030,0018,0018,0018,0018,0318\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/ir/codes/custom/:codeset/:key",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"codes",
+												"custom",
+												":codeset",
+												":key"
+											],
+											"variable": [
+												{
+													"key": "codeset",
+													"value": "{{device_id}}"
+												},
+												{
+													"key": "key",
+													"value": "TEST"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "getCode",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/ir/codes/custom/:codeset/:key",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"codes",
+												"custom",
+												":codeset",
+												":key"
+											],
+											"variable": [
+												{
+													"key": "codeset",
+													"value": "{{device_id}}"
+												},
+												{
+													"key": "key",
+													"value": "TEST"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "updateCode",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"format\": \"PRONTO\",\n    \"value\": \"0000,0068,0000,0010,0060,0018,0018,0018,0018,0018,0030,0018,0030,0018,0030,0018,0030,0018,0018,0018,0030,0018,0030,0018,0018,0018,0018,0018,0030,0018,0030,0018,0018,0018,0018,0318\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/ir/codes/custom/:codeset/:key",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"codes",
+												"custom",
+												":codeset",
+												":key"
+											],
+											"variable": [
+												{
+													"key": "codeset",
+													"value": "{{device_id}}"
+												},
+												{
+													"key": "key",
+													"value": "TEST"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "deleteKey",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/ir/codes/custom/:codeset/:key",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"codes",
+												"custom",
+												":codeset",
+												":key"
+											],
+											"variable": [
+												{
+													"key": "codeset",
+													"value": "{{device_id}}"
+												},
+												{
+													"key": "key",
+													"value": "TEST"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "emitters",
+					"item": [
+						{
+							"name": "learn",
+							"item": [
+								{
+									"name": "getLearningStatus",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/ir/emitters/:emitterId/learn",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"emitters",
+												":emitterId",
+												"learn"
+											],
+											"variable": [
+												{
+													"key": "emitterId",
+													"value": "{{emitter_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "startLearning",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/ir/emitters/:emitterId/learn?timeout=10",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"emitters",
+												":emitterId",
+												"learn"
+											],
+											"query": [
+												{
+													"key": "timeout",
+													"value": "10"
+												}
+											],
+											"variable": [
+												{
+													"key": "emitterId",
+													"value": "{{emitter_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "stopLearning",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{SERVER}}/api/ir/emitters/:emitterId/learn",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"emitters",
+												":emitterId",
+												"learn"
+											],
+											"query": [
+												{
+													"key": "active",
+													"value": "true",
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "emitterId",
+													"value": "{{emitter_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "send",
+							"item": [
+								{
+									"name": "sendCommandOnEmitter",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"codeset_id\": \"sony1\",\n  \"cmd_id\": \"MUTE\",\n  \"port_id\": \"1\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/ir/emitters/:deviceId/send",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"emitters",
+												":deviceId",
+												"send"
+											],
+											"variable": [
+												{
+													"key": "deviceId",
+													"value": "{{emitter_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "sendCommandOnEmitter default port",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"codeset_id\": \"lg1\",\n  \"cmd_id\": \"POWER_ON\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/ir/emitters/:deviceId/send",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"emitters",
+												":deviceId",
+												"send"
+											],
+											"variable": [
+												{
+													"key": "deviceId",
+													"value": "{{emitter_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "sendProntoCodeOnEmitter default port",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"code\": \"0000,0068,0000,0010,0060,0018,0030,0018,0018,0018,0030,0018,0018,0018,0018,0018,0030,0018,0018,0018,0030,0018,0030,0018,0030,0018,0018,0018,0030,0018,0018,0018,0018,0018,0030,0318\",\n  \"format\": \"PRONTO\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/ir/emitters/:deviceId/send",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"emitters",
+												":deviceId",
+												"send"
+											],
+											"variable": [
+												{
+													"key": "deviceId",
+													"value": "{{emitter_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "sendProntoCodeOnEmitter",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"code\": \"0000,0068,0000,0010,0060,0018,0030,0018,0018,0018,0030,0018,0018,0018,0018,0018,0030,0018,0018,0018,0030,0018,0030,0018,0030,0018,0018,0018,0030,0018,0018,0018,0018,0018,0030,0318\",\n  \"format\": \"PRONTO\",\n  \"port_id\": \"1\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/ir/emitters/:deviceId/send",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"emitters",
+												":deviceId",
+												"send"
+											],
+											"variable": [
+												{
+													"key": "deviceId",
+													"value": "{{emitter_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "sendHexCodeOnEmitter",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"code\": \"3;0x20F0A956;32;0\",\n  \"format\": \"HEX\",\n  \"port_id\": \"1\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{SERVER}}/api/ir/emitters/:deviceId/send",
+											"host": [
+												"{{SERVER}}"
+											],
+											"path": [
+												"api",
+												"ir",
+												"emitters",
+												":deviceId",
+												"send"
+											],
+											"variable": [
+												{
+													"key": "deviceId",
+													"value": "{{emitter_id}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "getEmitterCount",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"pm.test(\"pagination-count header is present\", function () {",
+											"    pm.response.to.have.header(\"pagination-count\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "HEAD",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/ir/emitters",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"ir",
+										"emitters"
+									],
+									"query": [
+										{
+											"key": "active",
+											"value": "true",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getEmitters",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"const responseJson = pm.response.json();",
+											"postman.setEnvironmentVariable(\"emitter_id\", responseJson[0].device_id);",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/ir/emitters?active=true",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"ir",
+										"emitters"
+									],
+									"query": [
+										{
+											"key": "active",
+											"value": "true"
+										},
+										{
+											"key": "page",
+											"value": "2",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": "1",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "getEmitter",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{SERVER}}/api/ir/emitters/:emitterId",
+									"host": [
+										"{{SERVER}}"
+									],
+									"path": [
+										"api",
+										"ir",
+										"emitters",
+										":emitterId"
+									],
+									"query": [
+										{
+											"key": "active",
+											"value": "true",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "emitterId",
+											"value": "{{emitter_id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "WebSocket",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{SERVER}}/ws",
+					"host": [
+						"{{SERVER}}"
+					],
+					"path": [
+						"ws"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "SERVER",
+			"value": "http://localhost:{{http_port}}"
+		},
+		{
+			"key": "externalSystem",
+			"value": "homeassistant"
+		},
+		{
+			"key": "apiUsername",
+			"value": "admin",
+			"type": "string"
+		},
+		{
+			"key": "apiPassword",
+			"value": "SET_PWD_IN_CURRENT_VALUE"
+		},
+		{
+			"key": "extTokenID",
+			"value": "test-1"
+		},
+		{
+			"key": "http_port",
+			"value": "8080"
+		},
+		{
+			"key": "https_port",
+			"value": "8443"
+		},
+		{
+			"key": "apiKeyId",
+			"value": "SET_KEY_IN_CURRENT_VALUE",
+			"type": "string"
+		},
+		{
+			"key": "remote_id",
+			"value": ""
+		},
+		{
+			"key": "remote",
+			"value": ""
+		}
+	]
+}

--- a/core-api/websocket/README.md
+++ b/core-api/websocket/README.md
@@ -1,0 +1,24 @@
+# Remote Two WebSocket Core-API
+
+The Remote Two acts as server. Whenever the remote enters standby it may choose to disconnect open WebSocket sessions.
+It is up to the client to reconnect again.
+
+The Core-API is defined with [AsyncAPI](https://www.asyncapi.com/).
+
+- [AsyncAPI YAML definition](UCR2-asyncapi.yaml).
+- See [/doc folder](../../doc/README.md) for further API documentation and information.
+
+## API HTML documentation
+
+- View with [AsyncAPI Studio online tool](https://studio.asyncapi.com/?url=https://raw.githubusercontent.com/unfoldedcircle/core-api/main/core-api/websocket/UCR2-asyncapi.yaml).  
+  The link will directly load the yaml definition file from GitHub and display it together with the HTML documentation
+  in the browser.
+
+The [AsyncAPI generator tool](https://github.com/asyncapi/generator) transforms the API definition into other formats.
+
+The easiest way to generate the HTML documentation from the AsyncAPI definition is to use the official
+[asyncapi/generator Docker image](https://hub.docker.com/r/asyncapi/generator). You can also try to use the command line
+tool with the instructions provided from the generator tool.
+The provided Bash wrapper script [`create-html-docker.sh`](create-html-docker.sh) creates the html documentation in the
+`./html` sub folder.
+

--- a/core-api/websocket/UCR2-asyncapi.yaml
+++ b/core-api/websocket/UCR2-asyncapi.yaml
@@ -1,0 +1,9362 @@
+# TODO split into multiple files and share common models!
+# Unfortunately https://github.com/asyncapi/bundler wasn't usable 2022-01 and most AsyncAPI tooling can't handle
+# external references! :-(
+# This needs to be fixed first: https://github.com/asyncapi/bundler/issues/34
+# Otherwise we have to hack together something, since copying and pasting the shared definitions between the different
+# APIs makes no sense...
+asyncapi: 2.2.0
+id: 'urn:com:unfoldedcircle:core'
+info:
+  title: Remote Two WebSocket Core-API
+  version: '0.24.2-beta'
+  contact:
+    name: API Support
+    url: https://github.com/unfoldedcircle/core-api/issues
+  license:
+    name: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
+    url: https://creativecommons.org/licenses/by-sa/4.0/
+  description: |
+    **Work in progress** API definition of the Remote Two Core WebSocket API.
+    
+    API message status legend:
+    
+    | Icon | Description                                                                     |
+    |------|---------------------------------------------------------------------------------|
+    | 💡   | Idea, not yet official part of API definition.                                  |
+    | 🚧   | Planned feature and most likely not (fully) implemented in the initial release. |
+    | 👷   | API definition is work in progress, not ready yet for implementation.           |
+    | 🔍   | API definition review & implementation.                                         |
+    | 🧪   | API has been implemented in the Remote Two and is currently being tested.       |
+    | 🚀   | Ready to use - feedback welcomed.                                               |
+    
+    ## Overview
+
+    The Remote Two WebSockets Core-API allows you to interact with the Unfolded Circle remote-core application and take
+    full control of its features.
+    
+    The remote-core application acts as server. Whenever the remote enters standby it may choose to disconnect client
+    connections.
+    
+    The focus of the Core-API is to provide all functionality for the UI application and the web-configurator.  
+    It may also be used by other external systems and integration drivers, if specific configuration or interaction
+    features are required, which are not present in the Integration API.
+
+    ## 🚧 Missing Features
+    
+    **This API is a preview version and does not yet contain all functionality.**
+    
+    The following features will be continuously added (in no particular order):
+    
+    - Matching features of the REST Core-API (except file up & download):
+      - Activity management    
+      - Infrared code management
+    - Static network configuration
+    
+    Please check the [core-api GitHub issues](https://github.com/unfoldedcircle/core-api/issues) for the current state. 
+    
+    ## API Versioning
+    
+    The API is versioned according to [SemVer](https://semver.org/).  
+    The initial public release will be `1.0.0` once it is considered stable enough with some initial integration
+    implementations and developer examples.
+    
+    **Any major version zero (`0.y.z`) is for initial development and may change at any time!**  
+    I.e. backward compatibility for minor releases is not yet established, anything MAY change at any time!
+    We try avoiding it, but it might still happen...
+
+    ## WebSocket Connection
+    
+    ### Authentication
+
+    Interaction with the API requires an API-key, user account or a session cookie (see login operation in the
+    REST Core-API).
+    
+    If the session cookie is sent with the WebSocket upgrade request, the connection is automatically authenticated.
+    This is recommended when using a web browser as client.
+
+    #### Basic authentication
+    
+    A user account can be used with [basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication)
+    in the WebSocket upgrade.
+    
+    - Header name: `Authentication`.
+    - Value: `Basic ` + _base64 encoded value of ${username}:${password}_
+    
+    #### API-key authentication
+
+    If the session based login is not possible or the client needs to use an API-key, then the preferred way to
+    establish an authenticated WebSocket connection is to provide the API-key in the header of the WebSocket
+    connection.
+
+    - Header name: `API-KEY`.
+    - Value: _API key_
+    
+    API keys can be created with the REST API and the `auth/api_keys` endpoints.
+
+    #### Message based authentication 
+
+    If the client cannot provide the API-key in the connection setup (e.g. a web browser), the server will send the
+    `auth_required` message right after the connection is established.
+
+    - The client must reply with the `auth` message containing the API-key.
+
+      - All other messages will be ignored, until the client successfully authenticates itself.
+      - The server will close an unauthenticated connection after a timeout of 15 seconds.
+
+    - The server replies with the `authentication` event including the result code of the authentication.
+
+      - `200`: authentication succeeded, API can be used.
+      - `401`: invalid authentication and the connection will be closed.
+
+externalDocs:
+  description: Find out more about the Remote Two
+  url: 'https://www.unfoldedcircle.com/'
+defaultContentType: application/json
+
+servers:
+  test:
+    url: localhost:8080
+    protocol: ws
+    description: |
+      Local test server.
+    security:
+      - token: []
+      - basic: []
+  test-wss:
+    url: localhost:8443
+    protocol: wss
+    description: |
+      Local test server.
+    security:
+      - token: []
+      - basic: []
+# TODO enhance tags with `externalDocs` and url links once API is hosted in public repo
+tags:
+  - name: integration
+    description: Device adapter providing entities
+  - name: entity
+    description: Representation of a controllable device or thing
+  - name: profile
+    description: User profile handling to group and organize entities in the UI
+  - name: dock
+    description: Docking station management, discovery and infrared testing functions
+  - name: wifi
+    description: WiFi network management
+
+channels:
+  /ws:
+    publish:
+      description: |
+        Core-API for clients to interact with the remote.
+        
+      operationId: pubRemoteMessage
+      tags:
+        - name: core
+      message:
+        oneOf:
+          # --- common
+          - $ref: '#/components/messages/auth'
+          - $ref: '#/components/messages/ping'
+          # --- system commands
+          - $ref: '#/components/messages/version'
+          - $ref: '#/components/messages/system'
+          - $ref: '#/components/messages/system_cmd'
+          - $ref: '#/components/messages/get_factory_reset_token'
+          - $ref: '#/components/messages/factory_reset'
+          - $ref: '#/components/messages/set_api_access'
+          - $ref: '#/components/messages/get_api_access'
+          - $ref: '#/components/messages/check_system_update'
+          - $ref: '#/components/messages/update_system'
+          - $ref: '#/components/messages/get_system_update_progress'
+          - $ref: '#/components/messages/get_power_mode'
+          - $ref: '#/components/messages/set_power_mode'
+          # --- configuration handling
+          - $ref: '#/components/messages/reset_configuration'
+          - $ref: '#/components/messages/get_configuration'
+          - $ref: '#/components/messages/get_button_cfg'
+          - $ref: '#/components/messages/set_button_cfg'
+          - $ref: '#/components/messages/get_device_cfg'
+          - $ref: '#/components/messages/set_device_cfg'
+          - $ref: '#/components/messages/get_display_cfg'
+          - $ref: '#/components/messages/set_display_cfg'
+          - $ref: '#/components/messages/get_features_cfg'
+          - $ref: '#/components/messages/set_features_cfg'
+          - $ref: '#/components/messages/get_haptic_cfg'
+          - $ref: '#/components/messages/set_haptic_cfg'
+          - $ref: '#/components/messages/get_localization_cfg'
+          - $ref: '#/components/messages/set_localization_cfg'
+          - $ref: '#/components/messages/get_timezone_names'
+          - $ref: '#/components/messages/get_localization_countries'
+          - $ref: '#/components/messages/get_localization_languages'
+          - $ref: '#/components/messages/localization_languages'
+          - $ref: '#/components/messages/get_network_cfg'
+          - $ref: '#/components/messages/set_network_cfg'
+          - $ref: '#/components/messages/get_software_update_cfg'
+          - $ref: '#/components/messages/set_software_update_cfg'
+          - $ref: '#/components/messages/get_power_saving_cfg'
+          - $ref: '#/components/messages/set_power_saving_cfg'
+          - $ref: '#/components/messages/get_profile_cfg'
+          - $ref: '#/components/messages/set_profile_cfg'
+          - $ref: '#/components/messages/get_sound_cfg'
+          - $ref: '#/components/messages/set_sound_cfg'
+          - $ref: '#/components/messages/get_voice_control_cfg'
+          - $ref: '#/components/messages/set_voice_control_cfg'
+          - $ref: '#/components/messages/get_voice_assistants'
+
+#          - $ref: '#/components/messages/get_log_cfg'
+#          - $ref: '#/components/messages/set_log_cfg'
+          # --- entity handling
+          - $ref: '#/components/messages/get_entity_types'
+          - $ref: '#/components/messages/get_entity'
+          - $ref: '#/components/messages/get_entities'
+          - $ref: '#/components/messages/get_available_entities'
+          - $ref: '#/components/messages/get_entity_commands'
+          - $ref: '#/components/messages/get_entity_command_metadata'
+          - $ref: '#/components/messages/execute_entity_command'
+          - $ref: '#/components/messages/update_entity'
+          - $ref: '#/components/messages/delete_entity'
+          - $ref: '#/components/messages/delete_entities'
+
+          # --- Dock handling
+          - $ref: '#/components/messages/get_dock_count'
+          - $ref: '#/components/messages/get_docks'
+          - $ref: '#/components/messages/create_dock'
+          - $ref: '#/components/messages/delete_all_docks'
+          - $ref: '#/components/messages/get_dock'
+          - $ref: '#/components/messages/update_dock'
+          - $ref: '#/components/messages/dock_connection_command'
+          - $ref: '#/components/messages/delete_dock'
+          - $ref: '#/components/messages/dock_command'
+          - $ref: '#/components/messages/get_dock_discovery_status'
+          - $ref: '#/components/messages/start_dock_discovery'
+          - $ref: '#/components/messages/stop_dock_discovery'
+          - $ref: '#/components/messages/get_dock_discovery_device'
+          - $ref: '#/components/messages/exec_cmd_on_discovered_dock'
+          - $ref: '#/components/messages/get_dock_setup_processes'
+          - $ref: '#/components/messages/create_dock_setup'
+          - $ref: '#/components/messages/stop_all_dock_setups'
+          - $ref: '#/components/messages/get_dock_setup_status'
+          - $ref: '#/components/messages/start_dock_setup'
+          - $ref: '#/components/messages/stop_dock_setup'
+
+          # --- IR handling
+#          - $ref: '#/components/messages/ir_send'
+#          - $ref: '#/components/messages/ir_learn'
+#          - $ref: '#/components/messages/ir_get_commands'
+#          - $ref: '#/components/messages/ir_add_cmd'
+#          - $ref: '#/components/messages/ir_update_cmd'
+#          - $ref: '#/components/messages/ir_remove_cmd'
+
+          # --- WiFi handling
+          - $ref: '#/components/messages/get_wifi_status'
+          - $ref: '#/components/messages/wifi_command'
+          - $ref: '#/components/messages/wifi_scan_start'
+          - $ref: '#/components/messages/wifi_scan_stop'
+          - $ref: '#/components/messages/get_wifi_scan_status'
+          - $ref: '#/components/messages/get_all_wifi_networks'
+          - $ref: '#/components/messages/add_wifi_network'
+          - $ref: '#/components/messages/del_all_wifi_networks'
+          - $ref: '#/components/messages/get_wifi_network'
+          - $ref: '#/components/messages/update_wifi_network'
+          - $ref: '#/components/messages/wifi_network_command'
+          - $ref: '#/components/messages/del_wifi_network'
+
+    subscribe:
+      description: Core-API for clients to receive messages from the remote.
+      operationId: subRemoteMessage
+      tags:
+        - name: core
+      message:
+        oneOf:
+          # --- common
+          - $ref: '#/components/messages/auth_required'
+          - $ref: '#/components/messages/authentication'
+          - $ref: '#/components/messages/pong'
+          - $ref: '#/components/messages/result'
+          # --- system commands
+          - $ref: '#/components/messages/version_info'
+          - $ref: '#/components/messages/system_info'
+          - $ref: '#/components/messages/factory_reset_token'
+          - $ref: '#/components/messages/api_access'
+          - $ref: '#/components/messages/system_update_info'
+          - $ref: '#/components/messages/get_power_mode'
+          - $ref: '#/components/messages/get_ambient_light'
+          # --- configuration handling
+          - $ref: '#/components/messages/configuration'
+          - $ref: '#/components/messages/button_cfg'
+          - $ref: '#/components/messages/device_cfg'
+          - $ref: '#/components/messages/display_cfg'
+          - $ref: '#/components/messages/haptic_cfg'
+          - $ref: '#/components/messages/localization_cfg'
+          - $ref: '#/components/messages/timezone_names'
+          - $ref: '#/components/messages/localization_countries'
+          - $ref: '#/components/messages/get_localization_languages'
+          - $ref: '#/components/messages/localization_languages'
+          - $ref: '#/components/messages/network_cfg'
+          - $ref: '#/components/messages/software_update_cfg'
+          - $ref: '#/components/messages/power_saving_cfg'
+          - $ref: '#/components/messages/profile_cfg'
+          - $ref: '#/components/messages/sound_cfg'
+          - $ref: '#/components/messages/voice_control_cfg'
+          - $ref: '#/components/messages/voice_assistants'
+
+#          - $ref: '#/components/messages/log_cfg'
+          # --- entity handling
+          - $ref: '#/components/messages/entity_types'
+          - $ref: '#/components/messages/entities'
+          - $ref: '#/components/messages/available_entities'
+          - $ref: '#/components/messages/entity_commands'
+          - $ref: '#/components/messages/entity'
+
+          # --- Dock handling
+          - $ref: '#/components/messages/dock_count'
+          - $ref: '#/components/messages/docks'
+          - $ref: '#/components/messages/dock'
+          - $ref: '#/components/messages/dock_discovery_status'
+          - $ref: '#/components/messages/dock_discovery_device'
+          - $ref: '#/components/messages/dock_system_info'
+          - $ref: '#/components/messages/dock_setup_processes'
+          - $ref: '#/components/messages/dock_setup_status'
+
+          # --- IR handling
+#          - $ref: '#/components/messages/ir_learned_code'
+#          - $ref: '#/components/messages/ir_commands'
+
+          # --- WiFi handling
+          - $ref: '#/components/messages/wifi_status'
+          - $ref: '#/components/messages/wifi_scan_status'
+          - $ref: '#/components/messages/wifi_networks'
+          - $ref: '#/components/messages/wifi_network'
+
+  /intg:
+    publish:
+      description: |
+        Integration driver and instance management.
+        
+        ⚠️ Attention: this is NOT a different WebSocket endpoint! It is purely used for logical grouping of all
+        integration driver and instance related messages in the documentation!
+        These messages are all available in the core `/ws` endpoint.
+      operationId: pubIntegrationMessage
+      tags:
+        - name: integrations
+      message:
+        oneOf:
+          # --- integration handling
+          - $ref: '#/components/messages/get_integration_status'
+          - $ref: '#/components/messages/integration_cmd'
+          - $ref: '#/components/messages/integration_driver_cmd'
+
+          - $ref: '#/components/messages/get_integration_driver_count'
+          - $ref: '#/components/messages/get_integration_drivers'
+          - $ref: '#/components/messages/register_integration_driver'
+          - $ref: '#/components/messages/get_integration_driver'
+          - $ref: '#/components/messages/update_integration_driver'
+          - $ref: '#/components/messages/delete_integration_driver'
+
+          - $ref: '#/components/messages/get_integration_count'
+          - $ref: '#/components/messages/get_integrations'
+          - $ref: '#/components/messages/create_integration'
+          - $ref: '#/components/messages/get_integration'
+          - $ref: '#/components/messages/update_integration'
+          - $ref: '#/components/messages/delete_integration'
+
+          - $ref: '#/components/messages/configure_entity_from_integration'
+          - $ref: '#/components/messages/configure_entities_from_integration'
+
+          # --- integration discovery
+          - $ref: '#/components/messages/get_integration_discovery_status'
+          - $ref: '#/components/messages/start_integration_discovery'
+          - $ref: '#/components/messages/stop_integration_discovery'
+          - $ref: '#/components/messages/get_discovered_integration_driver'
+          - $ref: '#/components/messages/get_discovered_intg_driver_metadata'
+          - $ref: '#/components/messages/configure_discovered_integration_driver'
+
+          # --- integration setup
+          - $ref: '#/components/messages/get_integration_setup_processes'
+          - $ref: '#/components/messages/setup_integration'
+          - $ref: '#/components/messages/stop_all_integration_setups'
+          - $ref: '#/components/messages/get_integration_setup_status'
+          - $ref: '#/components/messages/set_integration_user_data'
+          - $ref: '#/components/messages/stop_integration_setup'
+  
+    subscribe:
+      description: |
+        ⚠️ Attention: this is NOT a different WebSocket endpoint! It is purely used for logical grouping of all
+        integration driver and instance related messages in the documentation!
+        These messages are all available in the core `/ws` endpoint.
+      operationId: subIntegrationMessage
+      tags:
+        - name: integrations
+      message:
+        oneOf:
+          # --- integration handling
+          - $ref: '#/components/messages/integration_status'
+          - $ref: '#/components/messages/integration_driver_count'
+          - $ref: '#/components/messages/integration_drivers'
+          - $ref: '#/components/messages/integration_driver'
+          - $ref: '#/components/messages/integration_count'
+          - $ref: '#/components/messages/integrations'
+          - $ref: '#/components/messages/integration'
+
+          # --- integration discovery and setup
+          - $ref: '#/components/messages/integration_discovery_status'
+          - $ref: '#/components/messages/discovered_integration_driver'
+          - $ref: '#/components/messages/integration_setup_processes'
+          - $ref: '#/components/messages/integration_setup_info'
+
+  /profiles:
+    publish:
+      description: |
+        Profile management.
+        
+        ⚠️ Attention: this is NOT a different WebSocket endpoint! It is purely used for logical grouping of all profile
+        related messages in the documentation! These messages are all available in the core `/ws` endpoint.
+      operationId: pubProfileMessage
+      tags:
+        - name: profiles
+      message:
+        oneOf:
+          # --- profile handling
+          - $ref: '#/components/messages/get_profiles'
+          - $ref: '#/components/messages/get_profile'
+          - $ref: '#/components/messages/get_active_profile'
+          - $ref: '#/components/messages/switch_profile'
+          - $ref: '#/components/messages/add_profile'
+          - $ref: '#/components/messages/update_profile'
+          - $ref: '#/components/messages/delete_profile'
+          - $ref: '#/components/messages/delete_all_profiles'
+          # --- page handling
+          - $ref: '#/components/messages/get_pages'
+          - $ref: '#/components/messages/get_page'
+          - $ref: '#/components/messages/add_page'
+          - $ref: '#/components/messages/update_page'
+          - $ref: '#/components/messages/delete_page'
+          - $ref: '#/components/messages/delete_pages_in_profile'
+          # --- group handling
+          - $ref: '#/components/messages/get_groups'
+          - $ref: '#/components/messages/get_group'
+          - $ref: '#/components/messages/add_group'
+          - $ref: '#/components/messages/update_group'
+          - $ref: '#/components/messages/delete_group'
+          - $ref: '#/components/messages/delete_groups_in_profile'
+
+    subscribe:
+      description: |
+        ⚠️ Attention: this is NOT a different WebSocket endpoint! It is purely used for logical grouping of all profile
+        related messages in the documentation! These messages are all available in the core `/ws` endpoint.
+      operationId: subProfileMessage
+      tags:
+        - name: profiles
+      message:
+        oneOf:
+          # --- profile handling
+          - $ref: '#/components/messages/profile'
+          - $ref: '#/components/messages/profiles'
+          # --- page handling
+          - $ref: '#/components/messages/page'
+          - $ref: '#/components/messages/pages'
+          # --- group handling
+          - $ref: '#/components/messages/group'
+          - $ref: '#/components/messages/groups'
+
+  /events:
+    publish:
+      description: |
+        Notification signup for the client to receive event messages.
+        
+        ⚠️ Attention: this is NOT a different WebSocket endpoint! It is purely used for logical grouping of event
+        messages in the documentation! These messages are all available in the core `/ws` endpoint.
+      operationId: pubEventMessage
+      tags:
+        - name: events
+      message:
+        oneOf:
+          # --- event channels
+          - $ref: '#/components/messages/get_event_channels'
+          - $ref: '#/components/messages/subscribe_events'
+          - $ref: '#/components/messages/get_event_subscriptions'
+          - $ref: '#/components/messages/unsubscribe_events'
+          # TODO any more request messages?
+
+    subscribe:
+      description: |
+        Event messages for signed up channels.
+        
+        ⚠️ Attention: this is NOT a different WebSocket endpoint! It is purely used for logical grouping of event
+        messages in the documentation! These messages are all available in the core `/ws` endpoint.
+      operationId: subEventMessage
+      tags:
+        - name: events
+      message:
+        oneOf:
+          # --- event channels
+          - $ref: '#/components/messages/event_channels'
+          - $ref: '#/components/messages/event_subscriptions'
+          # --- event notifications
+          - $ref: '#/components/messages/warning'
+          - $ref: '#/components/messages/entity_change'
+          - $ref: '#/components/messages/activity_group_change'
+          - $ref: '#/components/messages/wifi_change'
+          - $ref: '#/components/messages/integration_driver_change'
+          - $ref: '#/components/messages/integration_change'
+          - $ref: '#/components/messages/integration_state'
+          - $ref: '#/components/messages/profile_change'
+          - $ref: '#/components/messages/configuration_change'
+          - $ref: '#/components/messages/ir_learning'
+          - $ref: '#/components/messages/dock_change'
+          - $ref: '#/components/messages/dock_state'
+          - $ref: '#/components/messages/dock_discovery'
+          - $ref: '#/components/messages/dock_setup_change'
+          - $ref: '#/components/messages/dock_update_change'
+          - $ref: '#/components/messages/integration_discovery'
+          - $ref: '#/components/messages/integration_setup_change'
+          - $ref: '#/components/messages/software_update'
+          - $ref: '#/components/messages/power_mode_change'
+          - $ref: '#/components/messages/battery_status'
+          - $ref: '#/components/messages/ambient_light_change'
+
+          # TODO define all events and response messages
+#          - $ref: '#/components/messages/log_event'
+#          - $ref: '#/components/messages/ui_notification'
+#          - $ref: '#/components/messages/log_cfg_change'
+#          - $ref: '#/components/messages/ui_cfg_change'
+#          # - $ref: '#/components/messages/ui_event'
+
+components:
+  securitySchemes:
+    token:
+      description: |
+        The API-key can be provided in header key `API-KEY`.
+        - If this header is not provided, the server will send the `auth_required` event after connection and the client
+        must authenticate with the `auth` message.
+      type: httpApiKey
+      in: header
+      name: API-KEY
+    basic:
+      description: |
+        To login with a user account, basic authentication can be used for the WebSocket upgrade. As an alternative,
+        a session based login with the REST API can be performed. The session cookie will automatically authenticate
+        the Websocket connection.
+      type: http
+      scheme: basic
+
+  # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  messages:
+    request:
+      summary: 🚀 Generic request message.
+      payload:
+        $ref: '#/components/schemas/commonReq'
+    response:
+      summary: 🚀 Generic response message.
+      payload:
+        $ref: '#/components/schemas/commonResp'
+    event:
+      summary: 🚀 Generic event message of a subscribed channel.
+      payload:
+        $ref: '#/components/schemas/commonEvent'
+    auth_required:
+      summary: 🧪 Authentication request event after connection is established.
+      description: |
+        This event is only sent if the client didn't provide authentication during connection setup.  
+        The client must then authenticate with the `auth` request message.
+      payload:
+        $ref: '#/components/schemas/authRequiredEvent'
+    auth:
+      summary: 🧪 Authenticate a connection.
+      description: |
+        Sent by the client right after establishing a connection if header authentication cannot be used, or after an 
+        `auth_required` request by the server.
+      payload:
+        $ref: '#/components/schemas/authRequestMsg'
+      x-response:
+        $ref: '#/components/messages/authentication'
+    authentication:
+      summary: 🧪 Authentication response.
+      description: |
+        The authentication result is provided in the `code` attribute:
+        - `200`: success, API can be used and message requests are accepted.
+        - `401`: authentication failed, the provided API-key is not valid. The server will close the connection.
+      payload:
+        $ref: '#/components/schemas/authMsg'
+    ping:
+      summary: 🚀 Application level based ping to determine whether connection is alive.
+      description: |
+        Client can ping the server to determine whether connection is alive. Server responds with pong.
+        
+        This is an application level ping as opposed to the standard WebSocket ping frames. This is only required if a
+        client framework doesn't support WebSocket ping frames!  
+        Additional payload data may be included in `msg_data` which will be echoed by the server.
+        E.g. a client timestamp to calculate round trip times.
+      payload:
+        $ref: '#/components/schemas/ping'
+      x-response:
+        $ref: '#/components/messages/pong'
+    pong:
+      summary: 🚀 Pong is a response to ping message
+      description: |
+        Server pong response to a ping to determine whether connection is alive.
+        This is an application level pong as opposed to default pong in websockets standard which is sent by client in
+        response to a ping.
+      payload:
+        $ref: '#/components/schemas/pong'
+    result:
+      summary: 🚀 Command result message
+      payload:
+        $ref: '#/components/schemas/commonResp'
+      examples:
+        - payload:
+            kind: resp
+            req_id: 123
+            msg: result
+            code: 200
+            msg_data: {}
+        - payload:
+            kind: resp
+            req_id: 124
+            msg: result
+            code: 400
+            msg_data:
+              code: "INV_ARGUMENT"
+              message: "Invalid argument. Foo must be a positive number."
+
+    # =========================================================================
+    # CORE-API MESSAGES
+    # =========================================================================
+
+    version:
+      summary: 🚀 Get version information.
+      payload:
+        $ref: '#/components/schemas/versionMsg'
+      x-response:
+        $ref: '#/components/messages/version_info'
+    version_info:
+      summary: 🧪 Version information response.
+      payload:
+        $ref: '#/components/schemas/versionInfoMsg'
+
+    system:
+      summary: 🚀 Get system information.
+      description: Get hardware information about the device like serial number, model number and hardware revision.
+      payload:
+        $ref: '#/components/schemas/getSystemInfoMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    system_info:
+      summary: 🧪 System information response.
+      payload:
+        $ref: '#/components/schemas/systemInfoMsg'
+    system_cmd:
+      summary: 🧪 Perform a system command like reboot or power-off.
+      description: |
+        The following system commands can be executed:
+        
+        - `STANDBY`: Put the device into standby mode.
+        - `REBOOT`: Reboot the device.
+        - `POWER_OFF`: Switch off the device
+        - `RESTART`: Restart all applications.
+        - `RESTART_UI`: Restart the ui application.
+        - `RESTART_CORE`: Restart the core service application.
+        
+        The server will respond with a `result` message and a status code of the request.  
+        For status code 200 the WebSocket connection will be closed and the command executed.
+      payload:
+        $ref: '#/components/schemas/systemCmdMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    get_factory_reset_token:
+      summary: Get factory reset token.
+      description: |
+        Get a factory reset token to perform a complete factory reset of the remote.
+
+        The token will be valid for 60 seconds. Afterwards, a new token must be requested.  
+        Whenever a new token is requested, any old tokens will be invalidated.
+      payload:
+        $ref: '#/components/schemas/getFactoryResetTokenMsg'
+      x-response:
+        $ref: '#/components/messages/factory_reset_token'
+    factory_reset_token:
+      summary: Factory reset token response.
+      payload:
+        $ref: '#/components/schemas/factoryResetTokenMsg'
+    factory_reset:
+      summary: Perform a factory reset.
+      description: |
+        A factory reset removes all configuration data and puts the device into a clean state.  
+
+        ⚠️ **Warning:** All user data will be erased and won't be recoverable!
+
+        A reset token must be requested first and provided to perform a factory reset.
+      payload:
+        $ref: '#/components/schemas/factoryResetMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    set_api_access:
+      summary: Enable or disable API access.
+      description: |
+        Enable / disable API access for web-configurator. If the account gets disabled, all active sessions are closed
+        and WebSocket connections disconnected.   
+        The server will respond with a `result` message and a status code of the request.
+      payload:
+        $ref: '#/components/schemas/setApiAccessMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    get_api_access:
+      summary: Get API access status.
+      description: |
+        The server will respond with an `api_access` message.
+      payload:
+        $ref: '#/components/schemas/getApiAccessMsg'
+      x-response:
+        $ref: '#/components/messages/api_access'
+    api_access:
+      summary: API access status response.
+      payload:
+        $ref: '#/components/schemas/apiAccessMsg'
+
+    check_system_update:
+      summary: 🧪 Check if system update is available.
+      description: |
+        Returns the known available system updates.
+
+        System update checks are run automatically (if not disabled in settings). Use the `force_update` flag to force
+        an update check.
+      payload:
+        $ref: '#/components/schemas/checkSystemUpdateMsg'
+      x-response:
+        $ref: '#/components/messages/system_update_info'
+    system_update_info:
+      summary: 🧪 Available system update response.
+      payload:
+        $ref: '#/components/schemas/systemUpdateInfoMsg'
+    update_system:
+      summary: 🔍 Perform system update.
+      description: |
+        Start a system update with the given `update_id` parameter. Use `latest` to use the latest available system update.
+
+        The system update will be started if:
+        - the system update has been downloaded already (`download` state is `DOWNLOADED`).
+        - the device has at least 50% battery charge.
+
+        If the system update is started, the response message contains `state: START`. In case there's not enough battery,
+        `503 service unavailable` is returned. 
+        It is recommended to perform the update while the remote is charging in the docking station.
+
+        The progress of the system update can be retrieved with the `get_system_update_progress` message, or by 
+        listening to the `software_update` event messages.
+
+        If the system update hasn't been downloaded yet (`download` state is `PENDING` or `ERROR`), this operation will only
+        start the download and return `state: DOWNLOAD`. Once successfully downloaded, it can be installed by this
+        message again.
+
+        ⚠️ Download progress events are not yet implemented!
+      payload:
+        $ref: '#/components/schemas/updateSystemMsg'
+      x-response:
+        $ref: '#/components/messages/update_system_result'
+    update_system_result:
+      summary: 🔍 System update response.
+      description: |
+        Returns the state of the system update request.
+      payload:
+        $ref: '#/components/schemas/updateSystemResultMsg'
+    get_system_update_progress:
+      summary: 🔍 Get system update progress.
+      description: |
+        This is a manual request for the update progress if the system update event messages cannot be used.
+      payload:
+        $ref: '#/components/schemas/getSystemUpdateProgressMsg'
+      x-response:
+        $ref: '#/components/messages/system_update_progress'
+    system_update_progress:
+      summary: 🔍 System update progress response.
+      payload:
+        $ref: '#/components/schemas/systemUpdateProgressMsg'
+
+    get_power_mode:
+      summary: 🔍 Get current power mode and battery information.
+      payload:
+        $ref: '#/components/schemas/getPowerModeMsg'
+      x-response:
+        $ref: '#/components/messages/power_mode'
+    power_mode:
+      summary: 🔍 Current power mode response.
+      payload:
+        $ref: '#/components/schemas/powerModeMsg'
+    set_power_mode:
+      summary: 🔍 Change the current power mode.
+      payload:
+        $ref: '#/components/schemas/setPowerModeMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    get_ambient_light:
+      summary: 🔍 Get current ambient light intensity.
+      payload:
+        $ref: '#/components/schemas/getAmbientLightMsg'
+      x-response:
+        $ref: '#/components/messages/ambient_light'
+    ambient_light:
+      summary: 🔍 Current ambient light response.
+      payload:
+        $ref: '#/components/schemas/ambientLightMsg'
+
+    reset_configuration:
+      summary: 🧪 Reset all settings to default values.
+      payload:
+        $ref: '#/components/schemas/resetConfigurationMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    get_configuration:
+      summary: 🧪 Get all system settings.
+      payload:
+        $ref: '#/components/schemas/getConfigurationMsg'
+      x-response:
+        $ref: '#/components/messages/configuration'
+    configuration:
+      summary: 🧪 All system settings response.
+      payload:
+        $ref: '#/components/schemas/configurationMsg'
+
+    get_button_cfg:
+      summary: 🧪 Get button settings.
+      payload:
+        $ref: '#/components/schemas/getButtonCfgMsg'
+      x-response:
+        $ref: '#/components/messages/button_cfg'
+    set_button_cfg:
+      summary: 🧪 Modify button settings.
+      payload:
+        $ref: '#/components/schemas/setButtonCfgMsg'
+      x-response:
+        $ref: '#/components/messages/button_cfg'
+    button_cfg:
+      summary: 🧪 Button settings response.
+      payload:
+        $ref: '#/components/schemas/buttonCfgMsg'
+
+    get_device_cfg:
+      summary: 🧪 Get remote device settings.
+      payload:
+        $ref: '#/components/schemas/getDeviceCfgMsg'
+      x-response:
+        $ref: '#/components/messages/device_cfg'
+    set_device_cfg:
+      summary: 🧪 Modify remote device settings.
+      payload:
+        $ref: '#/components/schemas/setDeviceCfgMsg'
+      x-response:
+        $ref: '#/components/messages/device_cfg'
+    device_cfg:
+      summary: 🧪 Remote device settings response.
+      payload:
+        $ref: '#/components/schemas/deviceCfgMsg'
+
+    get_display_cfg:
+      summary: 🧪 Get display settings.
+      payload:
+        $ref: '#/components/schemas/getDisplayCfgMsg'
+      x-response:
+        $ref: '#/components/messages/display_cfg'
+    set_display_cfg:
+      summary: 🧪 Modify display settings.
+      payload:
+        $ref: '#/components/schemas/setDisplayCfgMsg'
+      x-response:
+        $ref: '#/components/messages/display_cfg'
+    display_cfg:
+      summary: 🧪 Display settings response.
+      payload:
+        $ref: '#/components/schemas/displayCfgMsg'
+
+    get_features_cfg:
+      summary: 🧪 Get feature flag settings.
+      payload:
+        $ref: '#/components/schemas/getFeaturesCfgMsg'
+      x-response:
+        $ref: '#/components/messages/features_cfg'
+    set_features_cfg:
+      summary: 🧪 Modify a feature flag.
+      payload:
+        $ref: '#/components/schemas/setFeaturesCfgMsg'
+      x-response:
+        $ref: '#/components/messages/features_cfg'
+    features_cfg:
+      summary: 🧪 Feature flag settings response.
+      payload:
+        $ref: '#/components/schemas/featuresCfgMsg'
+
+    get_haptic_cfg:
+      summary: 🧪 Get haptic settings.
+      payload:
+        $ref: '#/components/schemas/getHapticCfgMsg'
+      x-response:
+        $ref: '#/components/messages/haptic_cfg'
+    set_haptic_cfg:
+      summary: 🧪 Modify haptic settings.
+      payload:
+        $ref: '#/components/schemas/setHapticCfgMsg'
+      x-response:
+        $ref: '#/components/messages/haptic_cfg'
+    haptic_cfg:
+      summary: 🧪 Haptic settings response.
+      payload:
+        $ref: '#/components/schemas/hapticCfgMsg'
+
+    get_localization_cfg:
+      summary: 🧪 Get localization settings.
+      payload:
+        $ref: '#/components/schemas/getLocalizationCfgMsg'
+      x-response:
+        $ref: '#/components/messages/localization_cfg'
+    set_localization_cfg:
+      summary: 🧪 Modify localization settings.
+      payload:
+        $ref: '#/components/schemas/setLocalizationCfgMsg'
+      x-response:
+        $ref: '#/components/messages/localization_cfg'
+    localization_cfg:
+      summary: 🧪 Localization settings response.
+      payload:
+        $ref: '#/components/schemas/localizationCfgMsg'
+    get_timezone_names:
+      summary: 🧪 Get all available time zone names.
+      payload:
+        $ref: '#/components/schemas/getTimezoneNamesMsg'
+      x-response:
+        $ref: '#/components/messages/timezone_names'
+    timezone_names:
+      summary: 🧪 Available time zone names response.
+      payload:
+        $ref: '#/components/schemas/timezoneNamesMsg'
+    get_localization_countries:
+      summary: 🧪 Get available countries for the localization configuration.
+      payload:
+        $ref: '#/components/schemas/getLocalizationCountriesMsg'
+      x-response:
+        $ref: '#/components/messages/localization_countries'
+    localization_countries:
+      summary: 🧪 Available localization countries response.
+      payload:
+        $ref: '#/components/schemas/localizationCountriesMsg'
+    get_localization_languages:
+      summary: 🧪 Get stored translations or request available translations from the UI.
+      description: |
+        The available translations are provided from the UI application.  
+        Future UI versions might provide new or updated translations.
+
+        If this request is sent to the UI application, the response is stored in the remote-core until new information
+        is available from the UI.
+        
+        If this request is received, the stored configuration from the UI application is returned. E.g. the
+        web-configurator requires the available translations.
+      payload:
+        $ref: '#/components/schemas/getLocalizationLanguagesMsg'
+      x-response:
+        $ref: '#/components/messages/localization_languages'
+    localization_languages:
+      summary: 🧪 Available translations response.
+      payload:
+        $ref: '#/components/schemas/localizationLanguagesMsg'
+
+    get_network_cfg:
+      summary: 🧪 Get network settings.
+      payload:
+        $ref: '#/components/schemas/getNetworkCfgMsg'
+      x-response:
+        $ref: '#/components/messages/network_cfg'
+    set_network_cfg:
+      summary: 🔍 Modify network settings.
+      description: |
+        Change one or multiple network settings.
+
+        ⚠️ The `ws` configuration object is an expert setting intended for support issues. Those settings may not be
+        exposed in a user frontend.
+        - The `ws` object is only returned, after it has been set manually.
+        - Settings stay persisted for PATCH requests not containing the `ws` key.
+        - Return and apply current system settings: send a PATCH request with an empty object: `"ws": {}".
+        - The `ws` settings can only be removed with a configuration reset: `DELETE /cfg`
+        - Modifying any `ws` settings requires a system reboot.
+      payload:
+        $ref: '#/components/schemas/setNetworkCfgMsg'
+      x-response:
+        $ref: '#/components/messages/network_cfg'
+    network_cfg:
+      summary: 🔍 Network settings response.
+      payload:
+        $ref: '#/components/schemas/networkCfgMsg'
+
+    get_software_update_cfg:
+      summary: 🧪 Get software update settings.
+      payload:
+        $ref: '#/components/schemas/getSoftwareUpdateCfgMsg'
+      x-response:
+        $ref: '#/components/messages/software_update_cfg'
+    set_software_update_cfg:
+      summary: 🧪 Modify software update settings.
+      description: |
+        Change one or multiple software update settings.
+
+        If `check_for_updates` is enabled:
+        - the device automatically checks for new updates daily. The check happens during a random time within the 
+          OTA window time frame `ota_window_start` - `ota_window_end`.
+        - if a new update is available, the update metadata is immediately downloaded and the firmware update file is
+          scheduled to download.
+        - the firmware file will only download if the remote has at least 50% battery charge.
+        - if the remote is not in the dock and suspended, the remote will not automatically wake up and the check
+          will be skipped.
+
+        If `auto_update` is enabled:
+        - once the firmware file is downloaded it will be automatically installed in the next OTA check window.
+        - the installation will only start if the remote has at least 50% battery charge.
+
+        OTA window fields:
+        - the stored values are used if omitted. 
+        - default values are set if not configured.
+        - the time of day corresponds to the configured timezone.
+        - for changing the update window, both start and end times are required, otherwise a default will be used.
+        - if the end time is before the start time, the window will spawn over midnight, e.g. `23:00:00` - `01:00:00`.
+
+        Optional software update channel & token:
+        - the default release channel is used if not configured.
+        - the stored values are used if omitted. 
+        - changing the update channel is intended for closed user groups only.  
+          ⚠️ High chance of breaking changes, bugs and loosing data!
+        - other channels than `default` might require an access token in `channel_token`.
+        - ⚠️ Changing the update channel or token requires a device restart, otherwise the automated updates will not use
+             the new channel!
+      payload:
+        $ref: '#/components/schemas/setSoftwareUpdateCfgMsg'
+      x-response:
+        $ref: '#/components/messages/software_update_cfg'
+    software_update_cfg:
+      summary: 🧪 Software update settings response.
+      payload:
+        $ref: '#/components/schemas/softwareUpdateCfgMsg'
+
+    get_power_saving_cfg:
+      summary: 🧪 Get power saving settings.
+      payload:
+        $ref: '#/components/schemas/getPowerSavingCfgMsg'
+      x-response:
+        $ref: '#/components/messages/power_saving_cfg'
+    set_power_saving_cfg:
+      summary: 🧪 Modify power saving settings.
+      payload:
+        $ref: '#/components/schemas/setPowerSavingCfgMsg'
+      x-response:
+        $ref: '#/components/messages/power_saving_cfg'
+    power_saving_cfg:
+      summary: 🧪 Power saving settings response.
+      payload:
+        $ref: '#/components/schemas/powerSavingCfgMsg'
+
+    get_profile_cfg:
+      summary: 🧪 Get profile settings.
+      payload:
+        $ref: '#/components/schemas/getProfileCfgMsg'
+      x-response:
+        $ref: '#/components/messages/profile_cfg'
+    set_profile_cfg:
+      summary: 🧪 Modify profile settings.
+      payload:
+        $ref: '#/components/schemas/setProfileCfgMsg'
+      x-response:
+        $ref: '#/components/messages/profile_cfg'
+    profile_cfg:
+      summary: 🧪 Profile settings response.
+      payload:
+        $ref: '#/components/schemas/profileCfgMsg'
+
+    get_sound_cfg:
+      summary: 🧪 Get sound settings.
+      payload:
+        $ref: '#/components/schemas/getSoundCfgMsg'
+      x-response:
+        $ref: '#/components/messages/sound_cfg'
+    set_sound_cfg:
+      summary: 🧪 Modify sound settings.
+      payload:
+        $ref: '#/components/schemas/setSoundCfgMsg'
+      x-response:
+        $ref: '#/components/messages/sound_cfg'
+    sound_cfg:
+      summary: 🧪 Sound settings response.
+      payload:
+        $ref: '#/components/schemas/soundCfgMsg'
+
+    get_voice_control_cfg:
+      summary: 🔍 Get voice control settings.
+      payload:
+        $ref: '#/components/schemas/getVoiceControlCfgMsg'
+      x-response:
+        $ref: '#/components/messages/voice_control_cfg'
+    set_voice_control_cfg:
+      summary: 🔍 Modify voice control settings.
+      payload:
+        $ref: '#/components/schemas/setVoiceControlCfgMsg'
+      x-response:
+        $ref: '#/components/messages/voice_control_cfg'
+    voice_control_cfg:
+      summary: 🔍 Voice control settings response.
+      payload:
+        $ref: '#/components/schemas/voiceControlCfgMsg'
+    get_voice_assistants:
+      summary: 🚧 Get available voice assistants.
+      payload:
+        $ref: '#/components/schemas/getVoiceAssistantsMsg'
+      x-response:
+        $ref: '#/components/messages/voice_assistants'
+    voice_assistants:
+      summary: 🚧 Voice assistants response.
+      payload:
+        $ref: '#/components/schemas/voiceAssistantsMsg'
+
+    # --- Entity handling
+
+    get_entity_types:
+      summary: 🧪 Retrieve supported entity types.
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/getEntityTypesMsg'
+      x-response:
+        $ref: '#/components/messages/entity_types'
+    entity_types:
+      summary: 🧪 List of supported entity types response.
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/entityTypesMsg'
+    get_entity:
+      summary: 🧪 Retrieve a configured entity.
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/getEntityMsg'
+      x-response:
+        $ref: '#/components/messages/entity'
+    get_entities:
+      summary: 🧪 Search and retrieve configured entities.
+      description: |
+        Returns all configured entities, optionally filtered by one or multiple entity types or integrations.
+        
+        The text search searches in the entity name, entity identifier and integration name.
+        
+        Attention: pagination is active and can be parameterized to return more items per page if required.
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/getEntitiesMsg'
+      x-response:
+        $ref: '#/components/messages/entities'
+    entities:
+      summary: 🧪 List of configured entities response.
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/entitiesMsg'
+    get_available_entities:
+      summary: 🧪 Retrieve the available entities provided by an integration.
+      description: |
+        ⚠️ At the moment it's only possible to retrieve available entities from one integration at a time.
+        
+        - **`filter.integration_id` must be specified!**
+        - available entities can be filtered by one or multiple entity types.
+        - the text search searches in the entity name, entity identifier and area.
+        
+        Attention: pagination is active and can be parameterized to return more items per page if required.
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/getAvailableEntitiesMsg'
+      x-response:
+        $ref: '#/components/messages/available_entities'
+    available_entities:
+      summary: 🧪 List of available entities response.
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/availableEntitiesMsg'
+    get_entity_commands:
+      summary: 🧪 Retrieve the available commands of an entity or entity type.
+      description: |
+        The commands can either be retrieved from a specific entity or from an entity type:
+        - `entity_id`: only available commands for the given entity are returned. This depends on the entity's features.
+        - `entity_type`: all commands for the given entity type are returned.
+        
+        The returned command identifiers are **not** the standard command identifiers like `on` or `off`, but _mapping_
+        identifiers like `light.on` and `light.color_temperature` for the command structure information returned with
+        `get_entity_command_metadata` or `GET /api/cfg/entity/commands`.  
+        
+        This then allows to build a full command request `execute_entity_command` message with or without parameters.
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/getEntityCommandsMsg'
+      x-response:
+        $ref: '#/components/messages/entity_commands'
+    entity_commands:
+      summary: 🧪 Available commands of an entity response.
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/entityCommandsMsg'
+    get_entity_command_metadata:
+      summary: 🔍 Get entity command definitions.
+      description: |
+        Meta-information about the entity commands.
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/getEntityCommandMetadataMsg'
+      x-response:
+        $ref: '#/components/messages/entity_command_metadata'
+    entity_command_metadata:
+      summary: 🔍 Entity command definitions.
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/entityCommandMetadataMsg'
+
+    execute_entity_command:
+      summary: 🧪 Execute an entity command.
+      description: |
+        Optional command data can be provided in attribute `params`.
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/executeEntityCommandMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    entity:
+      summary: 🧪 Entity information response.
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/entityMsg'
+    entity_change:
+      summary: 🧪 Entity change event.
+      description: |
+        Emitted if an entity has changed, a new entity has been added or a configured entity has been deleted.  
+        
+        If an entity state or dynamic attribute has changed (through notification of an integration driver), then only
+        the `attributes` object is included within `new_state`. This happens after an `entity_command` or if the entity
+        is updated manually through a user or an external system, e.g. if it has been switched off.
+        
+        If the entity definition has changed, e.g. the name, description or icon has been modified with the web
+        configurator, the full entity data is included within `new_state`.
+        
+        If a complete integration is removed then only an `integration_change` event is sent, i.e. there won't be
+        individual `entity_change` events for every removed entity!
+        
+        ⚠️ This event is also used to indicate the client to reload all entities. This is the case if only
+        `event_type: change` is set and the `entity_id` field is missing.
+      tags:
+        - name: entity
+        - name: event
+      payload:
+        $ref: '#/components/schemas/entityChangeEventMsg'
+    activity_group_change:
+      summary: 🧪 Activity group change event.
+      description: |
+        Emitted if an activity group has changed, a new group has been added or a group has been deleted.  
+        
+        ⚠️ This event is also used to indicate the client to reload all activity groups. This is the case if only
+        `event_type: change` is set and the `group_id` field is missing.
+      tags:
+        - name: entity
+        - name: event
+      payload:
+        $ref: '#/components/schemas/activityGroupChangeEventMsg'
+    update_entity:
+      summary: 🧪 Update an entity.
+      description: |
+        Update one or multiple properties of an entity.  
+
+        The updated entity object is returned if the entity could be updated.  
+        In case of an error the default `result` message is returned with an error code.
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/updateEntityMsg'
+      x-response:
+        $ref: '#/components/messages/entity'
+    delete_entity:
+      summary: 🧪 Remove a configured entity.
+      description: |
+        Delete the configured entity and remove it from all profile pages and groups.
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/deleteEntityMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    delete_entities:
+      summary: 🧪 Remove configured entities.
+      description: |
+        Unloads and deletes multiple configured entities, either by integration identifier or by entity identifiers.
+        If a deleted entity is still provided from an integration, it can be reused and will show up again as
+        available entity from its integration.
+    
+        ⚠️ An empty request body array will delete all configured entities!
+    
+        All references to the configured entities will be removed from profile pages and groups.
+        
+        This is a best effort operation:
+        - unknown entity identifiers are ignored, no error is returned
+
+        Deleted entities will trigger an `entity_change` event with `event_type: DELETE`. If a large amount of entities
+        are deleted, a single, generic `entity_change` event might be sent instead (without an `entity_id` field).
+      tags:
+        - name: entity
+      payload:
+        $ref: '#/components/schemas/deleteEntitiesMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    # --- Dock handling
+
+    get_dock_count:
+      summary: 🧪 Get total number of configured docks.
+      description: |
+        By default only active docks are counted. This can be changed with the `active` query parameter.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/getDockCountMsg'
+      x-response:
+        $ref: '#/components/messages/dock_count'
+    dock_count:
+      summary: 🧪 Total number of configured docks response.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/dockCountMsg'
+    get_docks:
+      summary: 🧪 List configured docks and their connection state.
+      description: |
+        Returns all dock configuration with paging. The configuration data is enriched with current connection information.
+        Use the `get_dock_count` operation to retrieve the total number of defined docking stations.
+
+        By default only active docks are returned. This can be changed with the `active` query parameter.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/getDocksMsg'
+      x-response:
+        $ref: '#/components/messages/docks'
+    docks:
+      summary: 🧪 Configured docks and their connection state response.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/docksMsg'
+    create_dock:
+      summary: 🧪 Create a new dock configuration.
+      description: |
+        Manually create and persist a new dock configuration. This is a low-level operation without configuring and setting
+        up the dock as with the `setup` operations! To establish a session to the dock, the connect operation must be
+        called afterwards.  
+        - Error `422` is returned if the given service name in `dock_id` already exists.
+        - If `custom_ws_url` is not specified, the dock address is resolved through an mDNS service name lookup in `dock_id`.   
+        - The `active` flag specifies if the dock will react to connection requests.
+        - Non-active docks will not auto-connect and must be enabled first to be used.
+        - Non-active docks won't be visible in the web-configurator.
+        - If no `token` is provided the default token is used! The token is used to authenticate the WebSocket
+          connection once a connection to the dock is established.
+        - If `model` is provided it must be one of the known dock model identifiers: `UCD2` or `YIO1DOCK`.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/createDockMsg'
+      x-response:
+        $ref: '#/components/messages/dock'
+    dock:
+      summary: 🧪 Configured dock response.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/dockMsg'
+    delete_all_docks:
+      summary: 🧪 Delete all dock configurations.
+      description: |
+        ⚠️ All defined dock configurations will be irrevocably deleted!
+
+        Active dock sessions will be disconnected and the persisted dock configurations removed.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/deleteAllDocksMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    get_dock:
+      summary: 🧪 Get dock configuration.
+      description: |
+        Returns the dock configuration, enriched with the current session information if a dock connection is established.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/getDockMsg'
+      x-response:
+        $ref: '#/components/messages/dock'
+    update_dock:
+      summary: 🧪 Change dock configuration like auto-connect or access token.
+      description: |
+        Update one or more dock fields.
+
+        - If the dock is in an `active` connection state, then the `name`, `token` and `wifi` values are persisted in the
+          dock if provided in the request. The request fails with `503` service unavailable if the configuration can't be
+          set in the docking station.
+        - An empty `custom_ws_url` value will remove the custom URL.
+        - If the dock is not active, the values are only stored in the remote. A changed `token` will be used for the next
+          connection attempt.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/updateDockMsg'
+      x-response:
+        $ref: '#/components/messages/dock'
+    dock_connection_command:
+      summary: 🧪 Start or stop a dock connection.
+      description: |
+        Establish or stop a session to a specific or all active docks.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/dockConnectionCommandMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    delete_dock:
+      summary: 🧪 Delete dock configuration.
+      description: |
+        ⚠️ The dock configuration will be irrevocably deleted!
+
+        An active dock session will be disconnected and the persisted dock configuration removed.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/deleteDockMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    dock_command:
+      summary: 🧪 Send a dock command.
+      description: |
+        The following `command` values are defined:
+        - `SET_LED_BRIGHTNESS`: set the maximum brightness of the front indicator LED. Set the `0..100` percentage as
+           string parameter in the `value` field.  
+        - `IDENTIFY`: identify the dock with blinking the indicator LED.
+        - `REMOTE_LOW_BATTERY`: trigger the low battery status indicator on the dock.
+        - `REMOTE_CHARGED`: trigger the remote charged indicator on the dock.
+        - `REMOTE_NORMAL`: trigger the normal remote operation mode on the dock.
+        - `REBOOT`: reboot the dock.
+        - `RESET`: ⚠️ factory reset the dock. Requires administrator privileges.  
+           The dock configuration will be deleted from the remote.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/dockCommandMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    get_dock_discovery_status:
+      summary: 🧪 Get docking station discovery status.
+      description: |
+        Returns the current discovery status and any discovered docks.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/getDockDiscoveryStatusMsg'
+      x-response:
+        $ref: '#/components/messages/dock_discovery_status'
+    dock_discovery_status:
+      summary: 🧪 Docking station discovery status response.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/dockDiscoveryStatusMsg'
+    start_dock_discovery:
+      summary: 🧪 Start discovery of new docking stations.
+      description: |
+        Start device discovery over Bluetooth and mDNS. Bluetooth or network discovery can be disabled with a query
+        parameter. By default the discovery automatically stops after 30 seconds. Use the `get_dock_discovery_status`
+        status request to check on discovered devices or `stop_dock_discovery` to stop discovery.
+
+        By default only new network devices are returned. If a dock is already configured it will be omitted from the
+        results, unless the query parameter `new=false` is set. Docks with Bluetooth enabled are always returned, since
+        this usually means that the dock needs to be re-configured.
+
+        - If BT is disabled in the remote, the `bt` parameter is ignored.
+        - Emits the WebSocket event `dock_discovery` with `event_type: START` when discovery starts.
+        - For each discovered device the WebSocket event `dock_discovery` with `event_type: DISCOVER` is emitted.
+        - This operation clears any old discovered devices and won't be accessible anymore with the GET operation.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/startDockDiscoveryMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    stop_dock_discovery:
+      summary: 🧪 Stop discovery of new docking stations.
+      description: |
+        Stops the device discovery. The current discovery status is returned in the response. Already discovered devices
+        won't be returned and can still be retrieved with the `get_dock_discovery_status` operation.
+
+        Emits the WebSocket event `dock_discovery` with `event_type: STOP`.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/stopDockDiscoveryMsg'
+      x-response:
+        $ref: '#/components/messages/dock_discovery_status'
+    get_dock_discovery_device:
+      summary: 🧪 Get docking station discovery device status.
+      description: |
+        Returns the discovered docking station device.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/getDockDiscoveryDeviceMsg'
+      x-response:
+        $ref: '#/components/messages/dock_discovery_device'
+    dock_discovery_device:
+      summary: 🧪 Docking station discovery device status response.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/dockDiscoveryDeviceMsg'
+    exec_cmd_on_discovered_dock:
+      summary: 🧪 Execute command on a discovered docking station.
+      description: |
+        Perform a WebSocket connection test with a discovered docking station. If the dock requires an API token, it must
+        be specified in the request body.  
+        The `IDENTIFY` command also blinks the status LED on the dock.
+
+        Response status codes:
+        - `200`: successful operation: the connection test was successful and docking station metadata could be retrieved.
+        - `404`: discovered dock with `dock_id` not found. Check if the discovery result is still available and has not
+                 been deleted. This can happen after a timeout since the discovery, or if the discovery result has been
+                 cleared with `DELETE /docks/discover`.
+        - `503`: docking station connection could not be established.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/execCmdOnDiscoveredDockMsg'
+      x-response:
+        $ref: '#/components/messages/dock_system_info'
+    dock_system_info:
+      summary: 🧪 Dock system information response.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/dockSystemInfoMsg'
+    get_dock_setup_processes:
+      summary: 🧪 Get current dock setup processes.
+      description: |
+        Return a list of all active setup process identifiers.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/getDockSetupProcessesMsg'
+      x-response:
+        $ref: '#/components/messages/dock_setup_processes'
+    dock_setup_processes:
+      summary: 🧪 Current dock setup processes response.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/dockSetupProcessesMsg'
+    create_dock_setup:
+      summary: 🧪 Start setting up a new docking station.
+      description: |
+        Create a new setup process from a discovered dock or from a manually provided dock address.
+
+        - If there's already a setup process running for the given dock id, status code `409` is returned.
+        - Emits the WebSocket event `dock_setup_change` with `event_type: START` when this operation returns `201`.
+
+        Start setup from dock discovery:
+        - The required request data can be obtained from the `/api/docks/discover` endpoints when searching for docking
+          stations over Bluetooth or Ethernet. Simply provide the returned `DockDiscovery` data object (which is a super
+          set of the required data to start a setup process).
+        - The returned `id` in the `DockSetupInfo` response will be the identifier for the next `PUT /docks/setup/:id`
+          call to provide additional data.
+
+        Manual setup:
+        - A dock identifier will automatically be created and returned in `DockSetupInfo`.
+        - The dock must be reachable on the network with the provided `custom_ws_url` and optional `token`. Otherwise,
+          status code `503` is returned.
+        - The setup process is automatically started after a successful POST request, no call to `PUT /docks/setup/:id`
+          is required.
+
+        Response status codes:
+        - `201`: setup process successfully started. Use `GET /docks/setup/:id` to poll for status updates, or listen to
+           WebSocket `dock_setup_change` event messages.
+        - `400`: invalid data in request body.
+        - `409`: a setup process is already running. Either wait until finished, or abort it.
+        - `503`: service not available to setup docking station.  
+           E.g. Bluetooth is disabled and therefore the docking station cannot be setup over Bluetooth. Either enable
+           Bluetooth or setup the dock over Ethernet.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/createDockSetupMsg'
+      x-response:
+        $ref: '#/components/messages/dock_setup_status'
+    dock_setup_status:
+      summary: 🧪 Dock setup information response.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/dockSetupStatusMsg'
+    stop_all_dock_setups:
+      summary: 🧪 Abort and remove all setup processes.
+      description: |
+        Stop all setup processes at the next possible operation and remove all setup process information.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/stopAllDockSetupsMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    get_dock_setup_status:
+      summary: 🧪 Get docking station setup status.
+      description: |
+        Poll operation to retrieve the current docking station setup state. See the `state` and `error` fields in the
+        response message. There are also WebSocket `dock_setup_change` event messages for state changes to avoid polling.
+
+        Defined setup states:
+        - `NEW`: setup has not yet been started. Use the `PUT` operation to provide the required data and to start setting up the dock.
+        - `CONFIGURING`: setup data is currently being transferred to the dock.
+        - `RESTARTING`: dock has been configured and is restarting to integrate into the network.
+        - `OK`: setup process has been completed successfully, the dock can now be used.
+        - `ERROR`: the setup process failed. Check the `error` field for more information.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/getDockSetupStatusMsg'
+      x-response:
+        $ref: '#/components/messages/dock_setup_status'
+    start_dock_setup:
+      summary: 🧪 Setup docking station.
+      description: |
+        Set required data to start the setup process and configure the docking station.
+        When using Bluetooth the WiFi network name and credentials must be provided to connect the dock to the WiFi network.
+
+        The `state` field in the response message indicate the current state of the setup process. Use the `GET` operation
+        to poll for state updates or listen to the corresponding WebSocket `dock_setup_change` event messages with
+        `event_type: SETUP`.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/startDockSetupMsg'
+      x-response:
+        $ref: '#/components/messages/dock_setup_status'
+    stop_dock_setup:
+      summary: 🧪 Abort the dock setup process.
+      description: |
+        Stop the setup process at the next possible operation and remove the setup process information.  
+        To start a new setup process, use the `POST /docks/setup` operation again.
+        
+        Emits the WebSocket event `dock_setup_change` with `event_type: STOP`.
+      tags:
+        - name: dock
+      payload:
+        $ref: '#/components/schemas/stopDockSetupMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    # --- WiFi handling
+
+    get_wifi_status:
+      summary: 🧪 Get WiFi status.
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiGetStatusMsg'
+      x-response:
+        $ref: '#/components/messages/wifi_status'
+    wifi_status:
+      summary: 🧪 WiFi status.
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiStatusMsg'
+
+    wifi_command:
+      summary: 🧪 WiFi connection handling.
+      description: |
+        Perform one of the following commands on the WLAN interface:
+
+        - `DISCONNECT`: Disconnect and wait for `REASSOCIATE` or `RECONNECT` command before connecting again.
+        - `RECONNECT`: Connect if disconnected (i.e. like `REASSOCIATE`, but only connect if in disconnected state).
+        - `REASSOCIATE`: Force reassociation.
+        - `ENABLE_ALL_NETWORKS`: Enable all network connections and start connecting to a network if in disconnected state.
+        - `DISABLE_ALL_NETWORKS`: Disable all network connections and disconnect if in connected state.
+
+        ⚠️Attention: `ENABLE_ALL_NETWORKS` and `DISABLE_ALL_NETWORKS` will persist the state! I.e. if all networks are 
+        disabled and the device is restarted afterwards, no WiFi connection will be established.
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiCommandMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    wifi_scan_start:
+      summary: 🧪 Start discovery of WiFi access points.
+      description: |
+        Request a new BSS scan. A scan usually takes a few seconds and the current state is returned with the
+        `get_wifi_scan_status` operation, together with the already found access points.
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiScanStartMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    wifi_scan_stop:
+      summary: 🧪 Stop discovery of WiFi access points.
+      description: |
+        Stops the access point discovery. The current discovery status is returned in the response.
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiScanStopMsg'
+      x-response:
+        $ref: '#/components/messages/wifi_scan_status'
+
+    get_wifi_scan_status:
+      summary: 🧪 Get discovered WiFi access points.
+      description: |
+        Returns the current discovery status and any discovered access points.
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiGetScanStatusMsg'
+      x-response:
+        $ref: '#/components/messages/wifi_scan_status'
+    wifi_scan_status:
+      summary: 🧪 Discovered WiFi access points.
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiScanStatusMsg'
+
+    get_all_wifi_networks:
+      summary: 🧪 Get configured WiFi networks.
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiGetAllNetworksMsg'
+      x-response:
+        $ref: '#/components/messages/wifi_networks'
+    wifi_networks:
+      summary: 🧪 Configured WiFi networks.
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiNetworksMsg'
+
+    add_wifi_network:
+      summary: 🧪 Create a new WiFi network configuration.
+      description: |
+        Add a new network configuration for the given SSID.  
+        For an open network without password the `password` field must be omitted (do not send an empty password value).
+
+        ⚠️ Only WPA-PSK (pre shared keys) and open networks are supported!
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiAddNetworkMsg'
+      x-response:
+        $ref: '#/components/messages/wifi_network'
+
+    del_all_wifi_networks:
+      summary: 🧪 Delete all configured WiFi networks.
+      description: |
+        Disconnects the WiFi network and removes all network configurations.
+
+        ⚠️ Attention: the network configuration is automatically persisted and the network configuration cannot
+        be retrieved anymore!
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiDelAllNetworksMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    get_wifi_network:
+      summary: 🧪 Get WiFi network configuration.
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiGetNetworkMsg'
+      x-response:
+        $ref: '#/components/messages/wifi_network'
+    wifi_network:
+      summary: 🧪 WiFi network configuration.
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiNetworkMsg'
+
+    update_wifi_network:
+      summary: 🧪 Change WiFi network configuration.
+      description: |
+        Set a new WiFi network password.
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiUpdateNetworkMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    wifi_network_command:
+      summary: 🧪WiFi network connection handling.
+      description: |
+        Perform one of the following commands on a network configuration:
+        - `ENABLE`: Enable a network. If no network is connected, it will be tried to connect to this network.
+        - `DISABLE`: Disable a network. If the network is currently connected it will be disconnected.
+        - `SELECT`: Select the given network and disable all others.
+
+        ⚠️ Attention: all network changes (enabled or disabled) are persisted!
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiNetworkCommandMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    del_wifi_network:
+      summary: 🧪 Delete a configured WiFi network.
+      description: |
+        The given network is removed from the configuration and disconnected if currently connected.
+
+        ⚠️ Attention: the network configuration is automatically persisted and the removed network configuration cannot
+        be retrieved anymore!
+      tags:
+        - name: wifi
+      payload:
+        $ref: '#/components/schemas/wifiDelNetworkMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    wifi_change:
+      summary: 🧪 WiFi change event.
+      description: |
+        Emitted if the WiFi status changed, e.g. connected or disconnected to an access point, or if a WiFi network
+        scan finished.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/wifiChangeEventMsg'
+
+    # --- Profile handling
+
+    get_profiles:
+      summary: 🧪 Retrieve all profiles.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/getProfilesMsg'
+      x-response:
+        $ref: '#/components/messages/profiles'
+    profiles:
+      summary: 🧪 List of available profiles response.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/profilesMsg'
+    get_profile:
+      summary: 🧪 Retrieve the specified profile.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/getProfileMsg'
+      x-response:
+        $ref: '#/components/messages/profile'
+    profile:
+      summary: 🧪 Profile data response.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/profileMsg'
+    get_active_profile:
+      summary: 🧪 Retrieve the active profile.
+      description: |
+        If no profile exists, or no profile is set active, 404 is returned.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/getActiveProfileMsg'
+      x-response:
+        $ref: '#/components/messages/profile'
+    switch_profile:
+      summary: 🧪 Switch active profile.
+      description: |
+        The administrator PIN in `admin_pin` is required to switch from a restricted to a normal profile.
+        If the current profile is a restricted profile and the pin is missing, error `401` is returned.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/switchProfileMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    add_profile:
+      summary: 🧪 Add a new profile.
+      description: |
+        There are two different types of profiles:
+
+        - Normal profile (default): can do anything, change settings, add pages, entities, integrations, etc.
+        - Restricted profile: intended for guests or children, who can only use the remote, but cannot change settings.
+      
+        The admin PIN is required to switch from a restricted to a normal profile. It can be defined in settings.
+    
+        - Switching away from a restricted profile will prompt the user to enter the admin PIN.
+        - Switching to a restricted profile can be done without entering the admin PIN.
+    
+        Profile request object:
+        
+        - `profile_id` is optional and auto-generated if not specified. Otherwise it needs to be a unique profile identifier.
+        - `name` is mandatory and must be unique.
+        - if the first profile is added, it is automatically set as the active profile.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/addProfileMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    update_profile:
+      summary: 🧪 Update a profile.
+      description: |
+        Update one or multiple properties of a profile. A missing property will not update its current value.  
+        - `profile_id` is mandatory and can't be changed.
+        - an empty `icon` value removes an existing icon identifier.
+        - a missing `pages` property will not change the page order.
+        - ⚠️ an empty `pages` array removes all pages and groups in the profile!
+        - ⚠️ missing page identifiers in the `pages` array will remove the page configuration!
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/updateProfileMsg'
+      x-response:
+        $ref: '#/components/messages/profile'
+    delete_profile:
+      summary: 🧪 Delete the specified profile.
+      description: All profile related pages and groups are also deleted.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/deleteProfileMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    delete_all_profiles:
+      summary: 🧪 Delete all profiles.
+      description: This also deletes all pages and groups.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/deleteAllProfilesMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    profile_change:
+      summary: 🧪 Profile change event.
+      description: |
+        Emitted if a profile configuration, related profile page or group has been changed, added or deleted.
+      tags:
+        - name: profile
+        - name: event
+      payload:
+        $ref: '#/components/schemas/profileChangeEventMsg'
+
+    # --- page handling
+
+    get_pages:
+      summary: 🧪 Retrieve all UI pages of a profile.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/getPagesMsg'
+      x-response:
+        $ref: '#/components/messages/pages'
+    pages:
+      summary: 🧪 List of defined UI pages response.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/pagesMsg'
+    get_page:
+      summary: 🧪 Retrieve the specified UI page.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/getPageMsg'
+      x-response:
+        $ref: '#/components/messages/page'
+    page:
+      summary: 🧪 UI page data response.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/pageMsg'
+    add_page:
+      summary: 🧪 Create a new UI page and add to profile.
+      tags:
+        - name: profile
+      description: |
+        - `profile_id` is mandatory.
+        - `page_id` is not required and is created automatically.
+        - `name` is mandatory and must be unique within the profile.
+      payload:
+        $ref: '#/components/schemas/addPageMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    update_page:
+      summary: 🧪 Update a UI page.
+      tags:
+        - name: profile
+      description: |
+        - `profile_id` and `page_id` are mandatory.
+      payload:
+        $ref: '#/components/schemas/updatePageMsg'
+      x-response:
+        $ref: '#/components/messages/page'
+    delete_page:
+      summary: 🧪 Delete a UI page.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/deletePageMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    delete_pages_in_profile:
+      summary: 🧪 Delete all pages of a profile
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/deletePagesInProfileMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    # --- group handling
+
+    get_groups:
+      summary: 🧪 Retrieve all UI groups of a profile.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/getGroupsMsg'
+      x-response:
+        $ref: '#/components/messages/groups'
+    groups:
+      summary: 🧪 List of defined UI groups response.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/groupsMsg'
+    get_group:
+      summary: 🧪 Retrieve the specified UI group.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/getGroupMsg'
+      x-response:
+        $ref: '#/components/messages/group'
+    group:
+      summary: 🧪 UI group data response.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/groupMsg'
+    add_group:
+      summary: 🧪 Create a new UI group and add to profile.
+      description: |
+        - `profile_id` is mandatory.
+        - `group_id` is not required and is created automatically.
+        - `name` is mandatory and must be unique within the profile.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/addGroupMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    update_group:
+      summary: 🧪 Update a UI group.
+      description: |
+        - `profile_id` and `group_id` are mandatory.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/updateGroupMsg'
+      x-response:
+        $ref: '#/components/messages/group'
+    delete_group:
+      summary: 🧪 Delete a UI group.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/deleteGroupMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+    delete_groups_in_profile:
+      summary: 🧪 Delete all groups in a profile.
+      tags:
+        - name: profile
+      payload:
+        $ref: '#/components/schemas/deleteGroupsInProfileMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    # --- integration handling
+
+    get_integration_status:
+      summary: 🧪 Retrieve an overview of the integration instances and their current connection state.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/getIntegrationStatusMsg'
+      x-response:
+        $ref: '#/components/messages/integration_status'
+    integration_status:
+      summary: 🧪 Summary information of the integration instances.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/integrationStatusMsg'
+
+    integration_cmd:
+      summary: 🧪 Execute an integration command.
+      description: |
+        Connect or disconnect integration instances.
+        
+        If `integration_id` is specified, then the command only applies to the given integration, otherwise to all
+        integration instances.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/integrationCmdMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    integration_driver_cmd:
+      summary: 🧪 Execute an integration driver command.
+      description: |
+        Start or stop integration drivers.
+        
+        If `driver_id` is specified, then the command only applies to the given driver, otherwise to all
+        integration drivers.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/integrationDriverCmdMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    get_integration_driver_count:
+      summary: 🧪 Get total number of registered integration drivers.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/getIntegrationDriverCountMsg'
+      x-response:
+        $ref: '#/components/messages/integration_driver_count'
+    integration_driver_count:
+      summary: 🧪 Total number of registered integration drivers response.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/integrationDriverCountMsg'
+
+    get_integration_drivers:
+      summary: 🧪 Retrieve all registered integration drivers.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/getIntegrationDriversMsg'
+      x-response:
+        $ref: '#/components/messages/integration_drivers'
+    integration_drivers:
+      summary: 🧪 List of registered integration drivers response.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/integrationDriversMsg'
+
+    register_integration_driver:
+      summary: 🧪 Register a new integration driver.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/registerIntegrationDriverMsg'
+      x-response:
+        $ref: '#/components/messages/integration_driver'
+
+    get_integration_driver:
+      summary: 🧪 Retrieve detail information of an integration driver.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/getIntegrationDriverMsg'
+      x-response:
+        $ref: '#/components/messages/integration_driver'
+    integration_driver:
+      summary: 🧪 Detail information of an integration driver response.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/integrationDriverMsg'
+
+    update_integration_driver:
+      summary: 🧪 Modify a configured integration driver.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/updateIntegrationDriverMsg'
+      x-response:
+        $ref: '#/components/messages/integration_driver'
+
+    delete_integration_driver:
+      summary: 🧪 Remove an integration driver.
+      description: |
+        Unloads and deletes an integration driver with all instances and provided entities.
+        
+        **Attention: all references to the integration driver will be removed! This includes all driver instances,
+        provided entities and their references in profile pages and groups.**
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/deleteIntegrationDriverMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    get_integration_count:
+      summary: 🧪 Get total number of integration instances.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/getIntegrationCountMsg'
+      x-response:
+        $ref: '#/components/messages/integration_driver_count'
+    integration_count:
+      summary: 🧪 Total number of integration instances response.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/integrationCountMsg'
+
+    get_integrations:
+      summary: 🧪 Retrieve all loaded integrations.
+      description: |
+        Returns all integration instances, optionally filtered by `type` or `enabled` state.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/getIntegrationsMsg'
+      x-response:
+        $ref: '#/components/messages/integrations'
+    integrations:
+      summary: 🧪 List of loaded integrations response.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/integrationsMsg'
+
+    create_integration:
+      summary: 🧪 Create a new integration instance from driver.
+      description: |
+        Create an integration driver instance and associate it with the driver.
+        For simple integration drivers there's a 1:1 relationship only between an instance and driver.
+        For multi-device drivers, each device corresponds to an integration instance.
+    
+        - the `integration_id` is automatically created by the system to make it unique over all integrations.
+        - for multi-device drivers the `device_id` must be specified and may not already exist in another instance of the
+          same driver.
+        - the driver's name is used by default if `name` isn't specified.
+        - the instance is active by default if `enabled` isn't specified.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/createIntegrationMsg'
+      x-response:
+        $ref: '#/components/messages/integration'
+    integration:
+      summary: 🧪 Integration instance information response.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/integrationMsg'
+
+    get_integration:
+      summary: 🧪 Get an integration instance.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/getIntegrationMsg'
+      x-response:
+        $ref: '#/components/messages/integration'
+
+    update_integration:
+      summary: 🧪 Modify a configured integration instance.
+      description: |
+        Modify one or several properties of an integration instance.  
+        See update model description on how to update or delete an existing property.
+        
+        The integration driver of an instance cannot be changed and will be ignored if provided in the request.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/updateIntegrationMsg'
+      x-response:
+        $ref: '#/components/messages/integration'
+
+    delete_integration:
+      summary: 🧪 Remove an integration instance.
+      description: |
+        Unloads and deletes an integration instance.
+        
+        **Attention: all references to the integration instance will be removed! This includes configured entities and 
+        their references in profile pages and groups.**
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/deleteIntegrationMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    configure_entity_from_integration:
+      summary: 🧪 Configure an available entity.
+      description: |
+        Configure a new Remote Two entity from an available integration entity. Once configured, the entity will no
+        longer show up as available entity (unless the `all` filter is set).
+        
+        The entity `name`, `icon` and `description` fields may be changed. If not specified in the request the values from
+        the available entity are used.
+        
+        In case of an error the default `result` message is returned with an error code.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/configureEntityFromIntegrationMsg'
+      x-response:
+        $ref: '#/components/messages/entity'
+
+    configure_entities_from_integration:
+      summary: 🧪 Configure multiple available entities.
+      description: |
+        Configure multiple new Remote Two entities from available integration entities. Once configured, the entities will
+        no longer show up as an available entity (unless the `filter=ALL` query parameter is set).
+        
+        If `entity_ids` is not provided or is empty, all entities from the integration are configured.
+  
+        Use message `configure_entity_from_integration` to configure a single entity and optionally rename it
+        or change its icon.
+        
+        This is a best effort operation:
+        - if an entity is already configured, it is ignored and not returned in the response.
+        - unknown entity identifiers are ignored, no error is returned.
+
+        Every newly configured entity will trigger an `entity_change` event.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/configureEntitiesFromIntegrationMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    get_integration_discovery_status:
+      summary: 🧪 Get external integration driver discovery status.
+      description: |
+        Returns the current discovery status and the discovered integration drivers.
+        
+        Use `start_integration_discovery` to clear old results and start a new discovery.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/getIntegrationDiscoveryStatusMsg'
+      x-response:
+        $ref: '#/components/messages/integration_discovery_status'
+    integration_discovery_status:
+      summary: 🧪 External integration driver discovery status response.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/integrationDiscoveryStatusMsg'
+
+    start_integration_discovery:
+      summary: 🧪 Start discovery of external integration drivers.
+      description: |
+        Start integration driver discovery on the network with mDNS. By default the discovery automatically stops after
+        30 seconds. Use the `get_integration_discovery_status` request to check on discovered devices or
+        `stop_integration_discovery` to stop discovery.
+
+        By default only new integration drivers are returned. If a driver is already configured it will be omitted from the
+        results, unless the query parameter `new=false` is set.
+
+        - Previously discovered integrations are removed, only newly discovered integrations will be returned.
+        - Emits the WebSocket event `integration_discovery` with `event_type: START` when discovery starts.
+        - For each discovered driver the WebSocket event `integration_discovery` with `event_type: DISCOVER` is emitted.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/startIntegrationDiscoveryMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    stop_integration_discovery:
+      summary: 🧪 Stop discovery of external integration drivers.
+      description: |
+        Stops the driver discovery and returns the current discovery status in the response.
+
+        Emits the WebSocket event `integration_discovery` with `event_type: STOP`.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/stopIntegrationDiscoveryMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    get_discovered_integration_driver:
+      summary: 🧪 Get integration driver discovery information.
+      description: |
+        Returns the discovered integration driver.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/getDiscoveredIntegrationDriverMsg'
+      x-response:
+        $ref: '#/components/messages/discovered_integration_driver'
+    discovered_integration_driver:
+      summary: 🧪 Integration driver discovery information.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/discoveredIntegrationDriverMsg'
+
+    get_discovered_intg_driver_metadata:
+      summary: 👷 Execute connection test and fetch metadata from discovered integration driver.
+      description: |
+        Perform a driver connection test with a discovered driver. If the driver requires a token, it must be specified in
+        the request data.
+
+        Response status codes:
+        - `200`: successful operation: the connection test was successful and driver metadata could be retrieved.
+        - `404`: discovered driver with `driver_id` not found. Check if the discovery result is still available and has not
+                 been deleted. This can happen after a timeout since the discovery, or if the discovery result has been
+                 cleared with starting a new discovery.
+        - `503`: integration driver connection could not be established.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/getDiscoveredIntgDriverMetadataMsg'
+      x-response:
+        $ref: '#/components/messages/integration_driver'
+
+    configure_discovered_integration_driver:
+      summary: 🧪 Register a discovered integration driver.
+      description: |
+        Register a discovered integration driver:
+        - establish communication with the driver.
+          - if the driver requires a password, it must be provided in the request.
+          - the discovered driver name and url can be overridden.
+        - fetch metadata from the driver.
+        - check compatability.
+        - register the driver and connection parameters in the remote.
+
+        After a successful registration the setup process of the driver can be started to configure the integration.
+        The required setup data is described in the returned `setup_data_schema` and the provided values by the user must
+        be passed to the `setup_integration` request.
+
+        Response status codes:
+        - `400`: invalid data in request body.
+        - `404`: no discovered driver found for given `driver_id`.
+        - `409`: integration driver is already registered.
+        - `503`: integration driver communication error. Either driver is not reachable or communication failed.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/configureDiscoveredIntegrationDriverMsg'
+      x-response:
+        $ref: '#/components/messages/integration_driver'
+
+    get_integration_setup_processes:
+      summary: 🧪 Get current integration setup processes.
+      description: |
+        Return a list of all active setup process identifiers. The returned ids can be used with the
+        `set_integration_user_data` and `stop_integration_setup` messages to continue or abort a setup process.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/getIntegrationSetupProcessesMsg'
+      x-response:
+        $ref: '#/components/messages/integration_setup_processes'
+    integration_setup_processes:
+      summary: 🧪 Current integration setup processes response.
+      description: |
+        Return a list of all active setup process identifiers.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/integrationSetupProcessesMsg'
+
+    setup_integration:
+      summary: 🧪 Start setting up a new integration driver.
+      description: |
+        Start a new setup process for the given integration driver and provided setup data, or reconfigure an existing
+        driver.
+
+        - This operation immediately starts the driver communication and setup process.
+        - There may only be one active setup process per driver, otherwise status code `409` is returned.
+
+        The returned `id` in the `IntegrationSetupInfo` response will be the identifier for the further setup operations
+        with the `set_integration_user_data` and `stop_integration_setup` requests. Once the setup process is
+        successfully finished, an integration instance is created. A setup process can be simple and fully automatic,
+        but may also require user interaction and further communication with the `set_integration_user_data` message.
+
+        Emits the WebSocket event `integration_setup_change` with `event_type: START`.
+
+        Request body:
+        - `name`: optional integration name. If not specified the name of the integration driver is used.
+        - `setup_data`: optional driver setting values corresponding to the driver's `setup_data_schema` object.
+        - `reconfigure`: set to true to reconfigure an already configured driver. The configuration options and behaviour
+          is driver dependent.
+
+        Response status codes:
+        - `400`: invalid data in request body. E.g. setting the reconfigure flag for a new driver which is not yet configured.
+        - `404`: specified `driver_id` in request body does not exist.
+        - `409`: a setup process for the given `driver_id` already exists. Either continue or abort existing process.
+        - `422`: the setup process cannot be used: either the integration is already configured or doesn't allow to be
+                 set up again.  
+        - `503`: integration driver communication error. Either driver is not reachable or communication failed.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/setupIntegrationMsg'
+      x-response:
+        $ref: '#/components/messages/integration_setup_info'
+    integration_setup_info:
+      summary: 🧪 Integration setup information response.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/integrationSetupInfoMsg'
+
+    stop_all_integration_setups:
+      summary: 🧪 Abort and remove all setup processes.
+      description: |
+        Stop all setup processes at the next possible operation and remove all setup process information.  
+        Depending on the integration driver, a started setup process cannot be aborted.
+
+        ⚠️ This stops all setup processes, not just for the current session!
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/stopAllIntegrationSetupsMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    get_integration_setup_status:
+      summary: 🧪 Get integration driver setup status.
+      description: |
+        Poll operation to retrieve the current integration driver setup state. See the `state` and `error` fields in the
+        response message. There are also WebSocket `integration_setup_change` event messages for state changes to avoid
+        polling.
+
+        Defined setup states:
+        - `SETUP`: setup is running and configuring the integration. 
+        - `WAIT_USER_ACTION`: user input is required to continue the setup process. See `require_user_action` in response
+           for the required user input. Provide the requested data with the `PUT` operation.
+        - `OK`: setup process has been completed successfully, the integration driver can now be used.
+        - `ERROR`: the setup process failed. Check the `error` field for more information.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/getIntegrationSetupStatusMsg'
+      x-response:
+        $ref: '#/components/messages/integration_setup_info'
+
+    set_integration_user_data:
+      summary: 🧪 Provide requested integration setup data.
+      description: |
+        Set required data to configure the integration driver or continue the setup process.
+
+        Defined user actions to set in the request body `action` field:
+        - `input_values`: if the user was requested to enter settings, e.g. connection or credential parameters to a device
+          or service.
+        - `confirm`: response to the user action `confirmation`. Set to `true` if the user had to perform an action like
+          pressing a button on a device and then confirms the action with continuing the setup process.  
+          The `false` value is prepared for yes / no choices.
+
+        The `state` field in the response message indicate the current state of the setup process. Use the
+        `get_integration_setup_status` message to poll for state updates or listen to the corresponding WebSocket
+        `integration_setup_change` event messages with `event_type: SETUP`.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/setIntegrationUserDataMsg'
+      x-response:
+        $ref: '#/components/messages/integration_setup_info' # TODO just result?
+
+    stop_integration_setup:
+      summary: 🧪 Abort the integration driver setup process.
+      description: |
+        Stop the setup process at the next possible operation and remove the setup process information.  
+        To start a new setup process, use the `setup_integration` request again.
+
+        Depending on the integration driver, a started setup process cannot be aborted.
+
+        Emits the WebSocket event `integration_setup_change` with `event_type: STOP`.
+      tags:
+        - name: integration
+      payload:
+        $ref: '#/components/schemas/stopIntegrationSetupMsg'
+      x-response:
+        $ref: '#/components/messages/result'
+
+    # =========================================================================
+    # NOTIFICATIONS API MESSAGES
+    # =========================================================================
+
+    get_event_channels:
+      summary: 🧪 Retrieve available event channels for the current session.
+      description: |
+        Depending on the security role not all event subscriptions may be available.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/getEventChannelsMsg'
+      x-response:
+        $ref: '#/components/messages/event_channels'
+    event_channels:
+      summary: 🧪 Available subscriptions for the current session.
+      description: |
+        Returns all subscribed event channels.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/eventChannelsMsg'
+    subscribe_events:
+      summary: 🧪 Subscribe to event channels.
+      description: |
+        Subscribe to one or multiple event channels.
+        
+        - The special `all` channel will deliver all available events and clear all other subscriptions for the session.
+        - If the session is already subscribed to the `all` channel, any other channels are ignored.
+        - The special `entities` channel will deliver all entity and activity-group related events. This includes all
+          entity-type channels (`entity_###`) and the `activity_group` channel.
+        - Depending on the security role not all event subscriptions may be available.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/subscribeEventsMsg'
+      x-response:
+        $ref: '#/components/messages/event_subscriptions'
+    get_event_subscriptions:
+      summary: 🧪 Retrieve the active event channel subscriptions.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/getEventSubscriptionsMsg'
+      x-response:
+        $ref: '#/components/messages/event_subscriptions'
+    unsubscribe_events:
+      summary: 🧪 Unsubscribe from event channels.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/unsubscribeEventsMsg'
+      x-response:
+        $ref: '#/components/messages/event_subscriptions'
+    event_subscriptions:
+      summary: 🧪 Event channel subscription status.
+      description: |
+        Response to `subscribe_events`, `unsubscribe_events` and `get_event_subscriptions`.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/eventSubscriptionsMsg'
+
+    warning:
+      summary: 🔍 System warning event.
+      description: |
+        Emitted for important system events like low battery or shutdown events.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/warningEventMsg'
+
+    integration_driver_change:
+      summary: 🔍 Integration driver change event.
+      description: |
+        Emitted if an integration driver has changed, a new driver has been added or a configured driver has been
+        deleted.
+      tags:
+        - name: integration
+        - name: event
+      payload:
+        $ref: '#/components/schemas/integrationDriverChangeEventMsg'
+    integration_change:
+      summary: 🔍 Integration change event.
+      description: |
+        Emitted if an integration instance has changed, a new instance has been added or a configured instance has been
+        deleted.
+      tags:
+        - name: integration
+        - name: event
+      payload:
+        $ref: '#/components/schemas/integrationChangeEventMsg'
+    integration_state:
+      summary: 🔍 Integration state event.
+      description: |
+        Emitted if the connection state of an integration driver or instance has changed.
+      tags:
+        - name: integration
+        - name: event
+      payload:
+        $ref: '#/components/schemas/integrationStateEventMsg'
+
+    configuration_change:
+      summary: 🧪 System configuration change event.
+      description: |
+        Emitted if a system setting has changed.
+        
+        The `msg_data.new_state` object only contains the configuration object of the setting that has changed and not
+        the full system configuration.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/configurationChangeEventMsg'
+
+    ir_learning:
+      summary: 🧪 IR code learn event.
+      description: |
+        Emitted if learning mode is started, stopped or a new IR code was learned from an IR emitter device.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/irLearningEventMsg'
+
+    dock_change:
+      summary: 🧪 Dock change event.
+      description: |
+        Emitted if a dock configuration has changed.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/dockChangeEventMsg'
+    dock_state:
+      summary: 🧪 Dock state event.
+      description: |
+        Emitted if the connection state of a dock has changed.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/dockStateEventMsg'
+
+    dock_discovery:
+      summary: 🧪 Docking station discovery event.
+      description: |
+        Emitted if dock discovery is started, stopped or a new dock was discovered on the network or via Bluetooth.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/dockDiscoveryEventMsg'
+
+    dock_setup_change:
+      summary: 🧪 Docking station setup state change event.
+      description: |
+        Emitted for all dock setup flow state changes.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/dockSetupChangeEventMsg'
+
+    dock_update_change:
+      summary: 🧪 Docking station firmware update change event.
+      description: |
+        Emitted for firmware update and progress state changes.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/dockUpdateChangeEventMsg'
+
+    integration_discovery:
+      summary: 🔍 Integration discovery event.
+      description: |
+        Emitted if integration discovery is started, stopped or a new integration was discovered on the network.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/integrationDiscoveryEventMsg'
+
+    integration_setup_change:
+      summary: 🔍 Integration setup state change event.
+      description: |
+        Emitted for all integration setup flow state changes.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/integrationSetupChangeEventMsg'
+
+    software_update:
+      summary: 🧪 Software update event.
+      description: |
+        Emitted during a system update to receive start, stop and progress events.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/softwareUpdateEventMsg'
+
+    power_mode_change:
+      summary: 🔍 Power mode change event.
+      description: |
+        Emitted when the power saving mode changes.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/powerModeChangeEventMsg'
+
+    battery_status:
+      summary: 🔍 Battery status event.
+      description: |
+        Emitted when the battery status changes.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/batteryStatusEventMsg'
+
+    ambient_light_change:
+      summary: 🔍 Ambient light change event.
+      description: |
+        Emitted when the ambient light changes during normal power mode.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/ambientLightChangeEventMsg'
+
+  # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  schemas:
+    # =========================================================================
+    # Common message schemas
+    # =========================================================================
+    commonReq:
+      description: Common request message properties.
+      type: object
+      properties:
+        kind:
+          description: Request message identifier.
+          type: string
+          const: req
+        id:
+          description: Request ID which must be increased for every new request. This ID will be returned in the response message.
+          type: integer
+          minimum: 0
+          default: 0
+        msg:
+          description: One of the defined API request message types.
+          type: string
+          minLength: 1
+          maxLength: 32
+      required:
+        - id
+        - msg
+    commonResp:
+      description: Common response message properties.
+      type: object
+      properties:
+        kind:
+          description: Response message identifier.
+          type: string
+          const: resp
+        req_id:
+          $ref: '#/components/schemas/msgId'
+        msg:
+          description: One of the defined API response message types.
+          type: string
+          minLength: 1
+          maxLength: 32
+        code:
+          description: Response code of the operation according to HTTP status codes.
+          type: integer
+          default: 200
+        msg_data:
+          description: Wrapper for response data object. Not returned for error responses with code != 200.
+          type: object
+      required:
+        - kind
+        - req_id
+        - msg
+        - code
+    commonEvent:
+      description: Common event message properties.
+      type: object
+      properties:
+        kind:
+          description: Event message identifier.
+          type: string
+          const: event
+        msg:
+          description: One of the defined API event message types.
+          type: string
+          minLength: 1
+          maxLength: 32
+        cat:
+          description: Event category.
+          type: string
+        ts:
+          type: string
+          format: date-time
+          description: Optional timestamp when the event was generated.
+        msg_data:
+          description: Wrapper for event data object.
+          type: object
+      required:
+        - kind
+        - msg
+        - msg_data
+    authRequiredEvent:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: auth_required
+            msg_data:
+              type: object
+              properties:
+                api:
+                  type: object
+                  properties:
+                    name:
+                      description: API name
+                      type: string
+                    version:
+                      description: API version
+                      type: string
+          required:
+            - msg
+    authRequestMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: auth
+            msg_data:
+              type: object
+              properties:
+                token:
+                  type: string
+          required:
+            - msg
+            - msg_data
+    authMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: authentication
+            msg_data:
+              type: object
+              properties:
+                core:
+                  description: Core version
+                  type: string
+          required:
+            - msg
+
+    # =========================================================================
+    # Core message schemas
+    # =========================================================================
+    versionMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: version
+          required:
+            - msg
+    versionInfoMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: version_info
+            msg_data:
+              $ref: '#/components/schemas/versionInfo'
+          required:
+            - msg
+
+    systemCmdMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: service_cmd
+            msg_data:
+              properties:
+                command:
+                  type: string
+                  enum:
+                    - STANDBY
+                    - REBOOT
+                    - POWER_OFF
+                    - RESTART
+                    - RESTART_UI
+                    - RESTART_CORE
+              required:
+                - command
+          required:
+            - msg
+            - msg_data
+    getSystemInfoMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: system
+          required:
+            - msg
+    systemInfoMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: system_info
+            msg_data:
+              $ref: '#/components/schemas/systemInfo'
+          required:
+            - msg
+
+    getFactoryResetTokenMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_factory_reset_token
+          required:
+            - msg
+    factoryResetTokenMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: factory_reset_token
+            msg_data:
+              type: object
+              properties:
+                token:
+                  type: string
+              required:
+                - token
+          required:
+            - msg
+    factoryResetMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: factory_reset
+            msg_data:
+              type: object
+              properties:
+                token:
+                  type: string
+              required:
+                - token
+          required:
+            - msg
+            - msg_data
+
+    setApiAccessMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_api_access
+            msg_data:
+              properties:
+                web_configurator:
+                  type: object
+                  properties:
+                    enabled:
+                      description: Enable or disable access for the web-configurator.
+                      type: boolean
+                    pin:
+                      description: Set a new access pin.
+                      type: string
+                      minLength: 4
+                    valid_to:
+                      description: |
+                        Optional timestamp when the access automatically expires. If not set the access is allowed until
+                        the account is disabled.
+                      type: string
+                      format: date-time
+                  required:
+                    - enabled
+              required:
+                - web_configurator
+          required:
+            - msg
+            - msg_data
+    getApiAccessMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_api_access
+          required:
+            - msg
+    apiAccessMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: api_access
+            msg_data:
+              properties:
+                web_configurator:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                    valid_to:
+                      description: |
+                        Optional timestamp when the access automatically expires. If not set the access is allowed until
+                        the account is disabled.
+                      type: string
+                      format: date-time
+                  required:
+                    - enabled
+              required:
+                - web_configurator
+          required: # msg_data is not required to reply with error code for invalid request
+            - msg
+
+    checkSystemUpdateMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: check_system_update
+            msg_data:
+              type: object
+              properties:
+                force_update:
+                  type: boolean
+          required:
+            - msg
+    systemUpdateInfoMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: system_update_info
+            msg_data:
+              $ref: '#/components/schemas/AvailableSystemUpdateResponse'
+          required:
+            - msg
+    updateSystemMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: update_system
+            msg_data:
+              type: object
+              properties:
+                update_id:
+                  description: Update image identification
+                  type: string
+              required:
+                - update_id
+          required:
+            - msg
+            - msg_data
+    updateSystemResultMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: update_system_result
+            msg_data:
+              $ref: '#/components/schemas/SystemUpdateResponse'
+          required:
+            - msg
+            - msg_data
+    getSystemUpdateProgressMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_system_update_progress
+            msg_data:
+              type: object
+              properties:
+                update_id:
+                  description: Update image identification
+                  type: string
+              required:
+                - update_id
+          required:
+            - msg
+            - msg_data
+    systemUpdateProgressMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: system_update_progress
+            msg_data:
+              $ref: '#/components/schemas/SystemUpdateProgress'
+          required:
+            - msg
+
+    getPowerModeMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_power_mode
+          required:
+            - msg
+    powerModeMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: power_mode
+            msg_data:
+              type: object
+              properties:
+                mode:
+                  $ref: '#/components/schemas/PowerMode'
+                battery:
+                  $ref: '#/components/schemas/batteryStatus'
+              required:
+                - mode
+          required:
+            - msg
+            - msg_data
+    setPowerModeMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_power_mode
+            msg_data:
+              type: object
+              properties:
+                mode:
+                  $ref: '#/components/schemas/PowerMode'
+              required:
+                - mode
+          required:
+            - msg
+            - msg_data
+
+    getAmbientLightMsg:
+      type: object
+      allOf:
+          - $ref: '#/components/schemas/commonReq'
+          - properties:
+              msg:
+                type: string
+                const: get_ambient_light
+            required:
+              - msg
+    ambientLightMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: ambient_light
+            msg_data:
+              $ref: '#/components/schemas/AmbientLight'
+          required:
+            - msg
+            - msg_data
+
+    resetConfigurationMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: reset_configuration
+          required:
+            - msg
+
+    getConfigurationMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_configuration
+          required:
+            - msg
+    configurationMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: configuration
+            msg_data:
+              $ref: '#/components/schemas/configuration'
+          required:
+            - msg
+
+    getButtonCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_button_cfg
+            msg_data:
+              $ref: '#/components/schemas/getConfigurationOptions'
+          required:
+            - msg
+    setButtonCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_button_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgButton'
+          required:
+            - msg
+            - msg_data
+    buttonCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: button_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgButton'
+          required:
+            - msg
+
+    getDeviceCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_device_cfg
+            msg_data:
+              $ref: '#/components/schemas/getConfigurationOptions'
+          required:
+            - msg
+    setDeviceCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_device_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgDevice'
+          required:
+            - msg
+            - msg_data
+    deviceCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: device_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgDevice'
+          required:
+            - msg
+
+    getDisplayCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_display_cfg
+            msg_data:
+              $ref: '#/components/schemas/getConfigurationOptions'
+          required:
+            - msg
+    setDisplayCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_display_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgDisplay'
+          required:
+            - msg
+            - msg_data
+    displayCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: display_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgDisplay'
+          required:
+            - msg
+
+    getFeaturesCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_features_cfg
+            msg_data:
+              $ref: '#/components/schemas/getConfigurationOptions'
+          required:
+            - msg
+    setFeaturesCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_features_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgFeatureUpdate'
+          required:
+            - msg
+            - msg_data
+    featuresCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: features_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgFeatures'
+          required:
+            - msg
+
+    getHapticCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_haptic_cfg
+            msg_data:
+              $ref: '#/components/schemas/getConfigurationOptions'
+          required:
+            - msg
+    setHapticCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_haptic_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgHaptic'
+          required:
+            - msg
+            - msg_data
+    hapticCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: haptic_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgHaptic'
+          required:
+            - msg
+
+    getLocalizationCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_localization_cfg
+            msg_data:
+              $ref: '#/components/schemas/getConfigurationOptions'
+          required:
+            - msg
+    setLocalizationCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_localization_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgLocalization'
+          required:
+            - msg
+            - msg_data
+    localizationCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: localization_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgLocalization'
+          required:
+            - msg
+    getTimezoneNamesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_timezone_names
+          required:
+            - msg
+    timezoneNamesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: timezone_names
+            msg_data:
+              type: array
+              items:
+                type: string
+          required:
+            - msg
+    getLocalizationCountriesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_localization_countries
+          required:
+            - msg
+    localizationCountriesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg_data:
+              type: array
+              items:
+                type: object
+                properties:
+                  code:
+                    $ref: '#/components/schemas/countryCode'
+                  name_en:
+                    description: |
+                      Country name in english. Native country names will be provided in additional `name_<language_code>`
+                      properties.
+                    type: string
+                additionalProperties: true
+                required:
+                  - code
+                  - name_en
+          required:
+            - msg
+    getLocalizationLanguagesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_localization_languages
+          required:
+            - msg
+    localizationLanguagesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg_data:
+              type: object
+              properties:
+                version:
+                  type: string
+                translations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      code:
+                        $ref: '#/components/schemas/languageCode'
+                      name:
+                        type: string
+                    required:
+                      - code
+                      - name
+              required:
+                - version
+                - translations
+          required:
+            - msg
+    getNetworkCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_network_cfg
+            msg_data:
+              $ref: '#/components/schemas/getConfigurationOptions'
+          required:
+            - msg
+    setNetworkCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_network_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgNetwork'
+          required:
+            - msg
+            - msg_data
+    networkCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: network_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgNetwork'
+          required:
+            - msg
+            - msg_data
+
+    getSoftwareUpdateCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_software_update_cfg
+            msg_data:
+              $ref: '#/components/schemas/getConfigurationOptions'
+          required:
+            - msg
+    setSoftwareUpdateCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_software_update_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgSoftwareUpdate'
+          required:
+            - msg
+            - msg_data
+    softwareUpdateCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: software_update_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgSoftwareUpdate'
+          required:
+            - msg
+
+    getPowerSavingCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_power_saving_cfg
+            msg_data:
+              $ref: '#/components/schemas/getConfigurationOptions'
+          required:
+            - msg
+    setPowerSavingCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_power_saving_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgPowerSaving'
+          required:
+            - msg
+            - msg_data
+    powerSavingCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: power_saving_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgPowerSaving'
+          required:
+            - msg
+
+    getProfileCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_profile_cfg
+          required:
+            - msg
+    setProfileCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_profile_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgProfileUpdate'
+          required:
+            - msg
+            - msg_data
+    profileCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: profile_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgProfile'
+          required:
+            - msg
+
+    getSoundCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_sound_cfg
+            msg_data:
+              $ref: '#/components/schemas/getConfigurationOptions'
+          required:
+            - msg
+    setSoundCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_sound_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgSound'
+          required:
+            - msg
+            - msg_data
+    soundCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: sound_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgSound'
+          required:
+            - msg
+
+    getVoiceControlCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_voice_control_cfg
+            msg_data:
+              $ref: '#/components/schemas/getConfigurationOptions'
+          required:
+            - msg
+    setVoiceControlCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_voice_control_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgVoiceControl'
+          required:
+            - msg
+            - msg_data
+    voiceControlCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: voice_control_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgVoiceControl'
+          required:
+            - msg
+    getVoiceAssistantsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_voice_assistants
+          required:
+            - msg
+    voiceAssistantsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: voice_assistants
+            msg_data:
+              type: array
+              items:
+                type: string
+          required:
+            - msg
+
+    # --- Entity handling
+
+    getEntityTypesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_entity_types
+          required:
+            - msg
+    entityTypesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: entity_types
+            msg_data:
+              type: array
+              items:
+                type: string
+          required:
+            - msg
+    getEntityMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_entity
+            msg_data:
+              type: object
+              properties:
+                entity_id:
+                  $ref: '#/components/schemas/entityId'
+              required:
+                - entity_id
+          required:
+            - msg
+            - msg_data
+    getEntitiesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_entities
+            msg_data:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/components/schemas/entityFilter'
+                paging:
+                  $ref: '#/components/schemas/paging'
+          required:
+            - msg
+    entitiesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: entities
+            msg_data:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/components/schemas/entityFilter'
+                paging:
+                  $ref: '#/components/schemas/pagination'
+                entities:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/entity'
+              required:
+                - entities
+          required:
+            - msg
+    getAvailableEntitiesMsg:
+      description: |
+        Retrieve the available entities provided by the integration instance.
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_available_entities
+            msg_data:
+              type: object
+              properties:
+                force_reload:
+                  description: Don't use cached entities and re-request available entities from integrations
+                  type: boolean
+                filter:
+                  $ref: '#/components/schemas/availableEntityFilter'
+                paging:
+                  $ref: '#/components/schemas/paging'
+          required:
+            - msg
+    availableEntitiesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: available_entities
+            msg_data:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/components/schemas/availableEntityFilter'
+                paging:
+                  $ref: '#/components/schemas/pagination'
+                available_entities:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/available_entity'
+              required:
+                - available_entities
+          required:
+            - msg
+    getEntityCommandsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_entity_commands
+            msg_data:
+              type: object
+              properties:
+                entity_id:
+                  type: string
+                entity_type:
+                  type: string
+          required:
+            - msg
+            - msg_data
+    entityCommandsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: entity_commands
+            msg_data:
+              type: object
+              properties:
+                entity_id:
+                  type: string
+                entity_type:
+                  type: string
+                commands:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/entityCommand'
+              required:
+                - commands
+          required:
+            - msg
+    getEntityCommandMetadataMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_entity_command_metadata
+          required:
+            - msg
+    entityCommandMetadataMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: entity_command_metadata
+            msg_data:
+              type: array
+              description: See REST API for EntityCommandMetadata object definition
+              items:
+                type: object
+          required:
+            - msg
+            - msg_data
+    executeEntityCommandMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: execute_entity_command
+            msg_data:
+              type: object
+              properties:
+                entity_id:
+                  $ref: '#/components/schemas/entityId'
+                cmd_id:
+                  $ref: '#/components/schemas/entityCommand'
+                params:
+                  description: |
+                    Optional key/value command parameters if required. See entity documentation for more information.
+                  type: object
+              required:
+                - entity_id
+                - cmd_id
+          required:
+            - msg
+            - msg_data
+    entityMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: entity
+            msg_data:
+              $ref: '#/components/schemas/entity'
+          required:
+            - msg
+    entityChangeEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: entity_change
+            cat:
+              type: string
+              const: ENTITY
+            msg_data:
+              $ref: '#/components/schemas/entityChange'
+          required:
+            - msg
+            - msg_data
+    activityGroupChangeEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: activity_group_change
+            cat:
+              type: string
+              const: ENTITY
+            msg_data:
+              $ref: '#/components/schemas/ActivityGroup'
+          required:
+            - msg
+            - msg_data
+    updateEntityMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: update_entity
+            msg_data:
+              $ref: '#/components/schemas/entityUpdate'
+          required:
+            - msg
+            - msg_data
+    deleteEntityMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: delete_entity
+            msg_data:
+              type: object
+              properties:
+                entity_id:
+                  $ref: '#/components/schemas/entityId'
+              required:
+                - entity_id
+          required:
+            - msg
+            - msg_data
+    deleteEntitiesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: delete_entities
+            msg_data:
+              type: object
+              properties:
+                integration_id:
+                  type: string
+                entity_ids:
+                  type: array
+                  items:
+                    type: string
+          required:
+            - msg
+            - msg_data
+
+    # --- Dock handling
+
+    getDockCountMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_dock_count
+            msg_data:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/components/schemas/dockFilter'
+          required:
+            - msg
+    dockCountMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: dock_count
+            msg_data:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/components/schemas/dockFilter'
+                count:
+                  type: integer
+              required:
+                - count
+          required:
+            - msg
+    getDocksMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_docks
+            msg_data:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/components/schemas/dockFilter'
+                paging:
+                  $ref: '#/components/schemas/paging'
+          required:
+            - msg
+    docksMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: docks
+            msg_data:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/components/schemas/dockFilter'
+                paging:
+                  $ref: '#/components/schemas/paging'
+                docks:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/dockConfiguration'
+              required:
+                - paging
+                - docks
+          required:
+            - msg
+    createDockMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: create_dock
+            msg_data:
+              $ref: '#/components/schemas/dockConfigurationRequest'
+          required:
+            - msg
+            - msg_data
+    dockMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: dock
+          required:
+            - msg
+    deleteAllDocksMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: delete_all_docks
+          required:
+            - msg
+    getDockMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_dock
+            msg_data:
+              type: object
+              properties:
+                dock_id:
+                  type: string
+              required:
+                - dock_id
+          required:
+            - msg
+            - msg_data
+    updateDockMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: update_dock
+            msg_data:
+              $ref: '#/components/schemas/dockUpdateRequest'
+          required:
+            - msg
+            - msg_data
+    dockConnectionCommandMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: dock_connection_command
+            msg_data:
+              type: object
+              properties:
+                dock_id:
+                  description: Optional dock_id, if omitted the command is applied to all docks.
+                  type: string
+                cmd:
+                  type: string
+                  enum:
+                    - CONNECT
+                    - DISCONNECT
+              required:
+                - cmd
+          required:
+            - msg
+            - msg_data
+    deleteDockMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: delete_dock
+            msg_data:
+              type: object
+              properties:
+                dock_id:
+                  type: string
+              required:
+                - dock_id
+          required:
+            - msg
+            - msg_data
+    dockCommandMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: dock_command
+            msg_data:
+              type: object
+              properties:
+                dock_id:
+                  type: string
+                command:
+                  type: string
+                  enum:
+                    - SET_LED_BRIGHTNESS
+                    - IDENTIFY
+                    - REMOTE_LOW_BATTERY
+                    - REMOTE_CHARGED
+                    - REMOTE_NORMAL
+                    - REBOOT
+                    - RESET
+                value:
+                  description: Command parameter value. Required for `SET_LED_BRIGHTNESS`.
+                  type: string
+                token:
+                  description: Optional token if dock uses a custom password.
+                  type: string
+              required:
+                - dock_id
+                - command
+          required:
+            - msg
+            - msg_data
+    getDockDiscoveryStatusMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_dock_discovery_status
+          required:
+            - msg
+    dockDiscoveryStatusMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: dock_discovery_status
+          required:
+            - msg
+    startDockDiscoveryMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: start_dock_discovery
+            msg_data:
+              type: object
+              properties:
+                timeout:
+                  description: Timeout in seconds.
+                  type: integer
+                  format: int32
+                  default: 30
+                  minimum: 1
+                  maximum: 300
+                bt:
+                  description: Use Bluetooth to discover new docks.
+                  type: boolean
+                  default: true
+                net:
+                  description: Query network to discover new docks.
+                  type: boolean
+                  default: true
+                new:
+                  description: Only return new devices, filter out already configured docks.
+                  type: boolean
+                  default: true
+          required:
+            - msg
+    stopDockDiscoveryMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: stop_dock_discovery
+          required:
+            - msg
+    getDockDiscoveryDeviceMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_dock_discovery_device
+            msg_data:
+              type: object
+              properties:
+                dock_id:
+                  type: string
+              required:
+                - dock_id
+          required:
+            - msg
+            - msg_data
+    dockDiscoveryDeviceMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: dock_discovery_device
+          required:
+            - msg
+    execCmdOnDiscoveredDockMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: exec_cmd_on_discovered_dock
+            msg_data:
+              type: object
+              properties:
+                dock_id:
+                  type: string
+                cmd:
+                  description: Command to execute.
+                  type: string
+                  enum:
+                    - CONNECTION_TEST
+                    - IDENTIFY
+                timeout:
+                  description: Timeout in seconds.
+                  type: integer
+                  format: int32
+                  default: 30
+                  minimum: 1
+                  maximum: 300
+                token:
+                  description: Optional token if dock uses a custom password.
+                  type: string
+              required:
+                - dock_id
+                - cmd
+          required:
+            - msg
+            - msg_data
+    dockSystemInfoMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: dock_system_info
+            msg_data:
+              $ref: '#/components/schemas/dockSystemInfo'
+          required:
+            - msg
+    getDockSetupProcessesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_dock_setup_processes
+          required:
+            - msg
+    dockSetupProcessesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: dock_setup_processes
+            msg_data:
+              type: object
+              properties:
+                sessions:
+                  type: array
+                  items:
+                    type: string
+              required:
+                - sessions
+          required:
+            - msg
+    createDockSetupMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: create_dock_setup
+            msg_data:
+              $ref: '#/components/schemas/createDockSetup'
+          required:
+            - msg
+            - msg_data
+    dockSetupStatusMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: dock_setup_status
+            msg_data:
+              $ref: '#/components/schemas/dockSetupInfo'
+          required:
+            - msg
+    stopAllDockSetupsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: stop_all_dock_setups
+          required:
+            - msg
+    getDockSetupStatusMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_dock_setup_status
+            msg_data:
+              type: object
+              properties:
+                dock_id:
+                  type: string
+          required:
+            - msg
+            - msg_data
+    startDockSetupMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: start_dock_setup
+            msg_data:
+              $ref: '#/components/schemas/dockSetup'
+          required:
+            - msg
+            - msg_data
+    stopDockSetupMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: stop_dock_setup
+            msg_data:
+              type: object
+              properties:
+                dock_id:
+                  type: string
+          required:
+            - msg
+            - msg_data
+
+    # --- WiFi handling
+
+    wifiGetStatusMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_wifi_status
+          required:
+            - msg
+    wifiStatusMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: wifi_status
+            msg_data:
+              $ref: '#/components/schemas/WifiStatus'
+          required:
+            - msg
+
+    wifiCommandMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: wifi_command
+            msg_data:
+              type: object
+              properties:
+                cmd:
+                  $ref: '#/components/schemas/WifiCmd'
+              required:
+                - cmd
+          required:
+            - msg
+            - msg_data
+
+    wifiScanStartMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: wifi_scan_start
+          required:
+            - msg
+
+    wifiScanStopMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: wifi_scan_stop
+          required:
+            - msg
+
+    wifiGetScanStatusMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_wifi_scan_status
+          required:
+            - msg
+    wifiScanStatusMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: wifi_scan_status
+            msg_data:
+              $ref: '#/components/schemas/ApScanStatus'
+          required:
+            - msg
+
+    wifiGetAllNetworksMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_all_wifi_networks
+          required:
+            - msg
+    wifiNetworksMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: wifi_networks
+            msg_data:
+              $ref: '#/components/schemas/SavedNetworks'
+          required:
+            - msg
+
+    wifiAddNetworkMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: add_wifi_network
+            msg_data:
+              $ref: '#/components/schemas/CreateWifiNetwork'
+          required:
+            - msg
+            - msg_data
+
+    wifiDelAllNetworksMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: del_all_wifi_networks
+          required:
+            - msg
+
+    wifiGetNetworkMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_wifi_network
+            msg_data:
+              type: object
+              properties:
+                id:
+                  type: integer
+                  minimum: 0
+              required:
+                - id
+          required:
+            - msg
+            - msg_data
+    wifiNetworkMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: wifi_network
+            msg_data:
+              $ref: '#/components/schemas/SavedNetwork'
+          required:
+            - msg
+
+    wifiUpdateNetworkMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: update_wifi_network
+            msg_data:
+              $ref: '#/components/schemas/ModifyWifiNetwork'
+          required:
+            - msg
+            - msg_data
+
+    wifiNetworkCommandMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: wifi_network_command
+            msg_data:
+              type: object
+              properties:
+                id:
+                  type: integer
+                  minimum: 0
+                cmd:
+                  $ref: '#/components/schemas/WifiNetworkCmd'
+              required:
+                - id
+                - cmd
+          required:
+            - msg
+            - msg_data
+
+    wifiDelNetworkMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: del_wifi_network
+            msg_data:
+              type: object
+              properties:
+                id:
+                  type: integer
+                  minimum: 0
+              required:
+                - id
+          required:
+            - msg
+            - msg_data
+
+    wifiChangeEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: wifi_change
+            cat:
+              type: string
+              const: REMOTE
+            msg_data:
+              $ref: '#/components/schemas/WifiChange'
+          required:
+            - msg
+            - msg_data
+
+    # --- Profile handling
+
+    getProfilesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_profiles
+          required:
+            - msg
+    profilesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: profiles
+            msg_data:
+              $ref: '#/components/schemas/profiles'
+          required:
+            - msg
+    getProfileMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_profile
+            msg_data:
+              properties:
+                profile_id:
+                  $ref: '#/components/schemas/simpleId'
+              required:
+                - profile_id
+          required:
+            - msg
+            - msg_data
+    profileMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: profile
+            msg_data:
+              $ref: '#/components/schemas/profile'
+          required:
+            - msg
+    getActiveProfileMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_active_profile
+          required:
+            - msg
+    switchProfileMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: switch_profile
+            msg_data:
+              type: object
+              properties:
+                profile_id:
+                  $ref: '#/components/schemas/simpleId'
+                admin_pin:
+                  type: string
+                  description: Optional administrator pin to switch away from a restricted profile.
+              required:
+                - profile_id
+          required:
+            - msg
+            - msg_data
+    addProfileMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: add_profile
+            msg_data:
+              $ref: '#/components/schemas/profileData'
+          required:
+            - msg
+            - msg_data
+    updateProfileMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: update_profile
+            msg_data:
+              $ref: '#/components/schemas/profileData'
+          required:
+            - msg
+            - msg_data
+    deleteProfileMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: delete_profile
+            msg_data:
+              type: object
+              properties:
+                profile_id:
+                  $ref: '#/components/schemas/simpleId'
+              required:
+                - profile_id
+          required:
+            - msg
+            - msg_data
+    deleteAllProfilesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: delete_all_profiles
+          required:
+            - msg
+    profileChangeEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: profile_change
+            cat:
+              type: string
+              const: UI
+            msg_data:
+              $ref: '#/components/schemas/profileChange'
+          required:
+            - msg
+            - msg_data
+
+    # --- page handling
+
+    getPagesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_pages
+            msg_data:
+              properties:
+                profile_id:
+                  $ref: '#/components/schemas/simpleId'
+              required:
+                - profile_id
+          required:
+            - msg
+            - msg_data
+    pagesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: pages
+            msg_data:
+              $ref: '#/components/schemas/pages'
+          required:
+            - msg
+    getPageMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_page
+            msg_data:
+              properties:
+                page_id:
+                  $ref: '#/components/schemas/simpleId'
+              required:
+                - page_id
+          required:
+            - msg
+            - msg_data
+    pageMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: page
+            msg_data:
+              $ref: '#/components/schemas/page'
+          required:
+            - msg
+    addPageMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: add_page
+            msg_data:
+              $ref: '#/components/schemas/pageData'
+          required:
+            - msg
+            - msg_data
+    updatePageMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: update_page
+            msg_data:
+              $ref: '#/components/schemas/pageData'
+          required:
+            - msg
+            - msg_data
+    deletePageMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: delete_page
+            msg_data:
+              type: object
+              properties:
+                page_id:
+                  $ref: '#/components/schemas/simpleId'
+              required:
+                - page_id
+          required:
+            - msg
+            - msg_data
+    deletePagesInProfileMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: delete_pages_in_profile
+            msg_data:
+              type: object
+              properties:
+                profile_id:
+                  $ref: '#/components/schemas/simpleId'
+              required:
+                - profile_id
+          required:
+            - msg
+            - msg_data
+
+    # --- group handling
+
+    getGroupsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_groups
+            msg_data:
+              type: object
+              properties:
+                profile_id:
+                  $ref: '#/components/schemas/simpleId'
+              required:
+                - profile_id
+          required:
+            - msg
+            - msg_data
+    groupsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: groups
+            msg_data:
+              $ref: '#/components/schemas/groups'
+          required:
+            - msg
+    getGroupMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_group
+            msg_data:
+              type: object
+              properties:
+                group_id:
+                  $ref: '#/components/schemas/simpleId'
+              required:
+                - group_id
+          required:
+            - msg
+            - msg_data
+    groupMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: group
+            msg_data:
+              $ref: '#/components/schemas/group'
+          required:
+            - msg
+    addGroupMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: add_group
+            msg_data:
+              $ref: '#/components/schemas/groupData'
+          required:
+            - msg
+            - msg_data
+    updateGroupMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: update_group
+            msg_data:
+              $ref: '#/components/schemas/groupData'
+          required:
+            - msg
+            - msg_data
+    deleteGroupMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: delete_group
+            msg_data:
+              type: object
+              properties:
+                group_id:
+                  $ref: '#/components/schemas/simpleId'
+              required:
+                - group_id
+          required:
+            - msg
+            - msg_data
+    deleteGroupsInProfileMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: delete_group
+            msg_data:
+              type: object
+              properties:
+                profile_id:
+                  $ref: '#/components/schemas/simpleId'
+              required:
+                - profile_id
+          required:
+            - msg
+            - msg_data
+
+    # --- integration handling
+
+    getIntegrationStatusMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_integration_status
+            msg_data:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/components/schemas/enabledFilter'
+                paging:
+                  $ref: '#/components/schemas/paging'
+          required:
+            - msg
+    integrationStatusMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: integration_status
+            msg_data:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/components/schemas/enabledFilter'
+                paging:
+                  $ref: '#/components/schemas/pagination'
+                status:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/integrationStatus'
+              required:
+                - drivers
+          required:
+            - msg
+
+    integrationCmdMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: integration_cmd
+            msg_data:
+              type: object
+              properties:
+                cmd_id:
+                  type: string
+                  enum:
+                    - CONNECT
+                    - DISCONNECT
+                integration_id:
+                  $ref: '#/components/schemas/integrationId'
+              required:
+                - cmd_id
+          required:
+            - msg
+            - msg_data
+
+    integrationDriverCmdMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: integration_driver_cmd
+            msg_data:
+              type: object
+              properties:
+                cmd_id:
+                  type: string
+                  enum:
+                    - START
+                    - STOP
+                driver_id:
+                  $ref: '#/components/schemas/driverId'
+              required:
+                - cmd_id
+          required:
+            - msg
+            - msg_data
+
+    getIntegrationDriverCountMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_integration_driver_count
+            msg_data:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/components/schemas/intgDriverFilter'
+          required:
+            - msg
+    integrationDriverCountMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: integration_driver_count
+            msg_data:
+              type: object
+              properties:
+                # TODO return request filter in response?
+                count:
+                  type: integer
+              required:
+                - count
+          required:
+            - msg
+
+    getIntegrationDriversMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_integration_drivers
+            msg_data:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/components/schemas/intgDriverFilter'
+                paging:
+                  $ref: '#/components/schemas/paging'
+          required:
+            - msg
+    integrationDriversMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: integration_drivers
+            msg_data:
+              type: object
+              properties:
+                paging:
+                  $ref: '#/components/schemas/pagination'
+                drivers:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/integrationDriverInfo'
+              required:
+                - drivers
+          required:
+            - msg
+
+    registerIntegrationDriverMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: register_integration_driver
+            msg_data:
+              $ref: '#/components/schemas/integrationDriverUpdate'
+          required:
+            - msg
+            - msg_data
+
+    getIntegrationDriverMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_integration_driver
+            msg_data:
+              type: object
+              properties:
+                driver_id:
+                  $ref: '#/components/schemas/driverId'
+              required:
+                - driver_id
+          required:
+            - msg
+            - msg_data
+    integrationDriverMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: integration_driver
+            msg_data:
+              $ref: '#/components/schemas/integrationDriver'
+          required:
+            - msg
+
+    updateIntegrationDriverMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: update_integration_driver
+            msg_data:
+              $ref: '#/components/schemas/integrationDriverUpdate'
+          required:
+            - msg
+            - msg_data
+
+    deleteIntegrationDriverMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: delete_integration_driver
+            msg_data:
+              type: object
+              properties:
+                driver_id:
+                  $ref: '#/components/schemas/driverId'
+              required:
+                - driver_id
+          required:
+            - msg
+            - msg_data
+
+    getIntegrationCountMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_integration_count
+            msg_data:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/components/schemas/enabledFilter'
+          required:
+            - msg
+    integrationCountMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: integration_count
+            msg_data:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/components/schemas/enabledFilter'
+                count:
+                  type: integer
+              required:
+                - count
+          required:
+            - msg
+
+    getIntegrationsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_integrations
+            msg_data:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/components/schemas/enabledFilter'
+                paging:
+                  $ref: '#/components/schemas/paging'
+          required:
+            - msg
+    integrationsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: integrations
+            msg_data:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/components/schemas/enabledFilter'
+                paging:
+                  $ref: '#/components/schemas/pagination'
+                integrations:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/integration'
+              required:
+                - integrations
+          required:
+            - msg
+
+    createIntegrationMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: create_integration
+            msg_data:
+              $ref: '#/components/schemas/integrationUpdate'
+          required:
+            - msg
+            - msg_data
+    integrationMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: integration
+            msg_data:
+              $ref: '#/components/schemas/integration'
+          required:
+            - msg
+            - msg_data
+
+    getIntegrationMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_integration
+            msg_data:
+              type: object
+              properties:
+                integration_id:
+                  $ref: '#/components/schemas/integrationId'
+              required:
+                - integration_id
+          required:
+            - msg
+            - msg_data
+
+    updateIntegrationMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: update_integration
+            msg_data:
+              $ref: '#/components/schemas/integrationUpdate'
+          required:
+            - msg
+            - msg_data
+
+    deleteIntegrationMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: delete_integration
+            msg_data:
+              type: object
+              properties:
+                integration_id:
+                  $ref: '#/components/schemas/integrationId'
+              required:
+                - integration_id
+          required:
+            - msg
+            - msg_data
+
+    configureEntityFromIntegrationMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: configure_entity_from_integration
+            msg_data:
+              type: object
+              properties:
+                integration_id:
+                  type: string
+                entity_id:
+                  description: Entity identifier from integration.
+                  type: string
+                name:
+                  $ref: '#/components/schemas/languageText'
+                icon:
+                  $ref: '#/components/schemas/iconIdentifier'
+                description:
+                  $ref: '#/components/schemas/languageText'
+              required:
+                - integration_id
+                - entity_id
+          required:
+            - msg
+            - msg_data
+
+    configureEntitiesFromIntegrationMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: configure_entities_from_integration
+            msg_data:
+              type: object
+              properties:
+                integration_id:
+                  type: string
+                entity_ids:
+                  description: |
+                    Entity identifiers from integration. Omitted or an empty array will configure all entities.
+                  type: array
+                  items:
+                    type: string
+              required:
+                - integration_id
+          required:
+            - msg
+            - msg_data
+
+    getIntegrationDiscoveryStatusMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_integration_discovery_status
+          required:
+            - msg
+    integrationDiscoveryStatusMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: integration_discovery_status
+            msg_data:
+              $ref: '#/components/schemas/IntegrationDiscoveryStatus'
+          required:
+            - msg
+            - msg_data
+
+    startIntegrationDiscoveryMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: start_integration_discovery
+            msg_data:
+              type: object
+              properties:
+                timeout:
+                  description: Timeout in seconds.
+                  type: integer
+                  format: int32
+                  default: 30
+                  minimum: 1
+                  maximum: 300
+                new:
+                  description: Only return new devices, filter out already configured integrations.
+                  type: boolean
+                  default: true
+          required:
+            - msg
+
+    stopIntegrationDiscoveryMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: stop_integration_discovery
+          required:
+            - msg
+
+    getDiscoveredIntegrationDriverMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_discovered_integration_driver
+            msg_data:
+              type: object
+              properties:
+                driver_id:
+                  type: string
+              required:
+                - driver_id
+          required:
+            - msg
+            - msg_data
+    discoveredIntegrationDriverMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: discovered_integration_driver
+            msg_data:
+              $ref: '#/components/schemas/integrationDiscoveryInformation'
+          required:
+            - msg
+            - msg_data
+
+    getDiscoveredIntgDriverMetadataMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_discovered_integration_driver_metadata
+            msg_data:
+              type: object
+              properties:
+                driver_id:
+                  type: string
+                timeout:
+                  description: Timeout in seconds.
+                  type: integer
+                  format: int32
+                  default: 5
+                  minimum: 3
+                  maximum: 60
+                connection:
+                  type: object
+                  properties:
+                    driver_url:
+                      type: string
+                    token:
+                      description: |
+                        Optional driver authentication token.
+                      type: string
+                      maxLength: 2048
+              required:
+                - driver_id
+          required:
+            - msg
+            - msg_data
+
+    configureDiscoveredIntegrationDriverMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: configure_discovered_integration_driver
+            msg_data:
+              type: object
+              properties:
+                driver_id:
+                  type: string
+                name:
+                  $ref: '#/components/schemas/languageText'
+                driver_url:
+                  description: Custom WebSocket URL of the driver, otherwise the discovered driver address is used.
+                  type: string
+                  format: uri
+                  maxLength: 2048
+                token:
+                  description: |
+                    Optional driver authentication token.
+                  type: string
+                  maxLength: 2048
+              required:
+                - driver_id
+          required:
+            - msg
+            - msg_data
+
+    getIntegrationSetupProcessesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_integration_setup_processes
+          required:
+            - msg
+    integrationSetupProcessesMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: integration_setup_processes
+            msg_data:
+              type: array
+              items:
+                type: string
+          required:
+            - msg
+            - msg_data
+
+    setupIntegrationMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: setup_integration
+            msg_data:
+              $ref: '#/components/schemas/CreateIntegrationSetup'
+          required:
+            - msg
+            - msg_data
+    integrationSetupInfoMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: integration_setup_info
+            msg_data:
+              $ref: '#/components/schemas/IntegrationSetupInfo'
+          required:
+            - msg
+            - msg_data
+
+    stopAllIntegrationSetupsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: stop_all_integration_setups
+          required:
+            - msg
+
+    getIntegrationSetupStatusMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_integration_setup_status
+            msg_data:
+              type: object
+              properties:
+                driver_id:
+                  type: string
+              required:
+                - driver_id
+          required:
+            - msg
+            - msg_data
+
+    setIntegrationUserDataMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_integration_user_data
+            msg_data:
+              type: object
+              properties: 
+                driver_id:
+                  type: string
+                data:
+                  type: object
+                  oneOf:
+                    - type: object
+                      properties:
+                        input_values:
+                          $ref: '#/components/schemas/SettingsValues'
+                      required:
+                        - input_values
+                    - type: object
+                      properties:
+                        confirm:
+                          type: boolean
+                      required:
+                        - confirm
+              required:
+                - driver_id
+                - data
+          required:
+            - msg
+            - msg_data
+
+    stopIntegrationSetupMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: stop_integration_setup
+            msg_data:
+              type: object
+              properties:
+                driver_id:
+                  type: string
+              required:
+                - driver_id
+          required:
+            - msg
+            - msg_data
+
+    getEventChannelsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_event_channels
+          required:
+            - msg
+    eventChannelsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: event_channels
+            msg_data:
+              type: object
+              properties:
+                channels:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/eventChannel'
+              required:
+                - events
+          required:
+            - msg
+    subscribeEventsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: subscribe_events
+            msg_data:
+              type: object
+              properties:
+                channels:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/eventChannel'
+              required:
+                - events
+          required:
+            - msg
+            - msg_data
+    getEventSubscriptionsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_event_subscriptions
+          required:
+            - msg
+    unsubscribeEventsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: unsubscribe_events
+            msg_data:
+              type: object
+              properties:
+                channels:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/eventChannel'
+              required:
+                - events
+          required:
+            - msg
+            - msg_data
+    eventSubscriptionsMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: event_subscriptions
+            msg_data:
+              type: object
+              properties:
+                channels:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/eventChannel'
+              required:
+                - events
+          required:
+            - msg
+    eventChannel:
+      type: string
+      description: The name of the event channel.
+      anyOf:
+        - enum:
+            - all
+            - configuration
+            - entities
+            - entity_button
+            - entity_switch
+            - entity_climate
+            - entity_cover
+            - entity_light
+            - entity_media_player
+            - entity_sensor
+            - entity_activity
+            - entity_macro
+            - entity_remote
+            - activity_groups
+            - integrations
+            - profiles
+            - emitters
+            - docks
+            - software_update
+            - battery_status
+            - ambient_light
+            # TODO define all event channels. Suggestions:
+#            - cfg_log
+#            - cfg_ui
+#            - log
+#            - notification
+#            - gui
+#            - wifi
+        - {}  # extensible enum: there might be more event channels than defined above
+
+    warningEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: warning
+            cat:
+              type: string
+              const: REMOTE
+            msg_data:
+              $ref: '#/components/schemas/warningEvent'
+          required:
+            - msg
+            - msg_data
+
+    integrationDriverChangeEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: integration_driver_change
+            cat:
+              type: string
+              const: DEVICE
+            msg_data:
+              $ref: '#/components/schemas/integrationDriverChange'
+          required:
+            - msg
+            - msg_data
+    integrationChangeEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: integration_change
+            cat:
+              type: string
+              const: DEVICE
+            msg_data:
+              $ref: '#/components/schemas/integrationChange'
+          required:
+            - msg
+            - msg_data
+    integrationStateEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: integration_state
+            cat:
+              type: string
+              const: DEVICE
+            msg_data:
+              $ref: '#/components/schemas/integrationStateData'
+          required:
+            - msg
+            - msg_data
+
+    configurationChangeEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: configuration_change
+            cat:
+              type: string
+              const: REMOTE
+            msg_data:
+              $ref: '#/components/schemas/configurationChange'
+          required:
+            - msg
+            - msg_data
+
+    irLearningEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: ir_learning
+            cat:
+              type: string
+              const: DEVICE
+            msg_data:
+              $ref: '#/components/schemas/irLearning'
+          required:
+            - msg
+            - msg_data
+
+    dockChangeEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: dock_change
+            cat:
+              type: string
+              const: DEVICE
+            msg_data:
+              $ref: '#/components/schemas/dockChangeData'
+          required:
+            - msg
+            - msg_data
+    dockStateEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: dock_state
+            cat:
+              type: string
+              const: DEVICE
+            msg_data:
+              $ref: '#/components/schemas/dockStateData'
+          required:
+            - msg
+            - msg_data
+
+    dockDiscoveryEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: dock_discovery
+            cat:
+              type: string
+              const: DEVICE
+            msg_data:
+              $ref: '#/components/schemas/dockDiscovery'
+          required:
+            - msg
+            - msg_data
+
+    dockSetupChangeEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: dock_setup_change
+            cat:
+              type: string
+              const: DEVICE
+            msg_data:
+              $ref: '#/components/schemas/dockSetupChange'
+          required:
+            - msg
+            - msg_data
+
+    dockUpdateChangeEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: dock_update_change
+            cat:
+              type: string
+              const: DEVICE
+            msg_data:
+              $ref: '#/components/schemas/dockUpdateChange'
+          required:
+            - msg
+            - msg_data
+
+    integrationDiscoveryEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: integration_discovery
+            cat:
+              type: string
+              const: DEVICE
+            msg_data:
+              $ref: '#/components/schemas/integrationDiscoveryEvent'
+          required:
+            - msg
+            - msg_data
+
+    integrationSetupChangeEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: integration_setup_change
+            cat:
+              type: string
+              const: DEVICE
+            msg_data:
+              $ref: '#/components/schemas/integrationSetupChange'
+          required:
+            - msg
+            - msg_data
+
+    softwareUpdateEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: software_update
+            cat:
+              type: string
+              const: REMOTE
+            msg_data:
+              $ref: '#/components/schemas/softwareUpdateEvent'
+          required:
+            - msg
+            - msg_data
+
+    powerModeChangeEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: power_mode_change
+            cat:
+              type: string
+              const: REMOTE
+            msg_data:
+              $ref: '#/components/schemas/powerModeChangeEvent'
+          required:
+            - msg
+            - msg_data
+
+    batteryStatusEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: battery_status
+            cat:
+              type: string
+              const: REMOTE
+            msg_data:
+              $ref: '#/components/schemas/batteryStatus'
+          required:
+            - msg
+            - msg_data
+
+    ambientLightChangeEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: ambient_light_change
+            cat:
+              type: string
+              const: REMOTE
+            msg_data:
+              $ref: '#/components/schemas/AmbientLight'
+          required:
+            - msg
+            - msg_data
+
+    # =========================================================================
+    # Event message schemas
+    # =========================================================================
+
+    error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message
+    ping:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: ping
+            msg_data:
+              type: object
+          required:
+            - msg
+    pong:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: pong
+            msg_data:
+              type: object
+          required:
+            - msg
+
+    warningEvent:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: warning
+            cat:
+              type: string
+              const: DEVICE
+            msg_data:
+              type: object
+              properties:
+                event:
+                  type: string
+                  enum:
+                    - LOW_BATTERY
+                    - OPEN_CASE
+                    - BATTERY_UNDERVOLT
+                shutdown:
+                  description: System initiated forced shutdown
+                  type: boolean
+                message:
+                  description: debug message
+                  type: string
+              required:
+                - event
+          required:
+            - msg
+            - msg_data
+
+    # =========================================================================
+    # Common schemas
+    # =========================================================================
+
+    msgId:
+      description: Request message ID which is reflected in response message.
+      type: integer
+      minimum: 0
+      default: 0
+
+    paging:
+      description: Paging information for returned items.
+      type: object
+      properties:
+        limit:
+          description: Number of returned items per page.
+          type: integer
+          format: int32
+          default: 10
+          minimum: 10
+        page:
+          description: Current page number. 1-based.
+          type: integer
+          format: int32
+          default: 1
+          minimum: 1
+
+    pagination:
+      description: Returned pagination information.
+      type: object
+      properties:
+        count:
+          description: Total number of items.
+          type: integer
+          format: int32
+          minimum: 0
+        limit:
+          description: Number of returned items.
+          type: integer
+          format: int32
+          minimum: 0
+        page:
+          description: Current page number. 1-based.
+          type: integer
+          format: int32
+          minimum: 1
+
+    versionInfo:
+      type: object
+      properties:
+        device_name:
+          description: Custom name of the remote
+          type: string
+        api:
+          description: API version
+          type: string
+        core:
+          description: Core app version
+          type: string
+        ui:
+          description: Frontend app version
+          type: string
+        os:
+          description: Operating system version
+          type: string
+        integrations: # untyped Map<string,string>
+          description: Versions of the available integrations. Map of (integration_name, version).
+          type: object
+          additionalProperties:
+            type: string
+
+    systemInfo:
+      type: object
+      properties:
+        model_name:
+          type: string
+        model_number:
+          type: string
+        serial_number:
+          type: string
+        hw_revision:
+          type: string
+
+    enabledFilter:
+      description: Simple filter by enabled flag.
+      type: object
+      properties:
+        filter:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+
+    intgDriverFilter:
+      description: Filter for integration drivers.
+      type: object
+      properties:
+        filter:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+            instantiable:
+              description: |
+                Filter if a driver is instantiable or not:
+                - true = only consider drivers which allow new integration instances to be created from. Either single-device drivers
+                  without an instance, or multi-device drivers.
+                - false = only drivers which allow no more instances
+                - NONE = any.
+              type: boolean
+            single_device:
+              description: |
+                true = only consider single-device drivers, false = only multi-device drivers, NONE = all.
+              type: boolean
+            has_instances:
+              description: |
+                Filter if a driver has integration instances or not:
+                - true = only consider drivers which have at least one integration instance,
+                - false = drivers without instances
+                - NONE = any.
+              type: boolean
+
+    availableEntityFilter:
+      description: Optional filters
+      type: object
+      properties:
+        integration_id:
+          $ref: '#/components/schemas/integrationId'
+        entity_types:
+          type: array
+          items:
+            $ref: '#/components/schemas/entityType'
+        entities:
+          $ref: '#/components/schemas/availEntitiesFilter'
+        text_search:
+          type: string
+          minLength: 1
+          maxLength: 50
+
+    availEntitiesFilter:
+      description: Filter available entities
+      type: string
+      enum:
+        - NEW
+        - CONFIGURED
+        - ALL
+    entityFilter:
+      description: Optional filters
+      type: object
+      properties:
+        integration_ids:
+          type: array
+          items:
+            $ref: '#/components/schemas/integrationId'
+        entity_types:
+          type: array
+          items:
+            $ref: '#/components/schemas/entityType'
+        text_search:
+          type: string
+          minLength: 1
+          maxLength: 50
+
+    entity: # YIO v1: loaded_entity
+      description: |
+        Configured entity in the remote to be used in one or more profiles.
+      type: object
+      properties:
+        entity_id:
+          $ref: '#/components/schemas/entityId'
+        entity_type:
+          $ref: '#/components/schemas/entityType'
+        integration_id:
+          $ref: '#/components/schemas/integrationId'
+        device_class:
+          description: |
+            Optional device type. This can be used by the UI to represent the entity with a different
+            icon, behaviour etc. See entity documentation for available device classes.
+          type: string
+        name:
+          description: |
+            Display name of the entity in the UI. An english text should always be provided as fallback option.
+          $ref: '#/components/schemas/languageText'
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+        features:
+          $ref: '#/components/schemas/entityFeatures'
+        options:
+          description: |
+            Feature options. See entity documentation for available options.
+          type: object
+        description:
+          $ref: '#/components/schemas/languageText'
+        attributes:
+          description: |
+            Dynamic entity attributes set by the integration driver. These are key/value pairs, see [integration entity
+            documentation](https://github.com/unfoldedcircle/core-api/tree/main/doc/entities) for detailed information.
+          type: object
+      required:
+        - entity_id
+        - entity_type
+        - integration_id
+        - name
+
+    entityUpdate:
+      description: |
+        Entity update data.
+        
+        If used in an update operation:
+        - Omitted properties will not change the configured value.
+        - An empty `icon` value will remove the icon identifier.
+        - `entity_id`, `entity_type` and `integration_id` cannot be changed.
+        
+        If returned in an `entity_change` event:
+        - Additional properties from the regular `entity` object might be included as well.
+      type: object
+      properties:
+        entity_id:
+          $ref: '#/components/schemas/entityId'
+        name:
+          $ref: '#/components/schemas/languageText'
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+# we had this in v1, but it's probably a risky feature allowing to change / disable features
+#        features:
+#          $ref: '#/components/schemas/entityFeatures'
+        description:
+          $ref: '#/components/schemas/languageText'
+      required:
+        - entity_id
+
+    available_entity:
+      description: Provided entity from an integration which can be configured to be used in the remote.
+      type: object
+      properties:
+        entity_id:
+          $ref: '#/components/schemas/entityId'
+        entity_type:
+          $ref: '#/components/schemas/entityType'
+        integration_id:
+          $ref: '#/components/schemas/integrationId'
+        name:
+          $ref: '#/components/schemas/languageText'
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+        features:
+          $ref: '#/components/schemas/entityFeatures'
+        area:
+          description: Optional area if supported by the integration. E.g. `Living room`
+          type: string
+      required:
+        - entity_id
+        - entity_type
+        - integration_id
+        - name
+
+    entityFeatures:
+      type: array
+      items:
+        $ref: '#/components/schemas/entityFeature'
+    entityFeature:
+      type: string
+    entityCommand:
+      description: |
+        Entity command identifier, as returned in the entity command metadata.
+        
+        This identifier may change at any time and may not be used for logic decisions in a client!
+        If entity specific information is required, the entity object must be loaded from the `entity_id`.
+      type: string
+    entityType:
+      description: Entity type.
+      type: string
+      enum:
+        - button
+        - climate
+        - cover
+        - light
+        - media_player
+        - sensor
+        - switch
+        - activity
+        - macro
+        - remote
+
+    ActivityGroup:
+      description: |
+        An activity group creates a dependency between multiple activities. Switching between activities will consider
+        the current state of the included entities and only turn-on or -off the required entities.
+      type: object
+      properties:
+        group_id:
+          $ref: '#/components/schemas/entityId'
+        name:
+          $ref: '#/components/schemas/languageText'
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+        description:
+          $ref: '#/components/schemas/languageText'
+        options:
+          $ref: '#/components/schemas/ActivityGroupOptions'
+        activities:
+          description: Included activities in the group.
+          type: array
+          items:
+            $ref: '#/components/schemas/IncludedActivity'
+
+    IncludedActivity:
+      description: |
+        Minimal activity object to show the activity in a user interface with it's friendly name and icon.
+      type: object
+      properties:
+        entity_id:
+          $ref: '#/components/schemas/entityId'
+        name:
+          $ref: '#/components/schemas/languageText'
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+        state:
+          $ref: '#/components/schemas/SequenceState'
+      required:
+        - entity_id
+        - name
+
+    SequenceState:
+      description: |
+        State of an Activity or Macro sequence:
+        - `RUNNING`: Sequence is currently running
+        - `COMPLETED`: Final state for a macro
+        - `ON`: Final activity state for the `on` sequence
+        - `OFF`: Final activity state for the `off` sequence
+        - `STOPPED`: The sequence was aborted with a stop request
+        - `TIMEOUT`: The sequence timed out and was aborted
+        - `ERROR`: There was an error running the sequence and did not complete
+      type: string
+      enum:
+        - RUNNING
+        - COMPLETED
+        - ON
+        - OFF
+        - STOPPED
+        - TIMEOUT
+        - ERROR
+
+    ActivityGroupOptions:
+      description: |
+        👷Not yet finalized!
+
+        Activity group specific options, e.g. how delays are handled when switching between activities.
+      type: object
+      properties:
+        remove_turn_on_delays:
+          description: |
+            - `previous_cmd_skipped`: Only remove delay steps if the previous step is skipped, because the entity is in a
+               power-on state.
+            - `between_skipped_cmds`: Only remove delay steps if the previous and next power-on steps are skipped, because
+               the entity is already in a power-on state.
+            - `never`: Never remove delay steps in the on-sequence of the new activity.
+          type: string
+          enum:
+            - previous_cmd_skipped
+            - between_skipped_cmds
+            - never
+        turn_off_unused_entities:
+          description: |
+            - `always`: Always turn off unused entities in the previous activity.
+            - `in_off_sequence`: Only turn off unused entities which are included in the off-sequence of the previous activity.
+            - `never`: Never turn off entities in the previous activity.
+          type: string
+          enum:
+            - always
+            - in_off_sequence
+            - never
+
+    languageCode:
+      description: |
+        Language culture code: starting with the two-letter [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+        code, followed by an optional [ISO-3166 country code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes),
+        separated by an underscore.
+        Examples: `en`, `en_UK`, `en_US`, `de`, `de_DE`, `de_CH` etc.
+      type: string
+      pattern: '^[a-z]{2}(_\w+)?$'
+
+    countryCode:
+      description: Two letter country code according to [ISO-3166-1-alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
+      type: string
+      format: iso-3166
+
+    languageText: # untyped Map<string,string>
+      type: object
+      description: Display text in the UI. An english text should always be provided as fallback option.
+      patternProperties:
+        ^[a-z]{2}(_\w+)?$: # TODO make culture code pattern more strict or more open?
+          type: string
+          description: |
+            Key value pairs of language texts. Key: ISO 639-1 code with optional country suffix to represent a `culture
+            code`. Examples: `en`, `en_UK`, `en_US`, `de`, `de_CH`.   
+            If we need to support more regional differences within a country, then the
+            [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag) might be a solution. This would even
+            support the various Swiss German dialects!
+      additionalProperties: false
+
+    getConfigurationOptions:
+      description: Optional request parameters.
+      type: object
+      properties:
+        default:
+          description: |
+            Get default values instead of configured values. Intended for a "default settings" function in the UI.
+          type: boolean
+          default: false
+
+    # =========================================================================
+    # from OpenAPI
+    # TODO use shared json schema! -> check if supported by new releases of the bundle & doc generation tools
+    # =========================================================================
+
+    configuration:
+      type: object
+      properties:
+        button:
+          $ref: '#/components/schemas/cfgButton'
+        device:
+          $ref: '#/components/schemas/cfgDevice'
+        display:
+          $ref: '#/components/schemas/cfgDisplay'
+        features:
+          $ref: '#/components/schemas/cfgFeatures'
+        haptic:
+          $ref: '#/components/schemas/cfgHaptic'
+        localization:
+          $ref: '#/components/schemas/cfgLocalization'
+        network:
+          $ref: '#/components/schemas/cfgNetwork'
+        power_saving:
+          $ref: '#/components/schemas/cfgPowerSaving'
+        profile:
+          $ref: '#/components/schemas/cfgProfile'
+        software_update:
+          $ref: '#/components/schemas/cfgSoftwareUpdate'
+        sound:
+          $ref: '#/components/schemas/cfgSound'
+        voice_control:
+          $ref: '#/components/schemas/cfgVoiceControl'
+        restart_required:
+          description: A configuration change requires a restart.
+          type: boolean
+
+    cfgButton:
+      type: object
+      properties:
+        brightness:
+          description: Button backlight brightness. 0 = off, 100 = max.
+          type: integer
+          minimum: 0
+          maximum: 100
+        auto_brightness:
+          description: When enabled, button backlight will automatically turn on in a dark room.
+          type: boolean
+      required:
+        - brightness
+        - auto_brightness
+
+    cfgDevice:
+      type: object
+      properties:
+        name:
+          description: Custom name of the remote
+          type: string
+          minimum: 1
+          maximum: 50
+      required:
+        - name
+
+    cfgDisplay:
+      type: object
+      properties:
+        brightness:
+          description: Display brightness.
+          type: integer
+          minimum: 0
+          maximum: 100
+        auto_brightness:
+          description: Automatically adjust the display brightness based on ambient lighting conditions.
+          type: boolean
+      required:
+        - brightness
+        - auto_brightness
+
+    cfgFeatures:
+      type: array
+      items:
+        $ref: '#/components/schemas/cfgFeature'
+
+    cfgFeature:
+      type: object
+      properties:
+        id:
+          type: string
+        enabled:
+          type: boolean
+        title:
+          $ref: '#/components/schemas/languageText'
+        description:
+          $ref: '#/components/schemas/languageText'
+        help_url:
+          type: string
+          format: url
+      required:
+        - id
+        - enabled
+        - title
+        - description
+
+    cfgFeatureUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+        enabled:
+          type: boolean
+      required:
+        - id
+        - enabled
+
+    cfgHaptic:
+      type: object
+      properties:
+        enabled:
+          description: Haptic feedback enabled.
+          type: boolean
+      required:
+        - enabled
+
+    cfgLocalization:
+      type: object
+      properties:
+        language_code:
+          $ref: '#/components/schemas/languageCode'
+        country_code:
+          $ref: '#/components/schemas/countryCode'
+        time_zone:
+          description: Time zone name according to IANA <https://www.iana.org/time-zones>, e.g. `Europe/Copenhagen`.
+          type: string
+        time_format_24h:
+          type: boolean
+        measurement_unit:
+          $ref: '#/components/schemas/measurementUnit'
+      required:
+        - language_code
+        - country_code
+        - time_zone
+        - time_format_24h
+        - measurement_unit
+
+    measurementUnit:
+      type: string
+      enum:
+        - METRIC
+        - US
+        - UK
+
+    cfgNetwork:
+      type: object
+      properties:
+        bt_enabled:
+          description: Enable Bluetooth.
+          type: boolean
+        wifi_enabled:
+          description: Enable WiFi.
+          type: boolean
+        bt:
+          description: Temporary read-only Bluetooth information until dedicated BT management endpoint is provided.
+          type: object
+          properties:
+            address:
+              description: Bluetooth MAC address
+              type: string
+        ws:
+          description: |
+            Optional expert settings for WebSocket (re-)connection handling.  
+            These settings are only intended for support issues and might change any time. Changed values are not supported
+            and might make the system unstable!
+          type: object
+          properties:
+            dock:
+              type: object
+            integration:
+              type: object
+      required:
+        - bt_enabled
+        - wifi_enabled
+
+    cfgPowerSaving:
+      type: object
+      properties:
+        wakeup_sensitivity:
+          description: Amount of movement needed to wake up the remote. 0 = disabled, 1 = min, 2 = medium, 3 = max.
+          type: integer
+          minimum: 0
+          maximum: 3
+        display_off_sec:
+          type: integer
+          minimum: 0
+          maximum: 60
+          description: Turn off display after given seconds.
+        standby_sec:
+          type: integer
+          minimum: 0
+          maximum: 10800
+          description: Activate standby after given seconds. 0 disables standby mode.
+      required:
+        - wakeup_sensitivity
+        - display_off_sec
+        - standby_sec
+
+    cfgProfile:
+      type: object
+      properties:
+        has_admin_pin:
+          description: An administrator pin has been set to use restricted profiles.
+          type: boolean
+      required:
+        - has_admin_pin
+
+    cfgProfileUpdate:
+      type: object
+      properties:
+        admin_pin:
+          $ref: '#/components/schemas/adminPin'
+
+    cfgSoftwareUpdate:
+      type: object
+      properties:
+        check_for_updates:
+          description: |
+            Automatically check for updates. If `auto_update` is enabled, the updates are automatically installed,
+            otherwise the user is only notified about the updates.
+
+            The time window when to check for new updates can be specified in `ota_window_start` and `ota_window_end`.
+            Update checks are performed daily.
+          type: boolean
+        auto_update:
+          description: |
+            Automatically update the remote when new software is available. Requires `check_for_updates` to be enabled.
+
+            Auto-installation of new firmwares will usually happen over 2 update checks: the first check finds a new
+            update, downloads the metadata and schedules the firmware file to be downloaded. The next check will find the
+            downloaded firmware file and installs it.
+          type: boolean
+        ota_window_start:
+          description: |
+            OTA update window start time: automatic update checks will only be performed during this time window.  
+            Furthermore, the remote needs to be in the docking station and have enough battery charge.
+
+            Format: time of day - as defined by `partial-time` in RFC3339
+          type: string
+          pattern: "^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$"
+        ota_window_end:
+          description: |
+            OTA update window end time.
+
+            - If the end time is before the start time, the window will spawn over midnight, e.g. `23:00:00` - `01:00:00`.
+            - Both start and end times are required, otherwise a default will be used.
+          type: string
+          pattern: "^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$"
+        channel:
+          description: |
+            Software update channels:
+            - `default`: release channel
+            - `testing`: new test and beta versions which might become the next release if successfully tested.
+            - `development`: untested alpha versions from the developers.  
+               ⚠️ High chance of breaking changes, bugs and loosing data!
+
+            Other channels than `default` might require an access token in `channel_token`, since they are intended for
+            a closed user group.
+          type: string
+          anyOf:
+            - enum:
+                - default
+                - testing
+                - development
+            - { }  # extensible enum: there might be more channels than defined above
+        channel_token:
+          description: |
+            Optional access token which might be required for non-default software update channels.
+            - This token is write only and cannot be retrieved anymore.
+            - If omitted when updating settings: the stored token will be used.
+            - If the `default` channel is selected when updating settings: the token will be ignored.
+          type: string
+          pattern: "^[-a-zA-Z0-9._~+/]{1,256}=?$"
+      required:
+        - check_for_updates
+        - auto_update
+
+    cfgSound:
+      type: object
+      properties:
+        enabled:
+          description: Sound effects enabled.
+          type: boolean
+        volume:
+          description: Sound effects volume.
+          type: integer
+          minimum: 0
+          maximum: 100
+      required:
+        - enabled
+        - volume
+
+    cfgVoiceControl:
+      type: object
+      properties:
+        microphone:
+          description: |
+            Enable microphone. Disabling the microphone will completely turn it off. Voice control and dictation won't work
+            with the remote or integrations.
+          type: boolean
+        enabled:
+          description: |
+            Enable voice control. Disabling voice control will still let you use voice dictation with integrations. 
+            Disable the microphone to completely switch off any microphone related functionality.
+          type: boolean
+        voice_assistant:
+          $ref: '#/components/schemas/voiceAssistant'
+      required:
+        - microphone
+        - enabled
+        - voice_assistant
+
+    voiceAssistant:
+      description: 🚧 Supported voice assistants. TODO not yet implemented.
+      type: string
+      enum:
+        - None
+
+    integrationStatus:
+      type: object
+      description: |
+        Integration instance status information. Intended to be used in a general overview of the integration drivers.
+      properties:
+        integration_id:
+          $ref: '#/components/schemas/integrationId'
+        name:
+          $ref: '#/components/schemas/languageText'
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+        device_state:
+          $ref: '#/components/schemas/deviceState'
+        driver_state:
+          $ref: '#/components/schemas/driverState'
+        state:
+          $ref: '#/components/schemas/integrationState'
+        enabled:
+          type: boolean
+
+    deviceState:
+      type: string
+      enum:
+        - UNKNOWN
+        - CONNECTING
+        - CONNECTED
+        - DISCONNECTED
+        - ERROR
+
+    driverState:
+      type: string
+      enum:
+        - NOT_CONFIGURED
+        - IDLE
+        - CONNECTING
+        - ACTIVE
+        - RECONNECTING
+        - ERROR
+
+    integrationState:
+      type: string
+      enum:
+        - NOT_CONFIGURED
+        - UNKNOWN
+        - IDLE
+        - CONNECTING
+        - CONNECTED
+        - DISCONNECTED
+        - RECONNECTING
+        - ACTIVE
+        - ERROR
+
+    integrationDriverType:
+      type: string
+      enum:
+        - LOCAL
+        - EXTERNAL
+
+    integrationDriverInfo:
+      description: |
+        Summary data of an integration driver intended for overview screens.
+      type: object
+      properties:
+        driver_id:
+          $ref: '#/components/schemas/driverId'
+        name:
+          $ref: '#/components/schemas/languageText'
+        developer_name:
+          type: string
+        driver_type:
+          $ref: '#/components/schemas/integrationDriverType'
+        driver_url:
+          description: WebSocket URL of the driver
+          type: string
+          format: uri
+          maxLength: 2048
+        version:
+          type: string
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+        enabled:
+          type: boolean
+        driver_state:
+          $ref: "#/components/schemas/driverState"
+      required:
+        - driver_id
+        - name
+        - driver_type
+        - version
+        - enabled
+
+    integrationDriver: # YIO v1: supported_integration
+      description: |
+        Integration driver model.
+        
+        A driver represents the communication aspect of an integration. E.g. how one can connect to it
+        and which API version it supports.
+        
+        One driver can provide multiple `Integration` instances. In the integration API they are
+        referred to as `multi-device integrations` and use the optional `device_id` property where
+        required. If a driver only provides a single instance, which is usually the default use case,
+        then the `device_id` is not used (or set to the default value `main`).
+      type: object
+      properties:
+        driver_id:
+          $ref: '#/components/schemas/driverId'
+        name:
+          $ref: '#/components/schemas/languageText'
+        driver_type:
+          $ref: '#/components/schemas/integrationDriverType'
+        driver_url:
+          description: WebSocket URL of the driver. Only optional for integration driver metadata.
+          type: string
+          format: uri
+          maxLength: 2048
+        token:
+          description: |
+            Optional driver authentication token.
+            
+            Note: the token will not be returned to external clients!
+          type: string
+          maxLength: 2048
+        auth_method:
+          $ref: '#/components/schemas/intgAuthMethod'
+        version:
+          description: Driver version, [SemVer](https://semver.org/) preferred.
+          type: string
+          maxLength: 20
+        min_core_api:
+          description: |
+            Optional version check: minimum required Core-API version in the remote.
+          type: string
+          maxLength: 20
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+        enabled:
+          description: |
+            Enables or disables driver communication.  
+            If disabled, all integration instances won't be activated, even if the instance is enabled.
+          type: boolean
+        description:
+          $ref: '#/components/schemas/languageText'
+        developer:
+          $ref: '#/components/schemas/driverDeveloper'
+        home_page:
+          description: Optional home page url for more information.
+          type: string
+          format: uri
+          maxLength: 255
+        device_discovery:
+          description: Driver supports multi-device discovery. **Not yet supported**.
+          type: boolean
+        setup_data_schema:
+          description: |
+            Driver configuration metadata describing configuration parameters for the web-configurator.
+            
+            **Not yet finalized**.
+          type: object
+          #$ref: '#/components/schemas/settingsPage'
+        release_date:
+          description: Release date of the driver.
+          type: string
+          format: date
+        driver_state:
+          $ref: "#/components/schemas/driverState"
+      required:
+        - driver_id
+        - name
+        - version
+
+    driverDeveloper:
+      type: object
+      description: Optional information about the integration developer.
+      properties:
+        name:
+          description: Optional developer information to display in UI / web-configurator.
+          type: string
+          maxLength: 50
+        url:
+          description: Optional developer home page.
+          type: string
+          format: uri
+          maxLength: 255
+        email:
+          description: Optional developer contact email.
+          type: string
+          format: email
+          maxLength: 100
+
+    integrationDriverUpdate:
+      type: object
+      description: |
+        Integration driver update model. This model corresponds to the `IntegrationDriver` model except there are no required
+        properties to allow patch updates. 
+
+        - Specified properties will update the current values.
+        - An empty value will delete the currently set property.
+        - For the create operation, the `driver_id` identifier can be specified by the client, but it needs to be unique among
+          all drivers. If omitted, a UUID will be assigned.  
+          A manually assigned, short, human-readable identifier is recommended for better recognizability.
+      properties:
+        driver_id:
+          $ref: '#/components/schemas/driverId'
+        name:
+          $ref: '#/components/schemas/languageText'
+        driver_url:
+          description: WebSocket URL of the driver
+          type: string
+          format: uri
+          maxLength: 2048
+        token:
+          description: |
+            Optional driver authentication token.
+            
+            Note: the token will not be returned to external clients!
+          type: string
+          maxLength: 2048
+        auth_method:
+          $ref: '#/components/schemas/intgAuthMethod'
+        version:
+          description: Driver version, [SemVer](https://semver.org/) preferred.
+          type: string
+          maxLength: 20
+        min_core_api:
+          description: |
+            Optional version check: minimum required Core-API version in the remote.
+          type: string
+          maxLength: 20
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+        enabled:
+          description: |
+            Enables or disables driver communication.  
+            If disabled, all integration instances won't be activated, even if the instance is enabled.
+          type: boolean
+        description:
+          $ref: '#/components/schemas/languageText'
+        developer:
+          $ref: '#/components/schemas/driverDeveloper'
+        home_page:
+          description: Optional home page url for more information.
+          type: string
+          format: uri
+          maxLength: 255
+        device_discovery:
+          description: Driver supports multi-device discovery. **Not yet supported**.
+          type: boolean
+        setup_data_schema:
+          description: |
+            Driver configuration metadata describing configuration parameters for the web-configurator.
+            
+            **TODO Not yet finalized**.
+          type: object
+          #$ref: '#/components/schemas/settingsPage'
+        release_date:
+          description: Release date of the driver.
+          type: string
+          format: date
+      required:
+        - driver_id
+
+    integration: # YIO v1: loaded_integration
+      description: |
+        An integration instance represents a configured integration driver.
+        
+        TODO add connection state?
+      type: object
+      properties:
+        integration_id:
+          $ref: '#/components/schemas/integrationId'
+        driver_id:
+          $ref: '#/components/schemas/driverId'
+        device_id:
+          $ref: '#/components/schemas/deviceId'
+        name:
+          $ref: '#/components/schemas/languageText'
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+        enabled:
+          type: boolean
+        setup_data:
+          description: Optional configuration data if supported or required by the driver.
+          type: object
+        device_state:
+          $ref: "#/components/schemas/deviceState"
+      required:
+        - integration_id
+        - driver_id
+        - name
+        - enabled
+
+    integrationUpdate:
+      type: object
+      description: |
+        Integration instance update model. This model corresponds to the `Integration` model except there are no required
+        properties to allow patch updates. 
+
+        - Specified properties will update the current values.
+        - An empty value will delete a set property.
+        - `device_id` is only required for multi-device integrations.
+      properties:
+        integration_id:
+          $ref: '#/components/schemas/integrationId'
+        driver_id:
+          $ref: '#/components/schemas/driverId'
+        device_id:
+          $ref: '#/components/schemas/deviceId'
+        name:
+          $ref: '#/components/schemas/languageText'
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+        enabled:
+          description: Enable / disable flag. For development use only!
+          type: boolean
+        setup_data:
+          description: Instance configuration object.
+          type: object
+      required:
+        - integration_id
+
+    IntegrationDiscoveryStatus:
+      type: object
+      properties:
+        active:
+          description: |
+            Integration discovery still active or not.
+          type: boolean
+        integrations:
+          type: array
+          items:
+            $ref: "#/components/schemas/integrationDiscoveryInformation"
+      required:
+        - discovery_active
+        - integrations
+
+    CreateIntegrationSetup:
+      type: object
+      properties:
+        driver_id:
+          $ref: '#/components/schemas/driverId'
+        name:
+          $ref: '#/components/schemas/languageText'
+        setup_data:
+          $ref: '#/components/schemas/SettingsValues'
+        reconfigure:
+          description: Reconfigure an already configured integration.
+          type: boolean
+      required:
+        - driver_id
+
+    IntegrationSetupInfo:
+      type: object
+      description: Integration setup state
+      properties:
+        id:
+          type: string
+        state:
+          $ref: '#/components/schemas/integrationSetupState'
+        error:
+          $ref: '#/components/schemas/integrationSetupError'
+        require_user_action:
+          description: If set, the setup process waits for the specified user action.
+          oneOf:
+            - type: object
+              properties:
+                input:
+                  type: object
+                  $ref: '#/components/schemas/SettingsPage'
+              required:
+                - input
+            - type: object
+              properties:
+                confirmation:
+                  type: object
+                  $ref: '#/components/schemas/ConfirmationPage'
+              required:
+                - confirmation
+      required:
+        - id
+        - state
+
+    entityChange:
+      type: object
+      description: |
+        The `new_state` property is omitted for `event_type` = `delete`.  
+        The client should reload all entity data, if only `event_type` is present.
+      properties:
+        event_type:
+          $ref: '#/components/schemas/defaultChangeEventType'
+        entity_id:
+          $ref: '#/components/schemas/entityId'
+        entity_type:
+          $ref: '#/components/schemas/entityType'
+        new_state:
+          $ref: '#/components/schemas/entityUpdate'
+      required:
+        - event_type
+
+    activityGroupChange:
+      type: object
+      description: |
+        The `new_state` property is omitted for `event_type` = `delete`.  
+        The client should reload all activity group data, if only `event_type` is present.
+      properties:
+        event_type:
+          $ref: '#/components/schemas/defaultChangeEventType'
+        group_id:
+          $ref: '#/components/schemas/entityId'
+        new_state:
+          $ref: '#/components/schemas/ActivityGroup'
+      required:
+        - event_type
+
+    profileChange:
+      type: object
+      description: |
+        The `new_state` property is omitted for `event_type` = `delete`.
+      properties:
+        event_type:
+          $ref: '#/components/schemas/defaultChangeEventType'
+        profile_id:
+          $ref: '#/components/schemas/simpleId'
+        page_id:
+          $ref: '#/components/schemas/simpleId'
+        group_id:
+          $ref: '#/components/schemas/simpleId'
+        new_state:
+          type: object
+          properties:
+            profile:
+              $ref: '#/components/schemas/profileData'
+            page:
+              $ref: '#/components/schemas/pageData'
+            group:
+              $ref: '#/components/schemas/groupData'
+      required:
+        - event_type
+        - profile_id
+
+    integrationDriverChange:
+      type: object
+      description: |
+        The `new_state` property is omitted for `event_type` = `delete`.
+      properties:
+        event_type:
+          $ref: '#/components/schemas/defaultChangeEventType'
+        driver_id:
+          $ref: '#/components/schemas/driverId'
+        new_state:
+          $ref: '#/components/schemas/integrationDriverUpdate'
+      required:
+        - event_type
+        - driver_id
+
+    integrationChange:
+      type: object
+      description: |
+        The `new_state` property is omitted for `event_type` = `delete`.
+      properties:
+        event_type:
+          $ref: '#/components/schemas/defaultChangeEventType'
+        integration_id:
+          $ref: '#/components/schemas/integrationId'
+        new_state:
+          $ref: '#/components/schemas/integrationUpdate'
+      required:
+        - event_type
+        - integration_id
+
+    integrationStateData:
+      type: object
+      properties:
+        driver_id:
+          $ref: '#/components/schemas/driverId'
+        device_state:
+          $ref: '#/components/schemas/deviceState'
+        driver_state:
+          $ref: '#/components/schemas/driverState'
+      required:
+        - driver_id
+
+    defaultChangeEventType:
+      type: string
+      enum:
+        - change
+        - new
+        - delete
+
+    configurationChange:
+      type: object
+      properties:
+        new_state:
+          $ref: '#/components/schemas/configuration'
+      required:
+        - new_state
+
+    irLearning:
+      type: object
+      properties:
+        device_id:
+          description: IR emitter device identifier.
+          type: string
+        event_type:
+          type: string
+          enum:
+            - START
+            - STOP
+            - CODE
+        code:
+          $ref: '#/components/schemas/irLearningCode'
+      required:
+        - device_id
+        - event_type
+
+    irLearningCode:
+      type: object
+      properties:
+        format:
+          description: IR format of learned IR code data.
+          type: string
+          enum:
+            - HEX
+            - PRONTO
+        value:
+          description: Learned IR code data.
+          type: string
+      required:
+        - format
+        - value
+
+    dockId:
+      type: string
+      format: "^[a-zA-Z0-9\\-\\.]+$"
+      minLength: 1
+      maxLength: 64
+      description: Dock identifier
+
+    dockName:
+      type: string
+      minLength: 1
+      maxLength: 40
+      description: User assignable friendly name to use instead of dock_id (service name).
+
+    dockUrl:
+      type: string
+      maxLength: 64
+      description: Dock WebSocket URL to override auto-discovery from the service name in `dock_id`.
+
+    dockToken:
+      type: string
+      format: password
+      minLength: 1
+      maxLength: 40
+      description: Access token
+
+    dockFilter:
+      description: Optional filters
+      type: object
+      properties:
+        active:
+          type: boolean
+
+    dockChangeData:
+      type: object
+      description: |
+        The `new_state` property is omitted for `event_type` = `delete`.
+      properties:
+        event_type:
+          $ref: '#/components/schemas/defaultChangeEventType'
+        dock_id:
+          $ref: '#/components/schemas/entityId'
+        new_state:
+          $ref: '#/components/schemas/dockConfiguration'
+      required:
+        - event_type
+        - dock_id
+
+    dockConfiguration:
+      type: object
+      properties:
+        dock_id:
+          type: string
+        name:
+          type: string
+        custom_ws_url:
+          type: string
+        resolved_ws_url:
+          type: string
+          maxLength: 64
+          description: Resolved WebSocket URL from the service name in `dock_id` if no `custom_ws_url` is used.
+        active:
+          type: boolean
+          description: |
+            Enable flag: active docks are automatically connected when network is available.
+        model:
+          type: string
+          description: Dock model number.
+        revision:
+          type: string
+          description: Dock revision.
+        serial:
+          type: string
+          description: Dock serial number.
+        led_brightness:
+          type: integer
+          minimum: 0
+          maximum: 100
+        eth_led_brightness:
+          type: integer
+          minimum: 0
+          maximum: 100
+        connection_type:
+          type: string
+          description: |
+            Network connection of the dock: `Ethernet` or `WiFi`.
+        version:
+          type: string
+          description: Firmware version
+        state:
+          $ref: '#/components/schemas/dockState'
+        learning_active:
+          type: boolean
+          description: Dock is in IR learning mode.
+        description:
+          $ref: '#/components/schemas/description'
+      required:
+        - dock_id
+        - active
+
+    dockConfigurationRequest: # from OpenAPI
+      type: object
+      properties:
+        dock_id:
+          $ref: '#/components/schemas/dockId'
+        name:
+          $ref: '#/components/schemas/dockName'
+        custom_ws_url:
+          $ref: '#/components/schemas/dockUrl'
+        token:
+          $ref: '#/components/schemas/dockToken'
+        active:
+          type: boolean
+          description: |
+            Enable flag: active docks are automatically connected when network is available.
+        model:
+          type: string
+          description: Dock model number.
+        description:
+          $ref: '#/components/schemas/description'
+      required:
+        - dock_id
+        - active
+
+    dockUpdateRequest:
+      type: object
+      properties:
+        dock_id:
+          $ref: '#/components/schemas/dockId'
+        name:
+          type: string
+          maxLength: 40
+          description: User assignable friendly name to use instead of dock_id (service name).
+        custom_ws_url:
+          $ref: '#/components/schemas/dockUrl'
+        token:
+          type: string
+          maxLength: 40
+          description: Access token to connect to the dock.
+        active:
+          type: boolean
+          description: Auto connect to dock when network is available.
+        description:
+          type: string
+          description: Optional description.
+        wifi:
+          type: object
+          properties:
+            ssid:
+              description: Network name (service set identifier)
+              type: string
+              maxLength: 32
+            password:
+              type: string
+              maxLength: 63
+      required:
+        - dock_id
+
+    dockSystemInfo:
+      type: object
+      properties:
+        name:
+          type: string
+        hostname:
+          type: string
+        model:
+          type: string
+        revision:
+          type: string
+        version:
+          type: string
+        serial:
+          type: string
+        ir_learning:
+          type: boolean
+        ethernet:
+          type: boolean
+        wifi:
+          type: boolean
+        ssid:
+          description: Network name (service set identifier)
+          type: string
+
+    dockStateData:
+      type: object
+      properties:
+        dock_id:
+          type: string
+        state:
+          $ref: '#/components/schemas/dockState'
+      required:
+        - dock_id
+        - state
+
+    dockState:
+      type: string
+      enum:
+        - IDLE
+        - CONNECTING
+        - ACTIVE
+        - RECONNECTING
+        - ERROR
+
+    dockDiscovery:
+      type: object
+      properties:
+        event_type:
+          type: string
+          enum:
+            - START
+            - STOP
+            - DISCOVER
+        dock:
+          $ref: '#/components/schemas/dockDiscoveryInformation'
+      required:
+        - event_type
+
+    dockDiscoveryInformation:
+      type: object
+      properties:
+        id:
+          type: string
+        configured:
+          type: boolean
+        friendly_name:
+          type: string
+        address:
+          description: Resolved device network address.
+          type: string
+        model:
+          description: Detected dock model.
+          type: string
+        version:
+          description: Detected firmware version.
+          type: string
+        discovery_type:
+          $ref: '#/components/schemas/discoveryType'
+        timestamp:
+          description: Timestamp of dock discovery.
+          type: string
+          format: date-time
+        bt:
+          type: object
+          description: Optional Bluetooth discovery information. Not present for network device.
+          properties:
+            signal:
+              description: Bluetooth signal strength. 0 = min, 5 = max.
+              type: integer
+              minimum: 0
+              maximum: 5
+            last_seen_sec:
+              description: |
+                Last time the device was seen on a Bluetooth scan. Values over 15 sec indicate that the device is no longer
+                reachable.
+              type: integer
+              format: int32
+      required:
+        - id
+        - configured
+        - discovery_type
+
+    discoveryType:
+      type: string
+      description: |
+        Device discovery type:
+        - `BT`: Bluetooth
+        - `NET`: LAN or WAN network
+      enum:
+        - BT
+        - NET
+
+    createDockSetup:
+      type: object
+      oneOf:
+        - type: object
+          properties:
+            discovery:
+              $ref: "#/components/schemas/dockSetupFromDiscovery"
+          required:
+            - discovery
+        - type: object
+          properties:
+            manually:
+              $ref: "#/components/schemas/dockSetup"
+          required:
+            - manual
+
+    dockSetup:
+      type: object
+      description: Dock setup data
+      properties:
+        dock_id:
+          $ref: "#/components/schemas/dockId"
+        name:
+          $ref: '#/components/schemas/dockName'
+        token:
+          $ref: '#/components/schemas/dockToken'
+        custom_ws_url:
+          $ref: '#/components/schemas/dockUrl'
+        description:
+          $ref: '#/components/schemas/description'
+        wifi:
+          description: |
+            Optional WiFi information if the dock should connect to (or be prepared for) WiFi instead of Ethernet.
+          type: object
+          properties:
+            ssid:
+              description: Network name (service set identifier)
+              type: string
+            password:
+              type: string
+              format: password
+          required:
+            - ssid
+            - password
+      required:
+        - name
+
+    dockSetupFromDiscovery: # subset of DockDiscovery
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/dockId"
+        friendly_name:
+          $ref: "#/components/schemas/dockName"
+        address:
+          description: Resolved device network address.
+          type: string
+        model:
+          description: Detected dock model.
+          type: string
+        version:
+          description: Detected firmware version.
+          type: string
+        discovery_type:
+          $ref: "#/components/schemas/discoveryType"
+      required:
+        - id
+        - discovery_type
+
+    dockSetupInfo:
+      type: object
+      description: Dock setup state
+      properties:
+        id:
+          type: string
+        name:
+          $ref: "#/components/schemas/dockName"
+        discovery_type:
+          $ref: "#/components/schemas/discoveryType"
+        state:
+          $ref: "#/components/schemas/dockSetupState"
+        error:
+          $ref: "#/components/schemas/dockSetupError"
+      required:
+        - id
+        - state
+
+    dockSetupChange:
+      type: object
+      properties:
+        event_type:
+          type: string
+          enum:
+            - START
+            - SETUP
+            - STOP
+        dock_id:
+          type: string
+        state:
+          $ref: '#/components/schemas/dockSetupState'
+        error:
+          $ref: '#/components/schemas/dockSetupError'
+      required:
+        - event_type
+        - dock_id
+        - state
+
+    dockSetupState:
+      type: string
+      enum:
+        - NEW
+        - CONFIGURING
+        - UPLOADING
+        - RESTARTING
+        - OK
+        - ERROR
+
+    dockSetupError:
+      type: string
+      enum:
+        - NONE
+        - NOT_FOUND
+        - CONNECTION_ERROR
+        - CONNECTION_REFUSED
+        - AUTHORIZATION_ERROR
+        - TIMEOUT
+        - ABORT
+        - PERSISTENCE_ERROR
+        - OTHER
+
+    dockUpdateChange:
+      type: object
+      properties:
+        event_type:
+          type: string
+          enum:
+            - START
+            - UPDATE
+            - STOP
+        dock_id:
+          type: string
+        update_id:
+          description: Update identifier
+          type: string
+        version:
+          description: Firmware version being installed
+          type: string
+        progress:
+          description: Update progress in percent
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 100
+        state:
+          $ref: '#/components/schemas/dockSetupState'
+        error:
+          $ref: '#/components/schemas/dockSetupError'
+      required:
+        - event_type
+        - dock_id
+        - state
+
+    AvailableSystemUpdateResponse:
+      type: object
+      properties:
+        update_in_progress:
+          type: boolean
+        last_check_date:
+          description: Last update check timestamp.
+          type: string
+          format: date-time
+        next_check_date:
+          description: Next scheduled update check timestamp.
+          type: string
+          format: date-time
+        update_check_enabled:
+          type: boolean
+        installed_version:
+          description: Installed system version.
+          type: string
+        available:
+          type: array
+          items:
+            $ref: '#/components/schemas/AvailableSystemUpdate'
+      required:
+        - update_check_enabled
+        - installed_version
+        - available
+
+    AvailableSystemUpdate:
+      type: object
+      properties:
+        id:
+          description: Update identifier
+          type: string
+        title:
+          type: string
+        description:
+          $ref: '#/components/schemas/languageText'
+        version:
+          type: string
+        channel:
+          $ref: '#/components/schemas/UpdateChannel'
+        release_date:
+          type: string
+          format: date
+        size:
+          type: integer
+          format: int64
+        release_notes_url:
+          type: string
+          format: uri
+        download:
+          $ref: '#/components/schemas/UpdateDownloadState'
+      required:
+        - id
+        - title
+        - description
+        - version
+        - release_date
+        - size
+
+    UpdateChannel:
+      type: string
+      enum:
+        - STABLE
+        - TESTING
+        - DEVELOPMENT
+
+    UpdateDownloadState:
+      description: |
+        Download status:
+        - `PENDING`: update is scheduled to download
+        - `DOWNLOADING`: update is currently downloading
+        - `DOWNLOADED`: update has been downloaded and is ready to be installed
+        - `ERROR`: download failed
+      type: string
+      enum:
+        - PENDING
+        - DOWNLOADING
+        - DOWNLOADED
+        - ERROR
+
+    SystemUpdateResponse:
+      type: object
+      properties:
+        state:
+          $ref: '#/components/schemas/SystemUpdateState'
+        update_id:
+          description: Update identifier
+          type: string
+      required:
+        - state
+        - update_id
+
+    softwareUpdateEvent:
+      type: object
+      properties:
+        event_type:
+          type: string
+          enum:
+            - START
+            - PROGRESS
+            - STOP
+        update_id:
+          description: Update identifier
+          type: string
+        progress:
+          $ref: '#/components/schemas/SystemUpdateProgress'
+      required:
+        - event_type
+        - update_id
+
+    powerModeChangeEvent:
+      type: object
+      properties:
+        mode:
+          $ref: '#/components/schemas/PowerMode'
+      required:
+        - mode
+
+    batteryStatus:
+      type: object
+      properties:
+        capacity:
+          description: Current battery charge in %
+          type: integer
+          minimum: 0
+          maximum: 100
+        status:
+          $ref: '#/components/schemas/PowerStatus'
+        power_supply:
+          description: Power supply online
+          type: boolean
+      required:
+        - capacity
+        - status
+
+    SystemUpdateProgress:
+      type: object
+      properties:
+        state:
+          $ref: '#/components/schemas/SystemUpdateState'
+        update_id:
+          description: Update identifier
+          type: string
+        download_percent:
+          description: Percent of download
+          type: integer
+        download_bytes:
+          description: Total of bytes to be downloaded
+          type: integer
+          format: int64
+        total_steps:
+          description: Total number of update steps
+          type: integer
+        current_step:
+          description: Current installation step index
+          type: integer
+        current_percent:
+          description: Percent in current step
+          type: integer
+      required:
+        - state
+        - update_id
+
+    SystemUpdateState:
+      type: string
+      enum:
+        - IDLE
+        - START
+        - RUN
+        - SUCCESS
+        - FAILURE
+        - DOWNLOAD
+        - DONE
+        - SUB_PROCESS
+        - PROGRESS
+
+    integrationDiscoveryEvent:
+      type: object
+      properties:
+        event_type:
+          type: string
+          enum:
+            - START
+            - STOP
+            - DISCOVER
+        integration:
+          $ref: '#/components/schemas/integrationDiscoveryInformation'
+      required:
+        - event_type
+
+    integrationDiscoveryInformation:
+      type: object
+      properties:
+        id:
+          type: string
+        configured:
+          description: |
+            Integration configuration flag:
+            - true: driver has already been configured
+            - false: driver has not yet been configured
+          type: boolean
+        name:
+          type: string
+        icon:
+          type: string
+        developer_name:
+          type: string
+        driver_url:
+          description: Resolved driver url.
+          type: string
+        pwd_protected:
+          description: Driver requires a connection password.
+          type: boolean
+        version:
+          description: Detected driver version.
+          type: string
+        timestamp:
+          description: Timestamp of driver discovery.
+          type: string
+          format: date-time
+      required:
+        - id
+        - configured
+        - name
+        - driver_url
+        - timestamp
+
+    integrationSetupChange: # TODO finalize object
+      type: object
+      properties:
+        event_type:
+          description: |
+            - `START`: setup started
+            - `SETUP`: setup in progress. See `state` enum for current setup state.
+            - `STOP`: setup finished, either with: `state: OK` for successful setup, or `state: ERROR` if setup 
+                      didn't completed successfully.
+          type: string
+          enum:
+            - START
+            - SETUP
+            - STOP
+        driver_id:
+          type: string
+        state:
+          $ref: '#/components/schemas/integrationSetupState'
+        error:
+          $ref: '#/components/schemas/integrationSetupError'
+        require_user_action:
+          description: If set, the setup process waits for the specified user action.
+          type: object
+          oneOf:
+            - type: object
+              properties:
+                input:
+                  type: object
+                  $ref: '#/components/schemas/SettingsPage'
+              required:
+                - input
+            - type: object
+              properties:
+                confirmation:
+                  type: object
+                  $ref: '#/components/schemas/ConfirmationPage'
+              required:
+                - confirmation
+      required:
+        - event_type
+        - driver_id
+        - state
+
+    integrationSetupState:
+      description: |
+        - `SETUP`: setup in progress
+        - `WAIT_USER_ACTION`: setup flow is waiting for user input. See `require_user_action` for requested input.
+        - `OK`: setup finished successfully
+        - `ERROR`: setup error
+      type: string
+      enum:
+        - SETUP
+        - WAIT_USER_ACTION
+        - OK
+        - ERROR
+
+    integrationSetupError:
+      description: |
+        More detailed error reason for `state: ERROR` condition.
+      type: string
+      enum:
+        - NONE
+        - NOT_FOUND
+        - CONNECTION_REFUSED
+        - AUTHORIZATION_ERROR
+        - TIMEOUT
+        - OTHER
+    
+    ConfirmationPage:
+      description: Confirmation screen
+      type: object
+      properties:
+        title:
+          $ref: '#/components/schemas/languageText'
+        message1:
+          description: Message to display between title and image (if supplied). Supports Markdown formatting.
+          $ref: '#/components/schemas/languageText'
+        image:
+          description: |
+            Optional base64-encoded image.
+
+            TODO maximum encoded length to avoid WebSocket continuation frames, supported image formats
+            (png & svg?), max height & width
+          type: string
+          format: byte
+          maxLength: 32768
+        message2:
+          description: Message to display below message1 or image (if supplied). Supports Markdown formatting.
+          $ref: '#/components/schemas/languageText'
+      required:
+        - title
+
+    SettingsPage:
+      description: Settings definition page, e.g. to configure an integration driver.
+      type: object
+      properties:
+        title:
+          $ref: '#/components/schemas/languageText'
+        settings:
+          description: One or multiple input field definitions, with optional pre-set values.
+          type: array
+          items:
+            $ref: '#/components/schemas/Setting'
+      required:
+        - title
+        - settings
+
+    Setting:
+      description: |
+        An input setting is of a specific type defined in `field.type` which defines how it is presented to the user.
+
+        Inspired by the [Homey SDK settings](https://apps.developer.homey.app/the-basics/devices/settings) concept.
+      type: object
+      properties:
+        id:
+          description: Unique identifier of the setting to be returned with the entered value.
+          type: string
+          maxLength: 50
+        label:
+          $ref: '#/components/schemas/languageText'
+        field:
+          oneOf:
+            - $ref: '#/components/schemas/SettingTypeNumber'
+            - $ref: '#/components/schemas/SettingTypeText'
+            - $ref: '#/components/schemas/SettingTypeTextArea'
+            - $ref: '#/components/schemas/SettingTypePassword'
+            - $ref: '#/components/schemas/SettingTypeCheckbox'
+            - $ref: '#/components/schemas/SettingTypeDropdown'
+            - $ref: '#/components/schemas/SettingTypeLabel'
+      required:
+        - id
+        - label
+        - field
+
+    SettingTypeNumber:
+      description: |
+        Number input with optional `min`, `max`, `steps` and `decimals` properties. The default value must be specified
+        in `value`. An optional unit of the number setting can be specified in `units`, which will be displayed next to
+        the input field.
+      type: object
+      properties:
+        number:
+          type: object
+          properties:
+            value:
+              description: Default value for input field.
+              type: number
+            min:
+              description: "Optional validation: minimum allowed value (inclusive)."
+              type: number
+            max:
+              description: "Optional validation: maximum allowed value (inclusive)."
+              type: number
+            steps:
+              description: |
+                Optional validation: allowed step increment between values. Might also be used in the UI for input helpers.
+              type: number
+            decimals:
+              description: "Number of decimal places. 0 = integer value"
+              type: integer
+              minimum: 0
+              default: 0
+            unit:
+              $ref: '#/components/schemas/languageText'
+          required:
+            - value
+      required:
+        - number
+
+    SettingTypeText:
+      description: |
+        Single line of text input.
+
+        TODO: format specifier for e.g. email, url, date, datetime etc.?
+      type: object
+      properties:
+        text:
+          type: object
+          properties:
+            value:
+              description: Optional default value.
+              type: string
+            regex:
+              description: Optional regex validation pattern for the input value.
+              type: string
+      required:
+        - text
+
+    SettingTypeTextArea:
+      description: Multi-line text input, e.g. for providing a description.
+      type: object
+      properties:
+        textarea:
+          type: object
+          properties:
+            value:
+              description: Optional default value.
+              type: string
+      required:
+        - textarea
+
+    SettingTypePassword:
+      description: |
+        Password or pin entry field with the input text hidden from the user. Otherwise the same as text input.
+      type: object
+      properties:
+        password:
+          type: object
+          properties:
+            value:
+              description: Optional default value.
+              type: string
+              format: password
+            regex:
+              description: Optional regex validation pattern for the input value.
+              type: string
+      required:
+        - password
+
+    SettingTypeCheckbox:
+      description: Checkbox setting with `true` / `false` values.
+      type: object
+      properties:
+        checkbox:
+          type: object
+          properties:
+            value:
+              description: Initial setting.
+              type: boolean
+          required:
+            - value
+      required:
+        - checkbox
+
+    SettingTypeDropdown:
+      description: Dropdown setting to pick a single value from a list. All values must be strings.
+      type: object
+      properties:
+        dropdown:
+          type: object
+          properties:
+            value:
+              description: Pre-selected dropdown id
+              type: string
+            items:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    description: Selection identifier.
+                    type: string
+                  label:
+                    $ref: '#/components/schemas/languageText'
+                required:
+                  - id
+                  - label
+          required:
+            - items
+      required:
+        - dropdown
+
+    SettingTypeLabel:
+      description: |
+        Additional read-only text for information purpose between other settings. Supports Markdown formatting.
+      type: object
+      properties:
+        label:
+          type: object
+          properties:
+            value:
+              $ref: '#/components/schemas/languageText'
+          required:
+            - value
+      required:
+        - label
+
+    SettingsValues:
+      description: |
+        User input result of a SettingsPage as key values.
+        - key: id of the field
+        - value: entered user value as string. This is either the entered text or number, selected checkbox state or the
+          selected dropdown item id.  
+          ⚠️ Non native string values as numbers or booleans are represented as string values!
+      type: object
+      additionalProperties:
+        type: string
+
+    description:
+      type: string
+      maxLength: 255
+      description: Optional description
+
+    groups:
+      type: array
+      items:
+        $ref: '#/components/schemas/group'
+
+    group:
+      type: object
+      description: |
+        The shown group switch in the UI is automatically determined by the capabilities of the group's entities.
+      properties:
+        group_id:
+          $ref: '#/components/schemas/simpleId'
+        profile_id:
+          $ref: '#/components/schemas/simpleId'
+        name:
+          $ref: '#/components/schemas/name'
+          description: Group name. Must be unique within the profile.
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+        entities:
+          type: array
+          description: Entity identifiers belonging to the group
+          items:
+            $ref: '#/components/schemas/simpleId'
+        description:
+          $ref: '#/components/schemas/description'
+      required:
+        - group_id
+        - profile_id
+        - name
+        - entities
+
+    groupData:
+      type: object
+      properties:
+        group_id:
+          $ref: '#/components/schemas/simpleId'
+        profile_id:
+          $ref: '#/components/schemas/simpleId'
+        name:
+          $ref: '#/components/schemas/name'
+          description: Group name
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+        entities:
+          type: array
+          description: |
+            Changed or re-ordered group entities.
+            An empty array remove all entities.
+            If the property is not specified the defined entities will not be changed.
+          items:
+            $ref: '#/components/schemas/simpleId'
+        description:
+          $ref: '#/components/schemas/description'
+
+    iconIdentifier:
+      type: string
+      format: "^[a-z0-9]+:[a-zA-Z0-9\\-_\\.]+$"
+      maxLength: 255
+      description: |
+        Optional icon identifier. The identifier consists of a prefix and a resource identifier, separated by `:`.  
+        Available prefixes:
+        - `uc:` - integrated icon font 
+        - `custom:` - custom resource
+
+        An empty identifier, while updating the object, removes the existing icon.
+
+    imageIdentifier:
+      type: string
+      format: "^[a-z0-9]+:[a-zA-Z0-9\\-_\\.]+$"
+      maxLength: 255
+      description: |
+        Optional image identifier. The identifier consists of a prefix and a resource identifier, separated by `:`.  
+        Available prefixes:
+        - `custom:` - custom resource
+        
+        An empty identifier, while updating the object, removes the existing image.
+
+    name:
+      type: string
+      minLength: 1
+      maxLength: 50
+
+    pages:
+      type: array
+      items:
+        $ref: '#/components/schemas/page'
+
+    page:
+      type: object
+      properties:
+        page_id:
+          $ref: '#/components/schemas/simpleId'
+        profile_id:
+          $ref: '#/components/schemas/simpleId'
+        name:
+          $ref: '#/components/schemas/name'
+          description: Group name. Must be unique within the profile.
+        image:
+          type: string
+          description: Optional image identifier
+        items:
+          type: array
+          description: Page items
+          items:
+            $ref: '#/components/schemas/pageItem'
+        pos:
+          type: integer
+          format: int32
+          minimum: 0
+          description: Position of the page within the profile
+      required:
+        - page_id
+        - profile_id
+        - name
+        - items
+        - pos
+
+    pageItem:
+      type: object
+      properties:
+        entity_id:
+          $ref: '#/components/schemas/entityId'
+        group_id:
+          $ref: '#/components/schemas/simpleId'
+        pos:
+          type: integer
+          format: int32
+          minimum: 0
+          description: |
+            Position of the item within the page. Returned on retrieval, ignored for page updates where the position is
+            taken from the page array position.
+      oneOf:
+        - required: [ entity_id ]
+        - required: [ group_id ]
+
+    pageData:
+      description: Profile page data to create or update an existing page.
+      type: object
+      properties:
+        page_id:
+          $ref: '#/components/schemas/simpleId'
+        profile_id:
+          $ref: '#/components/schemas/simpleId'
+        name:
+          $ref: '#/components/schemas/name'
+          description: Page name
+        image:
+          $ref: '#/components/schemas/imageIdentifier'
+        items:
+          type: array
+          description: |
+            Changed or re-ordered page items.
+            - An empty array removes all items.
+            - If the property is not specified the defined items will not be changed.
+          items:
+            $ref: '#/components/schemas/pageItem'
+      required:
+        - page_id
+        - profile_id
+        - name
+
+    profiles:
+      type: array
+      items:
+        $ref: '#/components/schemas/profile'
+
+    profile:
+      type: object
+      properties:
+        profile_id:
+          $ref: '#/components/schemas/simpleId'
+        name:
+          $ref: '#/components/schemas/name'
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+        restricted:
+          description: A restricted profile cannot change settings. Switching profiles requires the admin pin.
+          type: boolean
+        description:
+          $ref: '#/components/schemas/description'
+      required:
+        - profile_id
+        - name
+        - protected
+
+    profileData:
+      description: |
+        Profile data to create or modify a profile. Missing properties are not updated when modifying an existing profile.
+      type: object
+      properties:
+        profile_id:
+          $ref: '#/components/schemas/simpleId'
+        name:
+          $ref: '#/components/schemas/name'
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+        restricted:
+          description: A restricted profile cannot change settings. Switching profiles requires the admin pin.
+          type: boolean
+        description:
+          $ref: '#/components/schemas/description'
+        pages:
+          description: |
+            Used for update only: modify page order or delete pages in profile.
+            - An empty `pages` array will delete all pages and containing groups!
+            - If the property is missing, the existing page configuration will not be changed.
+          type: array
+          items:
+            $ref: '#/components/schemas/simpleId'
+      required:
+        - profile_id
+
+    adminPin:
+      type: string
+      maxLength: 20
+      description: Optional administrator pin.
+
+    simpleId:
+      type: string
+      format: "^[a-zA-Z0-9\\-_\\.]+$"
+      minLength: 1
+      maxLength: 36
+      description: Simple string identifier, also usable as URL parameter or file identifier.
+
+    driverId:
+      type: string
+      format: "^[a-zA-Z0-9\\-_]+$"
+      minLength: 1
+      maxLength: 36
+      description: Unique integration driver identifier, e.g. `hass`, `homey`, etc.
+
+    integrationId:
+      type: string
+      format: "^[a-zA-Z0-9\\-_\\.]+$"
+      minLength: 1
+      maxLength: 73
+      description: |
+        Unique integration instance identifier. Automatically created by the system when creating a new instance from a driver.
+
+    deviceId:
+      type: string
+      format: "^[a-zA-Z0-9\\-_]+$"
+      minLength: 1
+      maxLength: 36
+      description: Device identifier for multi-device integrations only.
+
+    entityId:
+      type: string
+      format: "^[a-zA-Z0-9\\-_\\.]+$"
+      minLength: 1
+      maxLength: 110
+      description: UC remote entity identifier.
+
+    intgAuthMethod:
+      type: string
+      description: |
+        Integration driver authentication method if a token is required.
+
+        The JSON `auth` message is used if a token is configured but no authentication method is set.
+      enum:
+        - HEADER
+        - MESSAGE
+
+    # --- OpenApi Wifi.yaml
+
+    ApScanStatus:
+      type: object
+      properties:
+        active:
+          type: boolean
+        scan:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccessPointScan'
+      required:
+        - active
+        - scan
+
+    AccessPointScan:
+      type: object
+      properties:
+        bssid:
+          description: MAC physical address of the access point (basic service set identifier)
+          type: string
+        frequency:
+          description: Frequency of the channel in MHz (e.g., 2412 = channel 1)
+          type: string
+        signal_level:
+          description: Signal level (dBm)
+          type: integer
+        auth:
+          description: Authentication method
+          type: string
+        ssid:
+          description: |
+            SSID network name as friendly UTF-8 representation. Use this name to present the network to users, but not for
+            adding a new network configuration. This is a lossy conversion from the native SSID byte array.
+          type: string
+        ssid_hex:
+          description: |
+            Hex encoded string of the native SSID byte array.
+
+            Always use this representation, when connecting to a network from a scan result.
+          type: string
+      required:
+        - bssid
+        - ssid
+        - ssid_hex
+
+    WifiStatus:
+      type: object
+      properties:
+        wpa_state:
+          $ref: '#/components/schemas/WpaState'
+        id:
+          description: Network identifier
+          type: integer
+        bssid:
+          description: MAC physical address of the access point (basic service set identifier)
+          type: string
+        ssid:
+          description: Network name (service set identifier)
+          type: string
+        ssid_hex:
+          description: Hex encoded string of the native SSID byte array.
+          type: string
+        freq:
+          description: Frequency of the channel in MHz (e.g., 2412 = channel 1)
+          type: integer
+        address:
+          description: MAC physical address of the WiFi adapter
+          type: string
+        pairwise_cipher:
+          type: string
+        group_cipher:
+          type: string
+        key_mgmt:
+          type: string
+        ip_address:
+          description: Client IP address
+          type: string
+        noise:
+          description: Noise level (dBm)
+          type: integer
+        rssi:
+          description: Signal level (dBm)
+          type: integer
+        avg_rssi:
+          description: Average RSSI (dBm)
+          type: integer
+        est_throughput:
+          description: Estimated throughput in kbps
+          type: integer
+        snr:
+          description: Signal-to-noise ratio in dB
+          type: integer
+        linkspeed:
+          description: Link speed (Mbps)
+          type: integer
+      required:
+        - wpa_state
+
+    CreateWifiNetwork:
+      type: object
+      properties:
+        ssid:
+          description: |
+            Network name (service set identifier).
+            
+            Only use for valid UTF-8 names, when creating a new configuration and not from a scan result.    
+            Always use `ssid_hex`, when adding a network configuration from a scan result! Otherwise it's not guaranteed,
+            that the correct network is configured. The SSID name can contain non-displayable characters.
+          type: string
+          minLength: 1
+          maxLength: 32
+        ssid_hex:
+          description: |
+            Hex encoded string of the native SSID byte array, returned from a network scan.
+          minLength: 2
+          maxLength: 64
+        password:
+          type: string
+          minLength: 1
+          maxLength: 63
+
+    # change to OpenAPI: enhanced with id
+    ModifyWifiNetwork:
+      type: object
+      properties:
+        id:
+          type: integer
+          minimum: 0
+        password:
+          type: string
+          minLength: 1
+          maxLength: 63
+      required:
+        - id
+        - password
+
+    SavedNetworks:
+      type: array
+      items:
+        $ref: '#/components/schemas/SavedNetwork'
+
+    SavedNetwork:
+      description: A saved network configuration (known network)
+      type: object
+      properties:
+        id:
+          description: Network identification, used for further operations on this network
+          type: integer
+        ssid:
+          description: Network name (service set identifier)
+          type: string
+        ssid_hex:
+          description: Hex encoded string of the native SSID byte array.
+          type: string
+        secured:
+          description: Secured or unsecured network
+          type: boolean
+        signal_level:
+          type: integer
+        state:
+          $ref: '#/components/schemas/NetworkState'
+      required:
+        - id
+        - ssid
+        - ssid_hex
+        - secured
+
+    WpaState:
+      description: |
+        - `UNKNOWN`: Unknown state. The driver returned a state which could not be handled.
+        - `ERROR`: Error retrieving state information.
+        - `DISCONNECTED`: This state indicates that client is not associated, but is likely to start looking for an access point. This state is entered when a connection is lost.
+        - `INTERFACE_DISABLED`: This state is entered if the network interface is disabled. The driver refuses any new operations that would use the radio until the interface has been enabled.
+        - `INACTIVE`: This state is entered if there are no enabled networks in the configuration. The driver is not trying to associate with a new network and external interaction (e.g. add or enable a network) is needed to start association.
+        - `SCANNING`: Scanning for a network.
+        - `AUTHENTICATED`: Trying to authenticate with a BSS/SSID.
+        - `ASSOCIATING`: Trying to associate with a BSS/SSID.
+        - `ASSOCIATED`: Association completed.
+        - `FOUR_WAY_HANDSHAKE`: WPA 4-Way Key Handshake in progress.
+        - `GROUP_HANDSHAKE`: WPA Group Key Handshake in progress.
+        - `COMPLETED`: All authentication completed.
+      type: string
+      enum:
+        - UNKNOWN
+        - ERROR
+        - DISCONNECTED
+        - INTERFACE_DISABLED
+        - INACTIVE
+        - SCANNING
+        - AUTHENTICATED
+        - ASSOCIATING
+        - ASSOCIATED
+        - FOUR_WAY_HANDSHAKE
+        - GROUP_HANDSHAKE
+        - COMPLETED
+
+    WifiCmd:
+      type: string
+      enum:
+        - DISCONNECT
+        - RECONNECT
+        - REASSOCIATE
+        - ENABLE_ALL_NETWORKS
+        - DISABLE_ALL_NETWORKS
+
+    WifiNetworkCmd:
+      type: string
+      enum:
+        - ENABLE
+        - DISABLE
+        - SELECT
+
+    NetworkState:
+      type: string
+      enum:
+        - CONNECTED
+        - OUT_OF_RANGE
+        - DISABLED
+        - TEMPORARY_DISABLED
+
+    WifiChange:
+      type: object
+      properties:
+        event:
+          $ref: '#/components/schemas/WifiEvent'
+
+    WifiEvent:
+      description: |
+        WiFi event:
+        - `CONNECTED`: Authentication completed successfully and data connection enabled.
+        - `DISCONNECTED`: Disconnected from access point and data connection not available.
+        - `SCAN_STARTED`: Network scan started.
+        - `SCAN_COMPLETED`: New network scan results available.
+        - `SCAN_FAILED`: Network scanning failed.
+        - `NETWORK_NOT_FOUND`: No suitable network was found.
+        - `WRONG_KEY`: Authentication failure due to an invalid pre-shared key.
+        - `NETWORK_ADDED`: A new network profile was added.
+        - `NETWORK_REMOVED`: A network profile was removed.
+      type: string
+      enum:
+        - CONNECTED
+        - DISCONNECTED
+        - SCAN_STARTED
+        - SCAN_COMPLETED
+        - SCAN_FAILED
+        - NETWORK_NOT_FOUND
+        - WRONG_KEY
+        - NETWORK_ADDED
+        - NETWORK_REMOVED
+
+    # --- OpenAPI PowerMode.yaml
+
+    PowerMode:
+      type: string
+      enum:
+        - NORMAL
+        - IDLE
+        - LOW_POWER
+        - SUSPEND
+
+    # --- OpenAPI Battery.yaml
+
+    PowerStatus:
+      type: string
+      enum:
+        - CHARGING
+        - DISCHARGING
+        - NOT_CHARGING
+        - FULL
+
+    # --- OpenAPI AmbientLight.yaml
+
+    AmbientLight:
+      type: object
+      properties:
+        intensity:
+          documentation: Light intensity. 0 = pitch black, 65535 = very bright.
+          type: integer
+          minimum: 0
+          maximum: 65535
+      required:
+        - intensity

--- a/core-api/websocket/create-html-docker.sh
+++ b/core-api/websocket/create-html-docker.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+readonly OUT_DIR=${PWD}/html
+
+mkdir -p "$OUT_DIR"
+docker run --rm -it \
+  -v "${OUT_DIR}":/app/example \
+  -v "${PWD}/UCR2-asyncapi.yaml":/app/asyncapi.yaml \
+  asyncapi/generator:1.9.2 asyncapi.yaml @asyncapi/html-template@0.25 --force-write -o example
+

--- a/core-api/websocket/remote-core_WebSocket API_firecamp.json
+++ b/core-api/websocket/remote-core_WebSocket API_firecamp.json
@@ -1,0 +1,1321 @@
+{
+    "meta": {
+        "__export_time": 1676966736697,
+        "__export_app": "firecamp_v2.6.1 ",
+        "__export_version": 1
+    },
+    "project": {
+        "name": "remote-core WS API",
+        "description": "",
+        "auth": {},
+        "scripts": {
+            "pre": "",
+            "post": "",
+            "test": ""
+        },
+        "meta": {
+            "active_auth": "no_auth"
+        }
+    },
+    "modules": [],
+    "requests": [
+        {
+            "meta": {
+                "name": "core v2",
+                "description": "",
+                "type": "websocket",
+                "version": "2.0"
+            },
+            "url": {
+                "slashes": true,
+                "protocol": "ws:",
+                "hash": "",
+                "pathname": "/ws",
+                "auth": "",
+                "host": "{{server}}",
+                "port": "",
+                "hostname": "{{server}}",
+                "password": "",
+                "username": "",
+                "origin": "ws://{{server}}",
+                "href": "ws://{{server}}/ws",
+                "query_params": [],
+                "path_params": []
+            },
+            "config": {
+                "protocols": [],
+                "reconnect": false,
+                "reconnectAttempts": 0,
+                "reconnectTimeout": 3000,
+                "rejectUnauthorized": false,
+                "followRedirects": true,
+                "handshakeTimeout": 3000,
+                "maxRedirects": 10,
+                "protocolVersion": 13,
+                "origin": "",
+                "maxPayload": -1
+            },
+            "connections": [
+                {
+                    "name": "Default",
+                    "headers": [
+                        {
+                            "key": "API-KEY",
+                            "value": "BtlCEne.OWU2YzBhZjMyNmI2NDQ5YWI3N2NmMGExYWU5ZTNlNDEuZmIzOTNkM2FhOGY2NDA1N2FjNzQzNDdlOWE1YTU0OTc",
+                            "disable": true,
+                            "type": "text"
+                        },
+                        {
+                            "key": "Authorization",
+                            "value": "Basic YWRtaW46cmVtb3RlMg==",
+                            "disable": true,
+                            "type": "text"
+                        }
+                    ],
+                    "query_params": [],
+                    "config": {
+                        "ping": false,
+                        "ping_interval": 45000
+                    },
+                    "is_default": true
+                },
+                {
+                    "name": "public",
+                    "headers": [
+                        {
+                            "key": "API-KEY",
+                            "value": "BtlCEne.OWU2YzBhZjMyNmI2NDQ5YWI3N2NmMGExYWU5ZTNlNDEuZmIzOTNkM2FhOGY2NDA1N2FjNzQzNDdlOWE1YTU0OTc",
+                            "disable": false,
+                            "type": "text"
+                        }
+                    ],
+                    "query_params": [],
+                    "config": {
+                        "ping": false,
+                        "ping_interval": 3000
+                    }
+                }
+            ],
+            "message_collection": [
+                {
+                    "name": "Integrations",
+                    "meta": {},
+                    "children": [
+                        {
+                            "name": "get_integration_status",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_integration_status\",\n  \"msg_data\": {\n    \"filter\": {\n      \"Xenabled\": true\n    },\n    \"paging\": {\n      \"limit\": 10,\n      \"page\": 1\n    }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_integrations",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_integrations\",\n  \"msg_data\": {\n    \"filter\": {\n      \"Xdriver_id\": \"hass\",\n      \"Xenabled\": true\n    },\n    \"paging\": {\n      \"limit\": 10,\n      \"page\": 1\n    }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_integration_driver",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_integration_driver\",\n  \"msg_data\": {\n    \"driver_id\": \"hass\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "integration_cmd",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"integration_cmd\",\n  \"msg_data\": {\n    \"cmd_id\": \"CONNECT\",\n    \"integration_id\": \"hass.main\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_integration_driver_count",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_integration_driver_count\",\n  \"msg_data\": {\n    \"filter\": {\n      \"enabled\": true\n    }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_integration",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_integration\",\n  \"msg_data\": {\n    \"integration_id\": \"hass.main\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "update_integration",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"update_integration\",\n  \"msg_data\": {\n    \"integration_id\": \"hass.main\",\n    \"Xdevice_id\": \"string\",\n    \"name\": { \"en\": \"FooBar\"},\n    \"icon\": \"dev:foo\",\n    \"enabled\": true,\n    \"setup_data\": {}\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "create_integration",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"create_integration\",\n  \"msg_data\": {\n    \"driver_id\": \"hass\",\n    \"Xdevice_id\": \"none\",\n    \"name\": { \"en\": \"Kusi's Home Assistant\"},\n    \"icon\": \"dev:test\",\n    \"enabled\": false,\n    \"setup_data\": { \"todo\": true }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_integration_count",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_integration_count\",\n  \"msg_data\": {\n    \"filter\": {\n      \"driver_id\": \"test\",\n      \"enabled\": true\n    }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_integration_drivers",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_integration_drivers\",\n  \"msg_data\": {\n    \"filter\": {\n      \"enabled\": true\n    },\n    \"paging\": {\n      \"limit\": 10,\n      \"page\": 1\n    }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "integration_driver_cmd",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"integration_driver_cmd\",\n  \"msg_data\": {\n    \"cmd_id\": \"START\",\n    \"driver_id\": \"hass\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "delete_integration_driver",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"delete_integration_driver\",\n  \"msg_data\": {\n    \"driver_id\": \"hass\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "delete_integration",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"delete_integration\",\n  \"msg_data\": {\n    \"integration_id\": \"test.main\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "register_integration_driver",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"register_integration_driver\",\n  \"msg_data\": {\n    \"driver_id\": \"hass\",\n    \"name\": {\n      \"en\": \"Home Assistant\"\n    },\n    \"driver_url\": \"http://localhost:8000/ws\",\n    \"token\": \"1-2-3\",\n    \"auth_method\": \"HEADER\",\n    \"version\": \"0.0.1\",\n    \"min_core_api\": \"0.6.0\",\n    \"icon\": \"uc:hass\",\n    \"enabled\": true,\n    \"description\": {\n      \"en\": \"Official Home Assistant integration for Remote Two\"\n    },\n    \"developer\": {\n      \"name\": \"Kusi\",\n      \"url\": \"http://unfoldedcircle.com\",\n      \"email\": \"markus.z@unfoldedcircle.com\"\n    },\n    \"home_page\": \"http://unfoldedcircle.com\",\n    \"device_discovery\": false,\n    \"setup_data_schema\": {},\n    \"release_date\": \"2022-04-24\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "update_integration_driver",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"update_integration_driver\",\n  \"msg_data\": {\n    \"driver_id\": \"hass\",\n    \"name\": {\n      \"en\": \"Home Assistant\",\n      \"de\": \"Home Assistant\"\n    },\n    \"driver_url\": \"http://localhost:8000/ws\",\n    \"token\": \"1-2-3\",\n    \"auth_method\": \"HEADER\",\n    \"version\": \"0.0.2\",\n    \"min_core_api\": \"0.6.0\",\n    \"icon\": \"uc:hass\",\n    \"enabled\": true,\n    \"description\": {\n      \"en\": \"Official Home Assistant integration for Remote Two\",\n      \"de\": \"Home Assistant Integration für Remote Two\"\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "Entities - hass.main",
+                    "meta": {},
+                    "children": [
+                        {
+                            "name": "get_entities by type",
+                            "meta": {},
+                            "children": [
+                                {
+                                    "name": "get_entities - button",
+                                    "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_entities\",\n  \"msg_data\": {\n    \"filter\": {\n      \"entity_type\": \"button\",\n      \"integration_id\": \"hass.main\"\n    },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                                    "meta": {
+                                        "type": "json",
+                                        "envelope": ""
+                                    }
+                                },
+                                {
+                                    "name": "get_entities - switch",
+                                    "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_entities\",\n  \"msg_data\": {\n    \"filter\": {\n      \"entity_type\": \"switch\",\n      \"integration_id\": \"hass.main\"\n    },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                                    "meta": {
+                                        "type": "json",
+                                        "envelope": ""
+                                    }
+                                },
+                                {
+                                    "name": "get_entities - climate",
+                                    "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_entities\",\n  \"msg_data\": {\n    \"filter\": {\n      \"entity_type\": \"climate\",\n      \"integration_id\": \"hass.main\"\n    },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                                    "meta": {
+                                        "type": "json",
+                                        "envelope": ""
+                                    }
+                                },
+                                {
+                                    "name": "get_entities - cover",
+                                    "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_entities\",\n  \"msg_data\": {\n    \"filter\": {\n      \"entity_type\": \"cover\",\n      \"integration_id\": \"hass.main\"\n    },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                                    "meta": {
+                                        "type": "json",
+                                        "envelope": ""
+                                    }
+                                },
+                                {
+                                    "name": "get_entities - light",
+                                    "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_entities\",\n  \"msg_data\": {\n    \"filter\": {\n      \"entity_type\": \"light\",\n      \"integration_id\": \"hass.main\"\n    },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                                    "meta": {
+                                        "type": "json",
+                                        "envelope": ""
+                                    }
+                                },
+                                {
+                                    "name": "get_entities - media_player",
+                                    "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_entities\",\n  \"msg_data\": {\n    \"filter\": {\n      \"entity_type\": \"media_player\",\n      \"integration_id\": \"hass.main\"\n    },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                                    "meta": {
+                                        "type": "json",
+                                        "envelope": ""
+                                    }
+                                },
+                                {
+                                    "name": "get_entities - sensor",
+                                    "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_entities\",\n  \"msg_data\": {\n    \"filter\": {\n      \"entity_type\": \"sensor\",\n      \"integration_id\": \"hass.main\"\n    },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                                    "meta": {
+                                        "type": "json",
+                                        "envelope": ""
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "get_available_entities by type",
+                            "meta": {},
+                            "children": [
+                                {
+                                    "name": "get_available_entities - button",
+                                    "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_available_entities\",\n  \"msg_data\": {\n    \"force_reload\": false,\n    \"filter\": {\n      \"entity_type\": \"button\",\n      \"integration_id\": \"hass.main\"\n      },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                                    "meta": {
+                                        "type": "json",
+                                        "envelope": ""
+                                    }
+                                },
+                                {
+                                    "name": "get_available_entities - switch",
+                                    "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_available_entities\",\n  \"msg_data\": {\n    \"force_reload\": false,\n    \"filter\": {\n      \"entity_type\": \"switch\",\n      \"integration_id\": \"hass.main\"\n      },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                                    "meta": {
+                                        "type": "json",
+                                        "envelope": ""
+                                    }
+                                },
+                                {
+                                    "name": "get_available_entities - climate",
+                                    "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_available_entities\",\n  \"msg_data\": {\n    \"force_reload\": false,\n    \"filter\": {\n      \"entity_type\": \"climate\",\n      \"integration_id\": \"hass.main\"\n      },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                                    "meta": {
+                                        "type": "json",
+                                        "envelope": ""
+                                    }
+                                },
+                                {
+                                    "name": "get_available_entities - cover",
+                                    "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_available_entities\",\n  \"msg_data\": {\n    \"force_reload\": false,\n    \"filter\": {\n      \"entity_type\": \"cover\",\n      \"integration_id\": \"hass.main\"\n      },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                                    "meta": {
+                                        "type": "json",
+                                        "envelope": ""
+                                    }
+                                },
+                                {
+                                    "name": "get_available_entities - light",
+                                    "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_available_entities\",\n  \"msg_data\": {\n    \"force_reload\": false,\n    \"filter\": {\n      \"entity_type\": \"light\",\n      \"integration_id\": \"hass.main\"\n      },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                                    "meta": {
+                                        "type": "json",
+                                        "envelope": ""
+                                    }
+                                },
+                                {
+                                    "name": "get_available_entities - media_player",
+                                    "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_available_entities\",\n  \"msg_data\": {\n    \"force_reload\": false,\n    \"filter\": {\n      \"entity_type\": \"media_player\",\n      \"integration_id\": \"hass.main\"\n      },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                                    "meta": {
+                                        "type": "json",
+                                        "envelope": ""
+                                    }
+                                },
+                                {
+                                    "name": "get_available_entities - sensor",
+                                    "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_available_entities\",\n  \"msg_data\": {\n    \"force_reload\": false,\n    \"filter\": {\n      \"entity_type\": \"sensor\",\n      \"integration_id\": \"hass.main\"\n      },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                                    "meta": {
+                                        "type": "json",
+                                        "envelope": ""
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "get_entity_types",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_entity_types\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_entities",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_entities\",\n  \"msg_data\": {\n    \"filter\": {\n      \"integration_id\": \"hass.main\"\n    },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_available_entities - ALL cached",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_available_entities\",\n  \"msg_data\": {\n    \"force_reload\": false,\n    \"filter\": {\n      \"integration_id\": \"hass.main\"\n      },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_available_entities - force reload ALL",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_available_entities\",\n  \"msg_data\": {\n    \"force_reload\": true,\n    \"filter\": {\n      \"integration_id\": \"hass.main\"\n      },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_available_entities - NEW cached",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_available_entities\",\n  \"msg_data\": {\n    \"force_reload\": false,\n    \"filter\": {\n      \"entities\": \"NEW\",\n      \"integration_id\": \"hass.main\"\n      },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_available_entities - CONFIGURED cached",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_available_entities\",\n  \"msg_data\": {\n    \"force_reload\": false,\n    \"filter\": {\n      \"entities\": \"CONFIGURED\",\n      \"integration_id\": \"hass.main\"\n      },\n    \"paging\": {\n      \"limit\": 100,\n      \"page\": 1\n    }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_entity_commands cover",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_entity_commands\",\n  \"msg_data\": {\n    \"entity_type\": \"cover\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_entity_commands by entity_id",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_entity_commands\",\n  \"msg_data\": {\n    \"entity_id\": \"hass.main.light.esstisch\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "execute_entity_command - light",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"execute_entity_command\",\n  \"msg_data\": {\n    \"entity_id\": \"hass.main.light.esstisch\",\n    \"cmd_id\":  \"off\",\n    \"params\": {}\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "delete_entity",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"delete_entity\",\n  \"msg_data\": {\n    \"entity_id\": \"light_test\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "update_entity",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"update_entity\",\n  \"msg_data\": {\n    \"entity_id\": \"light1\",\n    \"name\": { \"en\": \"Foo Bar Entity\" },\n    \"icon\": \"uc:test\",\n    \"description\": { \"en\": \"Testing rename\" }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "delete_all_entities",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"delete_all_entities\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_entity",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_entity\",\n  \"msg_data\": {\n    \"entity_id\": \"light1\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "configure_entity_from_integration",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"configure_entity_from_integration\",\n  \"msg_data\": {\n    \"entity_id\": \"media_player.esstisch\",\n    \"integration_id\": \"hass.main\",\n    \"name\": { \"en\": \"Test entity\" },\n    \"icon\": \"uc:test\",\n    \"description\": { \"en\": \"Entity configuration test\" }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "Groups",
+                    "meta": {},
+                    "children": [
+                        {
+                            "name": "delete_group",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"delete_group\",\n  \"msg_data\": {\n    \"group_id\": \"group_d7f28f80-6ac3-11eb-9439-0242ac130002\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_group",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_group\",\n  \"msg_data\": {\n      \"group_id\": \"def:g2\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "update_group",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"update_group\",\n  \"msg_data\": {\n    \"group_id\": \"group_d7f28f80-6ac3-11eb-9439-0242ac130002\",\n    \"name\": \"Lights 2\",\n    \"entities\": [\n      \"foo\",\n         \"light_121211-8e6e-11eb-9dcd-0242ac130003\",\n         \"light_f059987e-c270-4102-9c78-1ee19d1465db\",\n         \"light.desk_lamp\",\n      \"bar\"\n    ]\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "add_group",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"add_group\",\n  \"msg_data\": {\n    \"group_id\": \"group_d7f28f80-6ac3-11eb-9439-0242ac130002\",\n    \"name\": \"Just testing\",\n    \"entities\": [\n      \"foo\",\n      \"bar\"\n    ]\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_groups",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_groups\",\n  \"msg_data\": {\n      \"profile_id\": \"default\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "Profiles",
+                    "meta": {},
+                    "children": [
+                        {
+                            "name": "get_profiles",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_profiles\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "update_profile",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"update_profile\",\n  \"msg_data\": {\n    \"profile_id\": \"test\",\n     \"name\":  \"Dummy Profile\",\n     \"icon\": \"yio:bear\",\n     \"description\": \"Update test\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "add_profile",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"add_profile\",\n  \"msg_data\": {\n     \"name\":  \"Super Profile\",\n     \"icon\": \"yio:test\",\n     \"description\": \"WS test\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_profile",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_profile\",\n  \"msg_data\": {\n     \"profile_id\":  \"default\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "delete_profile",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"delete_profile\",\n  \"msg_data\": {\n     \"profile_id\":  \"test\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "switch_profile",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"switch_profile\",\n  \"msg_data\": {\n    \"profile_id\": \"default\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_active_profile",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_active_profile\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "Pages",
+                    "meta": {},
+                    "children": [
+                        {
+                            "name": "get_pages",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_pages\",\n  \"msg_data\": {\n      \"profile_id\": \"default\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "Events",
+                    "meta": {},
+                    "children": [
+                        {
+                            "name": "get_event_channels",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_event_channels\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_event_subscriptions",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_event_subscriptions\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "subscribe_events - All",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"subscribe_events\",\n  \"msg_data\": {\n      \"channels\": [\"all\"]\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "unsubscribe_events - All",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"unsubscribe_events\",\n  \"msg_data\": {\n    \"channels\": [\n      \"all\"\n    ]\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "Configuration",
+                    "meta": {},
+                    "children": [
+                        {
+                            "name": "get_configuration",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_configuration\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_voice_control_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_voice_control_cfg\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_network_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_network_cfg\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "set_button_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"set_button_cfg\",\n  \"msg_data\": {\n        \"auto_brightness\": false,\n        \"brightness\": 42\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_voice_assistants",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_voice_assistants\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_software_update_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_software_update_cfg\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "reset_configuration",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"reset_configuration\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_voice_control_cfg - Default settings",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_voice_control_cfg\",\n  \"msg_data\": {\n    \"default\": true\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_power_saving_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_power_saving_cfg\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "set_voice_control_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"set_voice_control_cfg\",\n  \"msg_data\": {\n        \"enabled\": true,\n        \"microphone\": true,\n        \"voice_assistant\": \"None\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_localization_cfg - Default settings",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_localization_cfg\",\n  \"msg_data\": {\n    \"default\": true\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "set_power_saving_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"set_power_saving_cfg\",\n  \"msg_data\": {\n        \"display_off_sec\": 5,\n        \"standby_sec\": 100,\n        \"wakeup_sensitivity\": 2\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_sound_cfg - Default settings",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_sound_cfg\",\n  \"msg_data\": {\n    \"default\": true\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_button_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_button_cfg\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_sound_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_sound_cfg\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "set_software_update_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"set_software_update_cfg\",\n  \"msg_data\": {\n        \"auto_update\": true,\n        \"check_for_updates\": true\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_button_cfg - Default settings",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_button_cfg\",\n  \"msg_data\": {\n    \"default\": true\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "set_sound_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"set_sound_cfg\",\n  \"msg_data\": {\n        \"enabled\": false,\n        \"volume\": 20\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_display_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_display_cfg\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "set_network_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"set_network_cfg\",\n  \"msg_data\": {\n        \"bt_enabled\": true,\n        \"wifi_enabled\": true\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_haptic_cfg - Default settings",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_haptic_cfg\",\n  \"msg_data\": {\n    \"default\": true\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_localization_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_localization_cfg\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_software_update_cfg - Default settings",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_software_update_cfg\",\n  \"msg_data\": {\n    \"default\": true\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_display_cfg - Default settings",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_display_cfg\",\n  \"msg_data\": {\n    \"default\": true\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_haptic_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_haptic_cfg\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "set_display_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"set_display_cfg\",\n  \"msg_data\": {\n        \"auto_brightness\": false,\n        \"brightness\": 39\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_power_saving_cfg - Default settings",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_power_saving_cfg\",\n  \"msg_data\": {\n    \"default\": true\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_timezone_names",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_timezone_names\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_network_cfg - Default settings",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_network_cfg\",\n  \"msg_data\": {\n    \"default\": true\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "set_localization_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"set_localization_cfg\",\n  \"msg_data\": {\n        \"country_code\": \"CH\",\n        \"language_code\": \"de_CH\",\n        \"measurement_unit\": \"METRIC\",\n        \"time_format_24h\": true,\n        \"time_zone\": \"Europe/Zurich\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "set_haptic_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"set_haptic_cfg\",\n  \"msg_data\": {\n        \"enabled\": false\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "set_device_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"set_device_cfg\",\n  \"msg_data\": {\n        \"name\": \"Test device\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_localization_languages",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_localization_languages\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_localization_countries",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_localization_countries\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_device_cfg",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_device_cfg\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "set_localization_languages",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"localization_languages\",\n    \"msg_data\": {\n        \"translations\": [\n            {\n                \"code\": \"da_DK\",\n                \"name\": \"Dansk\"\n            },\n            {\n                \"code\": \"de_DE\",\n                \"name\": \"Deutsch\"\n            },\n            {\n                \"code\": \"de_CH\",\n                \"name\": \"Schwiizerdütsch 2\"\n            },\n            {\n                \"code\": \"en_US\",\n                \"name\": \"English (US)\"\n            },\n            {\n                \"code\": \"hu_HU\",\n                \"name\": \"Magyar\"\n            },\n            {\n                \"code\": \"nl_NL\",\n                \"name\": \"Nederlands\"\n            }\n        ],\n        \"version\": \"default\"\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "System",
+                    "meta": {},
+                    "children": [
+                        {
+                            "name": "system_cmd - RESTART",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"system_cmd\",\n  \"msg_data\": {\n    \"command\": \"RESTART\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_factory_reset_token",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_factory_reset_token\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "system_cmd - POWER_OFF",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"system_cmd\",\n  \"msg_data\": {\n    \"command\": \"POWER_OFF\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "system_cmd - RESTART",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"system_cmd\",\n  \"msg_data\": {\n    \"command\": \"RESTART\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "factory_reset",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"factory_reset\",\n    \"msg_data\": {\n        \"token\": \"1-2-3\"\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "system_cmd - REBOOT",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"system_cmd\",\n  \"msg_data\": {\n    \"command\": \"REBOOT\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "set_api_access",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"set_api_access\",\n  \"msg_data\": {\n    \"web_configurator\": {\n      \"enabled\": true,\n      \"pin\": \"1234\",\n      \"valid_to\": \"2023-08-24T12:00:00Z\"\n    }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_api_access",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_api_access\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "Entities - remote",
+                    "meta": {},
+                    "children": [
+                        {
+                            "name": "get_entities",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 200,\n    \"msg\": \"get_entities\",\n    \"msg_data\": {\n        \"filter\": {\n            \"entity_type\": \"remote\",\n            \"integration_id\": \"uc.main\"\n        },\n        \"paging\": {\n            \"limit\": 100,\n            \"page\": 1\n        }\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "execute_entity_command on",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"execute_entity_command\",\n  \"msg_data\": {\n    \"entity_id\": \"836485d3-9cd5-4552-9031-c56fa5b47bb2\",\n    \"cmd_id\":  \"on\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "execute_entity_command UP",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"execute_entity_command\",\n  \"msg_data\": {\n    \"entity_id\": \"836485d3-9cd5-4552-9031-c56fa5b47bb2\",\n    \"cmd_id\":  \"send\",\n    \"params\": {\n      \"command\":  \"CURSOR_UP\"\n    }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "execute_entity_command ENTER",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"execute_entity_command\",\n  \"msg_data\": {\n    \"entity_id\": \"836485d3-9cd5-4552-9031-c56fa5b47bb2\",\n    \"cmd_id\":  \"CURSOR_ENTER\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "execute_entity_command DOWN",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"execute_entity_command\",\n  \"msg_data\": {\n    \"entity_id\": \"836485d3-9cd5-4552-9031-c56fa5b47bb2\",\n    \"cmd_id\":  \"send\",\n    \"params\": {\n      \"cmd_id\":  \"CURSOR_DOWN\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "execute_entity_command RIGHT",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"execute_entity_command\",\n  \"msg_data\": {\n    \"entity_id\": \"836485d3-9cd5-4552-9031-c56fa5b47bb2\",\n    \"cmd_id\":  \"send\",\n    \"params\": {\n      \"command\":  \"CURSOR_RIGHT\"\n    }\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "execute_entity_command",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"execute_entity_command\",\n  \"msg_data\": {\n    \"entity_id\": \"836485d3-9cd5-4552-9031-c56fa5b47bb2\",\n    \"cmd_id\":  \"send\",\n    \"params\": {}\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "execute_entity_command LEFT",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"execute_entity_command\",\n  \"msg_data\": {\n    \"entity_id\": \"836485d3-9cd5-4552-9031-c56fa5b47bb2\",\n    \"cmd_id\":  \"CURSOR_LEFT\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_entity_commands remote",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 200,\n  \"msg\": \"get_entity_commands\",\n  \"msg_data\": {\n    \"entity_type\": \"remote\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "wifi",
+                    "meta": {},
+                    "children": [
+                        {
+                            "name": "get_wifi_status",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 1,\n    \"msg\": \"get_wifi_status\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "wifi_scan_stop",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 8,\n    \"msg\": \"wifi_scan_stop\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "add_wifi_network Open",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 11,\n    \"msg\": \"add_wifi_network\",\n    \"msg_data\": {\n      \"ssid\": \"Guest\"\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "wifi_scan_start",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 7,\n    \"msg\": \"wifi_scan_start\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "del_all_wifi_networks",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 13,\n    \"msg\": \"del_all_wifi_networks\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_wifi_scan_status",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 9,\n    \"msg\": \"get_wifi_scan_status\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "ENABLE",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 16,\n    \"msg\": \"wifi_network_command\",\n    \"msg_data\": {\n      \"id\": 0,\n      \"cmd\": \"ENABLE\"\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "add_wifi_network",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 12,\n    \"msg\": \"add_wifi_network\",\n    \"msg_data\": {\n      \"ssid\": \"My Network\",\n      \"password\": \"Secret1234\"\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_all_wifi_networks",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 10,\n    \"msg\": \"get_all_wifi_networks\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "ENABLE_ALL_NETWORKS",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 5,\n    \"msg\": \"wifi_command\",\n    \"msg_data\": {\n      \"cmd\": \"ENABLE_ALL_NETWORKS\"\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "DISABLE",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 17,\n    \"msg\": \"wifi_network_command\",\n    \"msg_data\": {\n      \"id\": 0,\n      \"cmd\": \"DISABLE\"\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "DISABLE_ALL_NETWORKS",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 6,\n    \"msg\": \"wifi_command\",\n    \"msg_data\": {\n      \"cmd\": \"DISABLE_ALL_NETWORKS\"\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "RECONNECT",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 3,\n    \"msg\": \"wifi_command\",\n    \"msg_data\": {\n      \"cmd\": \"RECONNECT\"\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_wifi_network",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 14,\n    \"msg\": \"get_wifi_network\",\n    \"msg_data\": {\n      \"id\": 0\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "update_wifi_network",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 15,\n    \"msg\": \"update_wifi_network\",\n    \"msg_data\": {\n      \"password\": \"Secret0000\"\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "REASSOCIATE",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 4,\n    \"msg\": \"wifi_command\",\n    \"msg_data\": {\n      \"cmd\": \"REASSOCIATE\"\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "SELECT",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 17,\n    \"msg\": \"wifi_network_command\",\n    \"msg_data\": {\n      \"id\": 0,\n      \"cmd\": \"SELECT\"\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "del_wifi_network",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 19,\n    \"msg\": \"del_wifi_network\",\n    \"msg_data\": {\n      \"id\": 0\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "DISCONNECT",
+                            "body": "{\n    \"kind\": \"req\",\n    \"id\": 2,\n    \"msg\": \"wifi_command\",\n    \"msg_data\": {\n      \"cmd\": \"DISCONNECT\"\n    }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "ota",
+                    "meta": {},
+                    "children": [
+                        {
+                            "name": "check_system_update",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"check_system_update\"\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "get_system_update_progress",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"get_system_update_progress\",\n  \"msg_data\": {\n    \"update_id\": \"uc_v_rev1_lite-v0.4.0-979\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "check_system_update force",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"check_system_update\",\n  \"msg_data\": {\n    \"force_update\": true\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        },
+                        {
+                            "name": "update_system",
+                            "body": "{\n  \"kind\": \"req\",\n  \"id\": 0,\n  \"msg\": \"update_system\",\n  \"msg_data\": {\n    \"update_id\": \"uc_v_rev1_lite-v0.4.0-979\"\n  }\n}",
+                            "meta": {
+                                "type": "json",
+                                "envelope": ""
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "version",
+                    "body": "{\n    \"kind\": \"req\",\n    \"id\": 110,\n    \"msg\": \"version\"\n}",
+                    "meta": {
+                        "type": "json",
+                        "envelope": ""
+                    }
+                },
+                {
+                    "name": "system",
+                    "body": "{\n    \"kind\": \"req\",\n    \"id\": 111,\n    \"msg\": \"system\"\n}",
+                    "meta": {
+                        "type": "json",
+                        "envelope": ""
+                    }
+                },
+                {
+                    "name": "auth",
+                    "body": "{\n    \"kind\": \"req\",\n    \"id\": 0,\n    \"msg\": \"auth\",\n    \"access_token\": \"1-2-3\"\n}",
+                    "meta": {
+                        "type": "json",
+                        "envelope": ""
+                    }
+                },
+                {
+                    "name": "ping",
+                    "body": "{\n    \"kind\": \"req\",\n    \"id\": 333,\n    \"msg\": \"ping\",\n    \"msg_data\": {\n        \"hello\": \"core\"\n    }\n}",
+                    "meta": {
+                        "type": "json",
+                        "envelope": ""
+                    }
+                }
+            ]
+        }
+    ],
+    "environments": [
+        {
+            "name": "Production",
+            "variables": {
+                "server": "remotetwo.local"
+            }
+        },
+        {
+            "name": "Staging",
+            "variables": {
+                "server": "unfolded-simulator.local:8080"
+            }
+        },
+        {
+            "name": "Development",
+            "variables": {
+                "server": "localhost:8080"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This PR moves the REST & WebSocket Core-API specifications from the unfoldedcircle/core-simulator repository into this one, including the commit history.

Closes #4