### PR TITLE
Cleanup external access tokens in Core-API, driver request msgs in Integration-API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Added
+- Bluetooth HID peripheral support.
+- Custom integration installation. 
+- Integration-API: add `get_runtime_info` request message to retrieve driver runtime information from the Remote.
+
 ---
 
 ## 0.10.0-beta - 2024-04-10

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ The Remote Two WebSockets integrations API allows writing device integrations fo
 former YIO remote devices.  
 At the moment only user integrations running on an external host are supported.
 
+ℹ️ Beta release 1.9.0 allows to install custom integration drivers on the Remote. This is a developer preview feature
+to test their integrations.
+
 The integration driver acts as server and the Remote Two as client. The remote connects to the integration when an
 integration instance is configured. Whenever the remote enters standby it may choose to disconnect and automatically
 reconnect again after wakeup.

--- a/core-api/rest/CHANGELOG.md
+++ b/core-api/rest/CHANGELOG.md
@@ -10,6 +10,10 @@ This section contains unreleased changed which will be part of an upcoming relea
 
 ---
 
+## 0.34.1
+### Changed
+- Cleanup external token access endpoints for first implementation with Home Assistant.
+
 ## 0.34.0
 ### Added
 - Custom integration driver installation.

--- a/core-api/rest/UCR2-openapi.yaml
+++ b/core-api/rest/UCR2-openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Remote Two REST API
-  version: 0.34.0
+  version: 0.34.1
   contact:
     name: API Support
     url: 'https://github.com/unfoldedcircle/core-api/issues'
@@ -431,15 +431,15 @@ paths:
     get:
       tags:
         - external-token
-      summary: Get registered external systems.
+      summary: "\U0001F9EA Get registered external systems."
       description: |
-        External systems are handled with the R2 integrations. Before an access token for such a system can be provided,
-        the corresponding system needs to be registered.
+        External systems cannot be created manually. They are automatically being created if a custom integration driver
+        requests to use the "external tokens" feature. This is enabled with the driver feature `auth.external_tokens`.
 
-        _TODO: reference to WebSocket API for integration registration._
+        ⚠️ External integration drivers cannot use this feature.
 
-        If the expected system name is not returned by this call, any operations on that system name will fail:
-        `/auth/external/{system}`.
+        If the expected system name is not returned by this call, all operations on the `/auth/external/{system}` endpoints
+        with that system name will fail.
         Therefore, it's advisable to either call this method first or react on the 404 error while providing or updating an
         external system token, to inform the client user, that the integration is not available on the remote.
       operationId: getExternalSystems
@@ -468,27 +468,48 @@ paths:
     post:
       tags:
         - external-token
-      summary: Provide an access token of an external system.
+      summary: "\U0001F9EA Provide an access token of an external system."
       description: |
         An access token is usually required to connect to external systems like Home Assistant.
-        This method allows the external system to automatically provide the access token for the corresponding R2
+        This method allows the external system to automatically provide the access token for the corresponding Remote
         integration instead of forcing the user to type it in. If the token name already exists for the given system,
         error `422` is returned.
-        Use the put method to update an existing token.
+        Use the PUT method to update an existing token.
 
-        The format of the access token depends on the external system and the involved R2 integration.
-        It could be a UUID, a JWT or any other representation required for the integration to communicate with the
-        external system.
+        Required fields are:
+        - `token_id`: the main identifier for a given system. It must be unique within that system and may not end in
+          `-DATA` or `-URL`.
+        - `name`: a friendly name to show in a user interface. It must be unique within that system.
+        - `token`: the secret credential.
 
-        The `system` parameter is determined by the registered R2 integration. Only registered system name identifiers are
-        valid, otherwise error `404` will be returned.
-        E.g. a "FooBar" integration might register the system identifier name "foobar".
+        The format of the access token depends on the external system and the involved Remote integration.
+        It could be a UUID, a JWT, a PEM certificate or any other representation required for the integration to communicate
+        with the external system.
+
+        ⚠️ External access tokens can be used by the pre-installed integrations and the custom integrations installable by
+        the user. External integrations cannot access the secret token value.
+
+        ⚠️ The secret token value cannot be retrieved anymore with the API and is only available in the corresponding driver
+        runtime as a credential file.
+
+        To use the "external tokens" feature an integration driver has to request the driver feature `auth.external_tokens`.
+        If enabled, an external system is automatically created with the `system` identifier matching the `driver_id`.
+
         Use the `GET /auth/external` method the retrieve the registered systems.
+
+        Mapped credential files are automatically created in the corresponding integration driver runtime for the new token:
+        - Environment variable `UC_TOKENS_HOME` specifies the directory containing the credential files.
+        - The `token_id` value is used as credential file name for the secret token.
+          - For example: for `token_id: foobar`, the credential file is accessible at the `${UC_TOKENS_HOME}/foobar` path.
+          - The credential file contains the `token` field value in plain text.
+        - Optional files are created for the `url` and `data` fields:
+          - `{token_id}-URL` contains the `url` value. Example: `${UC_TOKENS_HOME}/foobar-URL`
+          - `{token_id}-DATA` contains the `data` value. Example: `${UC_TOKENS_HOME}/foobar-DATA`
       operationId: addExternalAccessToken
       parameters:
         - $ref: '#/components/parameters/system'
       requestBody:
-        description: Access token that needs to be added to the remote
+        description: Access token that needs to be added to the remote.
         content:
           application/json:
             schema:
@@ -500,19 +521,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  token_id:
-                    type: string
-                    format: '^[a-zA-Z0-9\-_]+$'
-                    minLength: 1
-                    maxLength: 36
-                    description: |
-                      Unique token identifier, used for later token management through the external system or management ui.
-                      If the token identifier has been provided in the request, then then same identifier is returned, otherwise a
-                      UUID is generated.
-                required:
-                  - token_it
+                $ref: '#/components/schemas/ExternalAccessTokenResponse'
         '400':
           $ref: '#/components/responses/Err400BadRequest'
         '401':
@@ -523,11 +532,10 @@ paths:
           $ref: '#/components/responses/Err404NotFound'
         '422':
           $ref: '#/components/responses/Err422UnprocessableEntity'
-      x-codegen-request-body-name: body
     head:
       tags:
         - external-token
-      summary: Get total number of available tokens for an external system.
+      summary: "\U0001F9EA Get total number of available tokens for an external system."
       operationId: getExternalAccessTokenCount
       parameters:
         - $ref: '#/components/parameters/system'
@@ -548,7 +556,7 @@ paths:
     get:
       tags:
         - external-token
-      summary: List available tokens for an external system.
+      summary: "\U0001F9EA List available tokens for an external system."
       operationId: getExternalAccessTokens
       parameters:
         - $ref: '#/components/parameters/system'
@@ -586,6 +594,8 @@ paths:
       tags:
         - external-token
       summary: Remove all access tokens of an external system.
+      description: |
+        All mapped credential files of the corresponding integration driver are also deleted.
       operationId: deleteExternalAccessTokensBySystem
       parameters:
         - $ref: '#/components/parameters/system'
@@ -602,7 +612,16 @@ paths:
     get:
       tags:
         - external-token
-      summary: Get external access token.
+      summary: "\U0001F9EA Get external access token."
+      description: |
+        Retrieve an external access token by system and token identifiers.
+
+        ⚠️ Only the public information of the token is returned, the secret token value itself cannot be retrieved anymore
+        with the API.
+
+        The secret token values are automatically mapped to credential files in the corresponding integration driver
+        runtime. The `token_id` value is used as file name for the token, with additional files for the optional `url` and
+        `data` fields.
       operationId: getExternalAccessToken
       parameters:
         - $ref: '#/components/parameters/system'
@@ -625,10 +644,13 @@ paths:
     put:
       tags:
         - external-token
-      summary: Replace an existing access token of an external system.
+      summary: "\U0001F9EA Replace an existing access token of an external system."
       description: |
         This methods allows an already provided token of an external system to be updated. The token is identified by
         the system name and the token identification.
+
+        The token, url and data values are also updated in the mapped credential files of the corresponding running
+        integration driver.
       operationId: replaceExternalAccessToken
       parameters:
         - $ref: '#/components/parameters/system'
@@ -657,6 +679,8 @@ paths:
       summary: Remove an external access token.
       description: |
         No error is returned if the `tokenId` doesn't exist. `404` is only returned it the `system` is not found.
+
+        The mapped credential files of the corresponding integration driver are also deleted.
       operationId: deleteExternalAccessToken
       parameters:
         - $ref: '#/components/parameters/system'
@@ -1914,6 +1938,8 @@ paths:
         provided entities and their references in profile pages and groups.
         - If the driver is a custom installed driver, the driver will be removed from the remote, including all
         configuration settings.
+        - If an external access token system has been created for the driver, it will be removed as well, including all
+          associated tokens!
       operationId: deleteIntegrationDriver
       parameters:
         - $ref: '#/components/parameters/driver_id'
@@ -12233,113 +12259,97 @@ components:
         system:
           $ref: '#/components/schemas/ExternalSystemId'
         name:
-          $ref: '#/components/schemas/ExternalSystemName'
+          $ref: '#/components/schemas/ExtSystemName'
+      required:
+        - system
+        - name
     ExternalSystemId:
       type: string
       format: '^[a-zA-Z0-9\-_]+$'
       minLength: 1
       maxLength: 50
       description: Unique external system identifier registered by an R2 integration to interact with the API.
-    ExternalSystemName:
+    TokenId:
+      type: string
+      format: '^[a-zA-Z0-9\-_]+$'
+      minLength: 1
+      maxLength: 36
+      description: |
+        Unique token identifier, used for later token management through the external system or management ui.
+    ExtSystemName:
       type: string
       minLength: 1
       maxLength: 50
       description: |
         Friendly name of the external system to display to the user within the app. This name must be unique for an external
         system and should be as short and concise as possible.
-        Use the description field for more information.
+    ExtAccessToken:
+      type: string
+      minLength: 1
+      maxLength: 32768
+      description: |
+        The token to access the external system with the corresponding Remote integration.
+        This could be a UUID, a JWT, a PEM certificate or any other representation required for the integration to
+        authenticate on the system.
+    ExtAccessTokenDescription:
+      type: string
+      maxLength: 2048
+      description: Optional description of the external access token.
+    ExtAccessTokenUrl:
+      type: string
+      maxLength: 2048
+      description: Optional URL of the external system.
+    ExtAccessTokenData:
+      type: string
+      maxLength: 32768
+      description: |
+        Optional data from the external system for the Remote integration.  
+        ⚠️ Attention: this data is not protected and retrievable by API clients!
     ExternalAccessTokens:
       type: array
       items:
-        type: object
-        properties:
-          system:
-            $ref: '#/components/schemas/ExternalSystemName'
-          token_id:
-            type: string
-          name:
-            type: string
-          description:
-            type: string
-            maxLength: 2048
-            description: Optional description of the external access token.
-          url:
-            type: string
-            maxLength: 2048
-            description: Optional URL of the external system.
-          data:
-            type: string
-            maxLength: 2048
-            description: Optional data from the external system for the R2 integration.
-          creation_date:
-            type: string
-            format: date-time
+        $ref: '#/components/schemas/ExternalAccessToken'
     ExternalAccessToken:
       type: object
       properties:
         system:
-          $ref: '#/components/schemas/ExternalSystemName'
+          $ref: '#/components/schemas/ExternalSystemId'
         token_id:
-          type: string
+          $ref: '#/components/schemas/TokenId'
         name:
-          type: string
-        token:
-          type: string
-          minLength: 1
-          maxLength: 2048
-          description: |
-            The token to access the external system with the corresponding R2 integration.
-            This could be a UUID, a JWT or any other representation required for the integration to authenticate on the
-            system.
+          $ref: '#/components/schemas/ExtSystemName'
         description:
-          type: string
-          maxLength: 2048
-          description: Optional description of the external access token.
+          $ref: '#/components/schemas/ExtAccessTokenDescription'
         url:
-          type: string
-          maxLength: 2048
-          description: Optional URL of the external system.
+          $ref: '#/components/schemas/ExtAccessTokenUrl'
         data:
-          type: string
-          maxLength: 2048
-          description: Optional data from the external system for the R2 integration.
+          $ref: '#/components/schemas/ExtAccessTokenData'
         creation_date:
           type: string
           format: date-time
+      required:
+        - system
+        - token_id
+        - name
+        - creation_date
     ExternalAccessTokenRequest:
       type: object
+      description: |
+        The token_id can be provided by the external system. If omitted, an UUID is generated and returned in the
+        ExternalAccessToken response. It may not end in `-DATA` or `-URL`.
       properties:
         token_id:
-          type: string
-          format: '^[a-zA-Z0-9\-_]+$'
-          minLength: 1
-          maxLength: 36
-          description: |
-            Unique token identifier, used for later token management through the external system or management ui.
-            This identifier can be provided by the external system. If omitted, an UUID is generated and returned in the
-            ExternalAccessToken response.
+          $ref: '#/components/schemas/TokenId'
         name:
-          $ref: '#/components/schemas/ExternalSystemName'
+          $ref: '#/components/schemas/ExtSystemName'
         token:
-          type: string
-          minLength: 1
-          maxLength: 2048
-          description: |
-            The token to access the external system with the corresponding R2 integration.
-            This could be a UUID, a JWT or any other representation required for the integration to authenticate on the
-            system.
+          $ref: '#/components/schemas/ExtAccessToken'
         description:
-          type: string
-          maxLength: 2048
-          description: Optional description of the external access token.
+          $ref: '#/components/schemas/ExtAccessTokenDescription'
         url:
-          type: string
-          maxLength: 2048
-          description: Optional URL of the external system.
+          $ref: '#/components/schemas/ExtAccessTokenUrl'
         data:
-          type: string
-          maxLength: 2048
-          description: Optional data from the external system for the R2 integration.
+          $ref: '#/components/schemas/ExtAccessTokenData'
       required:
         - name
         - token
@@ -12350,6 +12360,16 @@ components:
         description: Any other informative message about the external system
         url: 'ws://smart.home'
         data: 'optional: true, foo: bar, free: text'
+    ExternalAccessTokenResponse:
+      type: object
+      description: |
+        If the token identifier has been provided in the request, then then same identifier is returned, otherwise a
+        UUID is generated.
+      properties:
+        token_id:
+          $ref: '#/components/schemas/TokenId'
+      required:
+        - token_id
     FriendlyName:
       type: string
       maxLength: 64

--- a/doc/integration-driver/README.md
+++ b/doc/integration-driver/README.md
@@ -8,3 +8,14 @@
 - [Driver registration](driver-registration.md)
 - [Driver setup](driver-setup.md)
 - [Install integration driver on the device](driver-installation.md)
+
+## Examples
+
+- [Node.js API wrapper for the UC Integration API](https://github.com/unfoldedcircle/integration-node-library)
+- [Python API wrapper library for the UC Integration API](https://github.com/unfoldedcircle/integration-python-library)  
+  Integrations using the Python API wrapper:
+    - [Android TV integration](https://github.com/unfoldedcircle/integration-androidtv)
+    - [Apple TV integration](https://github.com/unfoldedcircle/integration-appletv)
+    - [Denon AVR integration](https://github.com/unfoldedcircle/integration-denonavr)
+- [API models in Rust](https://github.com/unfoldedcircle/api-model-rs)
+- [Home Assistant integration](https://github.com/unfoldedcircle/integration-home-assistant) written in Rust

--- a/doc/integration-driver/driver-installation.md
+++ b/doc/integration-driver/driver-installation.md
@@ -37,6 +37,12 @@ It is a reduced version of the `IntegrationDriver` object, without driver connec
     "en": "Control Foobar products",
     "de": "Steuere Foobar Produkte"
   },
+  "features": [
+    {
+      "name": "auth.external_tokens",
+      "required": true
+    }
+  ],
   "developer": {
     "name": "Unfolded Circle ApS",
     "email": "hello@unfoldedcircle.com",
@@ -70,8 +76,13 @@ It is a reduced version of the `IntegrationDriver` object, without driver connec
 }
 ```
 
-- `driver_id` must be at least 4 characters long and start with a letter. Only lower-case letters, digits and `-`, `_` are allowed.
-- Multiple language fields are not required. If only a single language is provided, it should use the `en` key.
+- `driver_id` must be at least 5 characters long and start with a lower-case letter.
+  - Only lower-case letters, digits and `-`, `_` are allowed.
+  - Common system identifiers are not allowed and will be rejected (e.g. `daemon`, `backup`, etc.).
+  - The `uc_` prefix should not be used. This is reserved for pre-installed integrations. Any custom integrations using
+    this prefix might get removed during a future firmware update.
+- Multiple language fields are not required, but recommended.
+  - If only a single language is provided, it should use the `en` key.
 - `setup_data_schema` is optional if the driver provides a setup flow.
   - This is the first screen of the setup, all further screens are dynamically provided by the driver. 
 - ⚠️ `min_core_api` is not yet used.
@@ -163,6 +174,9 @@ The driver runs in a sandbox with limited access to the host system.
   - The returned path may not be stored, it may change with future software updates.
 - Only the `$UC_CONFIG_HOME` and `$UC_DATA_HOME` directories are writeable and persisted between restarts.
   - The `/tmp` directory can be used for small temporary files. Files are not persisted between restarts.
+- A dynamic user and group is allocated when the driver is started.
+  - The user and group IDs may change between driver restarts.
+  - Write access to the `$UC_CONFIG_HOME`, `$UC_DATA_HOME` and `/tmp` directories is ensured.
 
 ⚠️ CPU and memory restrictions are not yet in place but will be enforced in a future firmware update!
 - A single integration driver should not use more than 100 MB of memory.
@@ -177,6 +191,16 @@ The integration runs on the same network environment as the Remote. There is no 
 
 ⚠️ A port-binding filter might be added in the future to prevent integrations to steal away ports of other integrations.
 The port range 8000-9200 and port 13333 must be avoided!
+
+#### Native integration drivers
+
+_TODO sysroot, available dynamic libraries_
+
+The [Remote Two Cross Compile Toolchain](https://github.com/unfoldedcircle/ucr2-toolchain) can be used to cross-compile
+a native binary for the Remote.
+
+- The driver must be compiled as a static binary for libc.
+- Most dynamic libraries in the cross-compile sysroot are NOT available in the custom integration runtime environment!
 
 ## Install driver
 

--- a/doc/integration-driver/driver-registration.md
+++ b/doc/integration-driver/driver-registration.md
@@ -1,6 +1,6 @@
 ## Driver Registration
 
-An integration driver can optionally register itself in a remote if the [driver advertisement](driver-advertisement.md)
+An external integration driver can optionally register itself in a remote if the [driver advertisement](driver-advertisement.md)
 for auto-discovery is not sufficient.  
 This is a convenience feature if a driver would like to provide its access token without the user requiring to manually
 enter it, or if the driver cannot be automatically be discovered by the remote due to network setup (non-local servers,

--- a/doc/integration-driver/websocket.md
+++ b/doc/integration-driver/websocket.md
@@ -8,7 +8,9 @@ protocol and are designed with message exchange patterns.
 
 ### Authentication
 
-An integration driver may require a token for authentication, or no authentication at all.
+⚠️ Custom integrations running on the remote do not support authentication.
+
+An external integration driver may require a token for authentication, or no authentication at all.
 
 - During driver registration the preferred authentication type and the token can be specified.
 - Default authentication method: message based if a token has been set.
@@ -75,8 +77,6 @@ restrictions), a fallback option with text messages exists. See AsyncAPI specifi
 ```
 
 The remote will close the connection if the integration sends any other code than 200 or 401. 
-
-**TODO** _describe token handling with REST API / web-configurator_
 
 #### No Authentication
 

--- a/integration-api/README.md
+++ b/integration-api/README.md
@@ -24,6 +24,7 @@ The provided Bash wrapper script [`create-html-docker.sh`](create-html-docker.sh
 
 | Integration API | UCR2 Firmware | Core Simulator |
 |-----------------|---------------|----------------|
-| 0.10.0          |               | 0.43.0         |
+| 0.11.0          | 1.9.2-beta    |                |
+| 0.10.0          | 1.7.12        | 0.43.0         |
 | 0.9.0           | 1.7.2         | 0.41.0         |
 | 0.8.0           | 1.5.2         | 0.39.7         |

--- a/integration-api/asyncapi.yaml
+++ b/integration-api/asyncapi.yaml
@@ -8,7 +8,7 @@ asyncapi: 2.2.0
 id: 'urn:com:unfoldedcircle:integration'
 info:
   title: Remote Two WebSocket Integration API
-  version: '0.10.0-beta'
+  version: '0.11.0-beta'
   contact:
     name: API Support
     url: https://github.com/unfoldedcircle/core-api/issues
@@ -131,6 +131,7 @@ channels:
           - $ref: '#/components/messages/supported_entity_types'
           - $ref: '#/components/messages/configured_entities'
           - $ref: '#/components/messages/localization_cfg'
+          - $ref: '#/components/messages/runtime_info'
     subscribe:
       description: |
         Integration API for the Remote Two to receive messages from integration drivers.  
@@ -160,6 +161,7 @@ channels:
           - $ref: '#/components/messages/get_supported_entity_types'
           - $ref: '#/components/messages/get_configured_entities'
           - $ref: '#/components/messages/get_localization_cfg'
+          - $ref: '#/components/messages/get_runtime_info'
 
 components:
   securitySchemes:
@@ -293,7 +295,7 @@ components:
         $ref: '#/components/schemas/driverMetadataMsg'
 
     enter_standby:
-      summary: 🔍 Remote Two goes into standby event.
+      summary: 🚀 Remote Two goes into standby event.
       description: |
         Notification event that the Remote Two goes into standby mode and won't process incoming events anymore.
       tags:
@@ -304,7 +306,7 @@ components:
         $ref: '#/components/schemas/enterStandbyEvent'
 
     exit_standby:
-      summary: 🔍 Remote Two leaves standby event.
+      summary: 🚀 Remote Two leaves standby event.
       description: |
         Notification event that the Remote Two is out of standby. The integration should resume operation if it
         suspended it while receiving the `enter_standby` event.  
@@ -374,7 +376,7 @@ components:
       payload:
         $ref: '#/components/schemas/deviceStateEventMsg'
     setup_driver:
-      summary: 🧪 Start driver setup.
+      summary: 🚀 Start driver setup.
       description: |
         If a driver includes a `setup_data_schema` object in its driver metadata, it enables the dynamic driver setup
         process. The setup process can be a simple "start-confirm-done" between the Remote Two and the integration
@@ -425,7 +427,7 @@ components:
       payload:
         $ref: '#/components/schemas/abortDriverSetupEvent'
     driver_setup_change:
-      summary: 🧪 Driver setup state change event.
+      summary: 🚀 Driver setup state change event.
       description: |
         Emitted for all driver setup flow state changes.
         
@@ -440,7 +442,7 @@ components:
       payload:
         $ref: '#/components/schemas/driverSetupChangeEvent'
     set_driver_user_data:
-      summary: 🧪 Provide requested driver setup data.
+      summary: 🚀 Provide requested driver setup data.
       description: |
         Set required data to configure the integration driver or continue the setup process.
         
@@ -487,7 +489,7 @@ components:
       payload:
         $ref: '#/components/schemas/availableEntitiesMsg'
     subscribe_events:
-      summary: 🧪 🍕 Subscribe to events.
+      summary: 🚀 🍕 Subscribe to events.
       description: |
         Subscribe to entity state change events to receive `entity_change` events from the integration driver.
         
@@ -514,18 +516,22 @@ components:
       x-response:
         $ref: '#/components/messages/result'
     get_version:
-      summary: 🚀 Get Remote Two version information.
+      summary: 🧪  Get Remote Two version information.
+      description: |
+        ℹ️️ implemented in firmware 0.9.2.
       payload:
         $ref: '#/components/schemas/getVersionMsg'
       x-response:
         $ref: '#/components/messages/version'
     version:
-      summary: 🔍 Remote version information response.
+      summary: 🧪 Remote version information response.
       payload:
         $ref: '#/components/schemas/versionMsg'
     get_supported_entity_types:
-      summary: 🚀 Get supported entities in the Remote Two.
+      summary: 🧪 Get supported entities in the Remote Two.
       description: |
+        ℹ️️ implemented in firmware 0.9.2.
+
         This is a metadata request for supported entities in the Remote Two and allows the client to check if it's still
         compatible. New releases can support new entities or entities might get renamed in major updates.
       tags:
@@ -543,12 +549,14 @@ components:
       payload:
         $ref: '#/components/schemas/supportedEntityTypesMsg'
     get_configured_entities:
-      summary: 🔍 Retrieve configured entities from this integration.
+      summary: 🧪 Retrieve configured entities from this integration.
       description: |
-        ⚠️ not yet implemented in the remote-core!
+        ℹ️️ implemented in firmware 0.9.2.
 
         Request the configured entities in the Remote Two originating from this integration. These are all the entities
-        which are being used in the Remote Two and assigned in a profile.
+        which have been configured in the Remote Two.  
+        ⚠️ This doesn't mean that all entities are actively being used (assigned in a profile and shown in the user
+        interface).
         
         This allows the driver e.g. to optimize its device communication and only consider actively used entities.  
         Another option for the driver to be notified about used entities is through the `subscribe_events` requests.
@@ -559,16 +567,18 @@ components:
       x-response:
         $ref: '#/components/messages/configured_entities'
     configured_entities:
-      summary: 🔍 Configured entities response.
+      summary: 🚀 Configured entities response.
       description: |
-        ⚠️ not yet implemented in the remote-core!
+        The returned entity identifiers are configured in the Remote.
       tags:
         - name: entity
       payload:
         $ref: '#/components/schemas/configuredEntitiesMsg'
     get_localization_cfg:
-      summary: 🔍 Retrieve the localization settings of the Remote Two.
+      summary: 🧪 Retrieve the localization settings of the Remote Two.
       description: |
+        ℹ️️ implemented in firmware 0.9.2.
+
         The active localization settings of the Remote Two can be used if the integration driver requires localized
         settings for texts or units of measurements. 
         
@@ -580,11 +590,31 @@ components:
       x-response:
         $ref: '#/components/messages/localization_cfg'
     localization_cfg:
-      summary: 🔍 Active localization settings of the Remote Two.
+      summary: 🧪 Active localization settings of the Remote Two.
       tags:
         - name: metadata
       payload:
         $ref: '#/components/schemas/localizationMsg'
+    get_runtime_info:
+      summary: 🔍 Retrieve driver runtime information from the Remote.
+      description: |
+        ℹ️️ implemented in firmware 0.9.2.
+
+        Request driver runtime information from the Remote. This returns driver and instance identifiers for advanced
+        usage of the REST Core-API. These identifiers could also be propagated to a home automation system to interact
+        with the Remote and REST Core-API.
+      tags:
+        - name: metadata
+      payload:
+        $ref: '#/components/schemas/getRuntimeInfoMsg'
+      x-response:
+        $ref: '#/components/messages/runtime_info'
+    runtime_info:
+      summary: 🔍 Driver runtime information from the Remote Two.
+      tags:
+        - name: metadata
+      payload:
+        $ref: '#/components/schemas/runtimeInfoMsg'
 
     get_entity_states:
       summary: 🚀 🍕 Get the current state of the configured entities.
@@ -1239,6 +1269,30 @@ components:
               const: localization_cfg
             msg_data:
               $ref: '#/components/schemas/localizationSettings'
+          required:
+            - msg
+            - msg_data
+
+    getRuntimeInfoMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_runtime_info
+          required:
+            - msg
+
+    runtimeInfoMsg:
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: runtime_info
+            msg_data:
+              $ref: '#/components/schemas/runtimeInfo'
           required:
             - msg
             - msg_data
@@ -2396,18 +2450,27 @@ components:
     versionInfo:
       type: object
       properties:
+        device_name:
+          description: Custom name of the remote
+          type: string
+        hostname:
+          description: Hostname of the remote
+          type: string
+        address:
+          description: MAC address of the remote
+          type: string
         api:
+          description: API version
           type: string
         core:
+          description: Core app version
           type: string
         ui:
+          description: Frontend app version
           type: string
         os:
+          description: Operating system version
           type: string
-        integrations: # untyped Map<string,string>
-          type: object
-          additionalProperties:
-            type: string
 
     localizationSettings:
       type: object
@@ -2417,6 +2480,7 @@ components:
         country_code:
           $ref: '#/components/schemas/countryCode'
         time_zone:
+          description: Time zone name according to IANA <https://www.iana.org/time-zones>, e.g. `Europe/Copenhagen`.
           type: string
         time_format_24h:
           type: boolean
@@ -2442,6 +2506,26 @@ components:
         - METRIC
         - US
         - UK
+
+    runtimeInfo:
+      type: object
+      properties:
+        driver_id:
+          description: Identifier under which this integration driver is accessible in the Remote.
+          type: string
+        intg_ids:
+          description: |
+            Defined integration instance identifiers of this integration driver in the Remote.  
+            ℹ️ Only single-device integration drivers are supported at the moment, i.e. there's maximum one integration
+               instance per driver.
+          type: array
+          items:
+            type: string
+        log_id:
+          description: Log service identifier for a custom integration driver running on the Remote.
+          type: string
+      required:
+        - driver_id
 
     # =========================================================================
     # from OpenAPI


### PR DESCRIPTION
Update driver installation documentation.

REST Core-API v0.34.1: update documentation of the external access tokens and cleanup data models.

Integration-API v0.11.0: cleanup driver request messages, add get_runtime_info request message for integration drivers to query runtime information from the Remote.