### PR TITLE
docs: add simple commands and more features to media-player entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Added
+- Media-player entity features ([#32](https://github.com/unfoldedcircle/core-api/issues/32), [feature-and-bug-tracker#56](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/56), [feature-and-bug-tracker#92](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/92)):
+  - new features: numpad, guide, info, eject, open_close, audio_track, subtitle, record.
+  - support "simple commands" for any additional commands not covered by a feature.
+
 ### Changed
 - Rename media-player `select_sound_mode` command parameter from `sound_mode` to `mode`.
 - Integration API: add `reconfigure` flag in `setup_driver` request message to reconfigure a driver.
-- Migrated REST- & WebSocket Core-APIs from the core-simulator repository to the `core-api` directory. 
+- Migrated REST- & WebSocket Core-APIs from the core-simulator repository to the `core-api` directory.
 
 ---
 

--- a/integration-api/asyncapi.yaml
+++ b/integration-api/asyncapi.yaml
@@ -8,7 +8,7 @@ asyncapi: 2.2.0
 id: 'urn:com:unfoldedcircle:integration'
 info:
   title: Remote Two WebSocket Integration API
-  version: '0.8.0-beta'
+  version: '0.9.0-beta'
   contact:
     name: API Support
     url: https://github.com/unfoldedcircle/core-api/issues
@@ -1882,20 +1882,32 @@ components:
                   - media_album
                   - media_image_url
                   - media_type
-                  - source
-                  - sound_mode
-#                  - up # TODO media navigation controls: part of entity, or solve as yet to define "media player / scene card"?
-#                  - down
-#                  - left
-#                  - right
-#                  - ok
-#                  - back
-#                  - menu
-#                  - home
+                  - dpad
+                  - numpad
+                  - home
+                  - menu
+                  - guide
+                  - info
+                  - color_buttons
+                  - channel_switcher
+                  - select_source
+                  - select_sound_mode
+                  - eject
+                  - open_close
+                  - audio_track
+                  - subtitle
+                  - record
                   # TODO playlist handling, browsing, searching
             options:
               type: object
               properties:
+                simple_commands:
+                  description: |
+                    Additional commands the media-player supports, which are not covered in the feature list.  
+                    Example: `["EXIT", "THUMBS_UP", "THUMBS_DOWN"]`
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/SimpleCommand'
                 volume_steps:
                   description: |
                     Number of available volume steps for the set volume command and UI controls. Examples:
@@ -1990,6 +2002,10 @@ components:
             - sensor
             - remote
         - {}  # extensible enum: there might be more supported entity types in a newer implementation than defined above
+
+    SimpleCommand:
+      type: string
+      format: "^[A-Z0-9\/_.:+#*°@%()?-]{1,20}$"
 
     # derived from Core-API integrationSetupChange: without driver_id
     driverSetupChange:


### PR DESCRIPTION
- Support "simple commands" for any additional commands not covered by features.
- Additional features: guide, info, eject, open_close, audio_track, subtitle, record.

Closes #32

Required for:
- https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/56
- https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/92
