### PR TITLE
Update Core- & Integration-APIs for Remote 3

### DIFF
--- a/.github/workflows/asyncapi.yml
+++ b/.github/workflows/asyncapi.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Generate core AsyncAPI HTML doc
         run: |
-          ag ./core-api/websocket/UCR2-asyncapi.yaml @asyncapi/html-template -o ./static/api/ws --force-write
+          ag ./core-api/websocket/UCR-core-asyncapi.yaml @asyncapi/html-template -o ./static/api/ws --force-write
 
       - name: Generate integration AsyncAPI HTML doc
         run: |

--- a/.github/workflows/asyncapi.yml
+++ b/.github/workflows/asyncapi.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Validate integration-api
         uses: WaleedAshraf/asyncapi-github-action@v0.0.10
         with:
-          filepath: './integration-api/asyncapi.yaml'
+          filepath: './integration-api/UCR-integration-asyncapi.yaml'
 
       - name: Validate dock-api
         uses: WaleedAshraf/asyncapi-github-action@v0.0.10
@@ -57,7 +57,7 @@ jobs:
 
       - name: Generate integration AsyncAPI HTML doc
         run: |
-          ag ./integration-api/asyncapi.yaml @asyncapi/html-template -o ./static/api/integration --force-write
+          ag ./integration-api/UCR-integration-asyncapi.yaml @asyncapi/html-template -o ./static/api/integration --force-write
 
       - name: Generate dock AsyncAPI HTML doc
         run: |

--- a/.github/workflows/asyncapi.yml
+++ b/.github/workflows/asyncapi.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Validate websocket-api
         uses: WaleedAshraf/asyncapi-github-action@v0.0.10
         with:
-          filepath: './core-api/websocket/UCR2-asyncapi.yaml'
+          filepath: './core-api/websocket/UCR-core-asyncapi.yaml'
 
       - name: Validate integration-api
         uses: WaleedAshraf/asyncapi-github-action@v0.0.10

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -22,4 +22,4 @@ jobs:
         uses: mbowman100/swagger-validator-action@master
         with:
           files: |
-            ./core-api/rest/UCR2-openapi.yaml
+            ./core-api/rest/UCR-core-openapi.yaml

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Unfolded Circle Core APIs
 
-This repository contains API specifications of [Unfolded Circle Remote Two](https://www.unfoldedcircle.com/) products.
+This repository contains API specifications of [Unfolded Circle Remote](https://www.unfoldedcircle.com/) products.
 
 ## Overview
 
@@ -12,10 +12,10 @@ This repository contains API specifications of [Unfolded Circle Remote Two](http
 
 API definitions:
 
-- [WebSocket Integration API](./integration-api/README.md) defined with [AsyncAPI](https://www.asyncapi.com/).
-- [WebSocket Core API](./core-api/websocket/README.md) defined with [AsyncAPI](https://www.asyncapi.com/)
-- [REST Core API](./core-api/rest/README.md) defined with [OpenAPI](https://www.openapis.org/)
-- [WebSocket Dock API](./dock-api/README.md) defined with [AsyncAPI](https://www.asyncapi.com/)
+- [WebSocket Integration-API](./integration-api/README.md) defined with [AsyncAPI](https://www.asyncapi.com/).
+- [WebSocket Core-API](./core-api/websocket/README.md) defined with [AsyncAPI](https://www.asyncapi.com/)
+- [REST Core-API](./core-api/rest/README.md) defined with [OpenAPI](https://www.openapis.org/)
+- [WebSocket Dock-API](./dock-api/README.md) defined with [AsyncAPI](https://www.asyncapi.com/)
 
 Integration driver documentation:
 
@@ -25,42 +25,41 @@ Integration driver documentation:
 
 ## Integration API
 
-The Remote Two WebSockets integrations API allows writing device integrations for the Unfolded Circle Remote Two and
-former YIO remote devices.  
+The Remote WebSockets integration-API allows writing device integrations for the Unfolded Circle Remote devices.  
 At the moment only user integrations running on an external host are supported.
 
 ℹ️ Beta release 1.9.0 allows to install custom integration drivers on the Remote. This is a developer preview feature
 to test their integrations.
 
-The integration driver acts as server and the Remote Two as client. The remote connects to the integration when an
+The integration driver acts as server and the Remote device as client. The remote connects to the integration when an
 integration instance is configured. Whenever the remote enters standby it may choose to disconnect and automatically
 reconnect again after wakeup.
 
-The goal of the integration API is to cover not only simple static drivers, like controlling GPIOs on a Raspberry Pi,
+The goal of the integration-API is to cover not only simple static drivers, like controlling GPIOs on a Raspberry Pi,
 but also support to integrate existing home automation hubs like Home Assistant, Homey, openHAB etc.  
-The focus of the integration API is on entity integration, not on controlling or configuring the Remote Two. Please
-refer to the core-API for further functionality.
+The focus of the integration API is on entity integration, not on controlling or configuring the Remote device. Please
+refer to the Core-API for further functionality.
 
-An integration driver usually doesn't need to use the core-API as well, unless it also wants to customize certain device
+An integration driver usually doesn't need to use the Core-API as well, unless it also wants to customize certain device
 behaviour or automatically add or configure its entities to the users profile.
 
 ### Develop integration drivers
 
-Since we are providing an API and not an SDK for a specific programming language, one can develop integrations in any
-language which is capable running a WebSockets server.
+Since we are providing an API and not an SDK for a specific programming language, one can develop external integrations
+in any language which is capable running a WebSockets server and handling JSON data.
 
 The downside of an API is that more low-level coding is required. In our case this involves running a WebSocket server,
-handling the connections from the Remote Two, and parsing the JSON payload in the WebSocket text messages. However, once
-this is done, the required API message interactions are rather simple to handle. 
+handling the connections from the Remote device, and parsing the JSON payload in the WebSocket text messages.
+However, once this is done, the required API message interactions are rather simple to handle. 
 
 See [how to write an integration driver](doc/integration-driver/write-integration-driver.md) for more information about
-how to develop an integration driver for the Remote Two.
+how to develop an integration driver for the Remote devices.
 
 #### Examples
 
 - [API models in Rust](https://github.com/unfoldedcircle/api-model-rs)
-- [Node.js API wrapper for the UC Integration API](https://github.com/unfoldedcircle/integration-node-library)
-- [Python API wrapper library for the UC Integration API](https://github.com/unfoldedcircle/integration-python-library)  
+- [Node.js API wrapper for the UC Integration-API](https://github.com/unfoldedcircle/integration-node-library)
+- [Python API wrapper library for the UC Integration-API](https://github.com/unfoldedcircle/integration-python-library)  
   Integrations using the Python API wrapper:
   - [Android TV integration](https://github.com/unfoldedcircle/integration-androidtv)
   - [Apple TV integration](https://github.com/unfoldedcircle/integration-appletv)
@@ -71,14 +70,14 @@ We plan to release more examples in the future.
 
 ## Core APIs
 
-The Remote Two WebSockets & REST core APIs allow you to interact with the Unfolded Circle remote-core application and
+The UC Remote WebSockets & REST Core-APIs allow you to interact with the Unfolded Circle remote-core service and
 take full control of its features.
 
 See [core-api](./core-api) directory for more information.
 
 ## Other resources
 
-- [remote-core simulator](https://github.com/unfoldedcircle/core-simulator) to start developing integrations without a Remote Two device
+- [remote-core simulator](https://github.com/unfoldedcircle/core-simulator) to start developing integrations without a UC Remote device
 - Open Source [remote-ui application](https://github.com/unfoldedcircle/remote-ui)
 
 ## API versioning

--- a/core-api/README.md
+++ b/core-api/README.md
@@ -1,13 +1,15 @@
-# Remote Two Core-APIs
+# Unfolded Circle Remote Core-APIs
 
-The Remote Two WebSockets & REST Core-APIs allow you to interact with the Unfolded Circle remote-core application and
-take full control of its features. The APIs are specialized for certain tasks, but otherwise contain the same
-functionality.
+The Unfolded Circle Remote WebSocket & REST Core-APIs allow you to interact with the Unfolded Circle remote-core service
+and take full control of its features. The APIs are specialized for certain tasks, but otherwise contain the same
+functionality and data models.
 
-- The REST API adds:
+- The UCR REST Core-API adds:
     - Custom resource handling for uploading icons, images etc.
+    - Installing custom remote-ui and web-configurator components.
+    - Installing custom integration drivers.
     - User management and authentication handling.
-- The WebSockets API adds:
+- The UCR WS Core-API adds:
     - Event subscription with asynchronous notifications.
 
 The API specifications are defined with [OpenAPI](https://swagger.io/specification/) & [AsyncAPI](https://www.asyncapi.com/)
@@ -20,6 +22,7 @@ in YAML format.
 
 | UCR2 Firmware | Core Simulator | REST API | WS API |
 |---------------|----------------|----------|--------|
+| 1.9.2-beta    |                | 0.34.1   | 0.26.0 |
 | 1.9.0-beta    |                | 0.34.0   | 0.26.0 |
 | 1.8.0-beta    |                | 0.33.0   | 0.26.0 |
 | 1.7.8         | 0.42.0         | 0.32.0   | 0.25.0 |

--- a/core-api/rest/CHANGELOG.md
+++ b/core-api/rest/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This section contains unreleased changed which will be part of an upcoming release. 
 
+### Changed
+- Changed naming for Remote Two and Remote 3 (same API).
+
 ---
 
 ## 0.34.1

--- a/core-api/rest/CHANGELOG.md
+++ b/core-api/rest/CHANGELOG.md
@@ -10,6 +10,7 @@ This section contains unreleased changed which will be part of an upcoming relea
 
 ### Changed
 - Changed naming for Remote Two and Remote 3 (same API).
+- Add UCR3 specific enhancements and feature flags for charger and button backlight.
 
 ---
 

--- a/core-api/rest/README.md
+++ b/core-api/rest/README.md
@@ -5,7 +5,7 @@ The UCR REST Core-API is defined with [OpenAPI](https://www.openapis.org/).
 You can use the online [Swagger Editor](https://editor.swagger.io/) to load and browse the specification or use your
 favorite IDE with OpenAPI support (e.g. IntelliJ or Visual Studio Code).
 
-- [OpenAPI YAML definition](UCR2-openapi.yaml).
+- [OpenAPI YAML definition](UCR-core-openapi.yaml).
   - ℹ️ This is a bundled YAML file generated from individual definitions.
   - Most OpenAPI tools only work with a single file.
   - We might publish the original definitions at a later time.

--- a/core-api/rest/README.md
+++ b/core-api/rest/README.md
@@ -1,6 +1,6 @@
-# Remote Two REST Core-API
+# Unfolded Circle Remote REST Core-API
 
-The Core-API is defined with [OpenAPI](https://www.openapis.org/).
+The UCR REST Core-API is defined with [OpenAPI](https://www.openapis.org/).
 
 You can use the online [Swagger Editor](https://editor.swagger.io/) to load and browse the specification or use your
 favorite IDE with OpenAPI support (e.g. IntelliJ or Visual Studio Code).

--- a/core-api/rest/UCR-core-openapi.yaml
+++ b/core-api/rest/UCR-core-openapi.yaml
@@ -11,7 +11,7 @@ info:
     url: 'https://creativecommons.org/licenses/by-sa/4.0/'
   description: "The Unfolded Circle REST Core-API for Remote Two/3 (_UCR REST Core-API_ in short) allows to configure the remote and\nmanage custom resource files. Furthermore, API-keys for the WebSocket & REST APIs can be created.\n\n## Overview\n\nThe Unfolded Circle Remote Core-APIs consist of:\n- this REST API\n- the [UCR WebSocket Core-API](https://github.com/unfoldedcircle/core-api/tree/main/core-api/websocket),\n  providing asynchronous events.\n\nThe focus of the Core-APIs is to provide all functionality for the UI application and the web-configurator.  \nThey allow to interact with the Unfolded Circle remote-core service and take full control of its features.\n\nThe Core-APIs may also be used by other external systems and integration drivers, if specific configuration or\ninteraction features are required, which are not present in the [UCR Integration-API](https://github.com/unfoldedcircle/core-api/tree/main/integration-api).\n\n## Authentication\n\nAll API endpoints besides `/api/pub` are secured. Available authentication methods are:\n- `Basic Auth` for every request.  \n  This should only be used for simple testing. At the moment there's only a single user account available for the\n  web-configurator.\n  - User: `web-configurator`\n  - Password: generated pin shown in the remote-UI.\n- `Bearer Token` for every request.  \n  This is the preferred authentication method for external systems communicating with the UCR REST Core-API.\n  - See `/auth/api_keys` endpoints on how to create and manage API keys.\n  - Only the `admin` role is supported at the moment. More roles will be added in the future.\n  - Example for a curl request:  \n    `curl 'http://$IP/api/system' --header 'Authorization: Bearer $API_KEY'`\n- `Cookie` based session login with the `/api/pub/login` endpoint.  \n  This is the preferred method for web frontends like the web-configurator.\n\n## \U0001F6A7 Missing Features\n\n**This API is a preview version and does not yet contain all functionality.**\n\nThe following features will be continuously added (in no particular order):\n\n- Upload of custom certificate\n- Static network configuration\n\nPlease check the [core-api GitHub issues](https://github.com/unfoldedcircle/core-api/issues) for the current state. \n\n## API Versioning\n\nThe API is versioned according to [SemVer](https://semver.org/).  \nThe initial public release will be `1.0.0` once it is considered stable enough with some initial integration\nimplementations and developer examples.\n\n**Any major version zero (`0.y.z`) is for initial development and may change at any time!**  \nI.e. backward compatibility for minor releases is not yet established, anything MAY change at any time!\nWe try avoiding it, but it might still happen...\n"
 externalDocs:
-  description: Find out more about the Remote 3
+  description: Find out more about the Remotes
   url: 'https://www.unfoldedcircle.com/'
 servers:
   - url: /api
@@ -14607,9 +14607,13 @@ components:
       type: object
       properties:
         model_name:
+          description: Friendly name of the device model.
           type: string
         model_number:
-          description: 'Model number of the remote (ucr2 for Remote Two, ucr3 for Remote 3).'
+          description: |
+            Full model number of the remote:
+            - `ucr2` for Remote Two
+            - `ucr3-##` for Remote 3, ## suffix indicates color variant
           type: string
         serial_number:
           type: string
@@ -14883,8 +14887,9 @@ components:
     VersionInfo:
       type: object
       properties:
-        model_number:
-          description: 'Model number of the remote (ucr2 for Remote Two, ucr3 for Remote 3).'
+        model:
+          description: |
+            Short model identifier of the remote (UCR2 for Remote Two, UCR3 for Remote 3).
           type: string
         device_name:
           description: Custom name of the remote
@@ -14899,7 +14904,7 @@ components:
           description: API version
           type: string
         core:
-          description: Core app version
+          description: Core service version
           type: string
         ui:
           description: Frontend app version

--- a/core-api/rest/UCR2-openapi.yaml
+++ b/core-api/rest/UCR2-openapi.yaml
@@ -5,6 +5,7 @@ info:
   contact:
     name: API Support
     url: 'https://github.com/unfoldedcircle/core-api/issues'
+    email: support@unfoldedcircle.com
   license:
     name: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
     url: 'https://creativecommons.org/licenses/by-sa/4.0/'
@@ -6546,6 +6547,15 @@ paths:
       summary: Get button settings.
       description: |
         Button backlight configuration.
+
+        Device features:
+        - `BACKLIGHT`: buttons have backlight (UCR2, UCR3).  
+        - `RGB_COLOR`: RGB color backlight support (UCR3).
+        - `ZONES`: backlight can be controlled with individual zones (UCR3).
+
+        Backlight zone definitions can be retrieved with `/cfg/device/button_layout`.
+
+        ⚠️ Individual color per zone is not yet supported.
       operationId: getButtonSettings
       parameters:
         - name: default
@@ -6575,7 +6585,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CfgButtons'
+              $ref: '#/components/schemas/CfgButtonsUpdate'
         required: true
       responses:
         '200':
@@ -6647,7 +6657,10 @@ paths:
         - cfg
       summary: Get the button layouts of the device.
       description: |
-        Meta-information about the button groups and button layouts.
+        Meta-information about the button groups, button layouts and backlight zone information.
+
+        If a button group supports backlight zones, an additional entry with button group `type` suffix `_backlight` is
+        defined.
       operationId: getRemoteDeviceButtonLayoutSettings
       responses:
         '200':
@@ -9507,6 +9520,56 @@ paths:
           $ref: '#/components/responses/Err403Forbidden'
         '503':
           $ref: '#/components/responses/Err503ServiceUnavailable'
+  /system/power/charger:
+    get:
+      tags:
+        - system
+      summary: Get battery charger information.
+      description: |
+        Device features:
+        - `DOCK_CHARGING`: device can be charged in docking station (UCR2, UCR3).
+        - `WIRELESS_CHARGING`: device has wireless charging support (UCR3).
+      operationId: getBatteryCharger
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatteryCharger'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
+    put:
+      tags:
+        - system
+      summary: "\U0001F477 Enable or disable wireless charging."
+      description: |
+        This operation is only supported on devices with wireless charging.
+      operationId: updateBatteryCharger
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatteryChargerUpdate'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatteryCharger'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+        '503':
+          $ref: '#/components/responses/Err503ServiceUnavailable'
   /system/power/standby_inhibitors:
     get:
       tags:
@@ -10964,11 +11027,36 @@ components:
         status:
           $ref: '#/components/schemas/PowerStatus'
         power_supply:
-          description: Power supply online
+          description: 'A power supply is online, device doesn''t run on battery.'
           type: boolean
       required:
         - capacity
         - status
+    BatteryCharger:
+      type: object
+      properties:
+        features:
+          type: array
+          items:
+            type: string
+        power_supply:
+          description: 'A power supply is online, device doesn''t run on battery.'
+          type: boolean
+        wireless_charging:
+          description: Wireless charging is active. Only returned on devices with wireless charging.
+          type: boolean
+        wireless_charging_enabled:
+          description: Wireless charging is enabled. Only returned on devices with wireless charging.
+          type: boolean
+      required:
+        - features
+        - power_supply
+    BatteryChargerUpdate:
+      type: object
+      properties:
+        wireless_charging_enabled:
+          description: Enable or disable wireless charging. Only supported on devices with wireless charging.
+          type: boolean
     PowerStatus:
       type: string
       enum:
@@ -11059,12 +11147,56 @@ components:
           type: integer
           minimum: 0
           maximum: 100
+        static_color:
+          $ref: '#/components/schemas/StaticButtonColor'
         auto_brightness:
           description: 'When enabled, button backlight will automatically turn on in a dark room.'
           type: boolean
+        features:
+          description: Supported features by the device.
+          type: array
+          items:
+            type: string
       required:
         - brightness
         - auto_brightness
+    CfgButtonsUpdate:
+      description: Button configuration model to update settings. Missing properties are not changed.
+      type: object
+      properties:
+        brightness:
+          description: 'Overall button backlight brightness. 0 = off, 100 = max.'
+          type: integer
+          minimum: 0
+          maximum: 100
+        static_color:
+          $ref: '#/components/schemas/StaticButtonColor'
+        auto_brightness:
+          description: 'When enabled, button backlight will automatically turn on in a dark room.'
+          type: boolean
+    StaticButtonColor:
+      description: 'Static color settings for given zones, if supported by the device.'
+      type: object
+      properties:
+        rgb:
+          description: 'The overall rgb color value for the specified zones [int, int, int].'
+          type: array
+          items:
+            type: integer
+            minimum: 0
+            maximum: 255
+          minItems: 3
+          maxItems: 3
+        zones:
+          description: The enabled backlight zones. All zones are enabled if no zones are set.
+          type: array
+          items:
+            type: string
+            minimum: 1
+            maximum: 50
+          maxItems: 32
+      required:
+        - rgb
     CfgDisplay:
       type: object
       properties:
@@ -11423,12 +11555,21 @@ components:
       maxLength: 255
       description: Optional description
     DeviceButtonGroup:
-      description: Button group type.
+      description: |
+        Button group type, either physical buttons or button backlight zones:
+        - `keypad`: physical keypad buttons.
+        - `keypad_backlight`: button backlight zones.
       type: string
       enum:
         - keypad
+        - keypad_backlight
     DeviceButtonLayout:
-      description: 'Button group definitions with layout placement, size, icon and language specific names.'
+      description: |
+        Button group definitions with layout placement, size, icon and language specific names.
+
+        The grid width & height definitions do not need to be proportional! To get the correct size, the grid has to be
+        placed over the physical dimensions of the button group. For example if buttons in a row can be placed in the middle
+        of another button row, the width value can be doubled, with the button width set to 2.
       type: object
       properties:
         type:
@@ -14468,6 +14609,7 @@ components:
         model_name:
           type: string
         model_number:
+          description: 'Model number of the remote (ucr2 for Remote Two, ucr3 for Remote 3).'
           type: string
         serial_number:
           type: string
@@ -14741,6 +14883,9 @@ components:
     VersionInfo:
       type: object
       properties:
+        model_number:
+          description: 'Model number of the remote (ucr2 for Remote Two, ucr3 for Remote 3).'
+          type: string
         device_name:
           description: Custom name of the remote
           type: string

--- a/core-api/rest/UCR2-openapi.yaml
+++ b/core-api/rest/UCR2-openapi.yaml
@@ -1,16 +1,16 @@
 openapi: 3.0.3
 info:
-  title: Remote Two REST API
-  version: 0.34.1
+  title: Remote Two/3 REST Core-API
+  version: 0.35.0
   contact:
     name: API Support
     url: 'https://github.com/unfoldedcircle/core-api/issues'
   license:
     name: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
     url: 'https://creativecommons.org/licenses/by-sa/4.0/'
-  description: "The Unfolded Circle Remote Two REST API allows to configure the remote and manage custom resource files.\nFurthermore, API-keys for the WebSocket & REST APIs can be created.\n\n## Overview\n\nThe Remote Two WebSockets Core-API allows you to interact with the Unfolded Circle remote-core application and take\nfull control of its features.\n\nThe focus of the Core-API is to provide all functionality for the UI application and the web-configurator.  \nIt may also be used by other external systems and integration drivers, if specific configuration or interaction\nfeatures are required, which are not present in the Integration API.\n\n## Authentication\n\nAll API endpoints besides `/api/pub` are secured. Available authentication methods are:\n- `Basic Auth` for every request.  \n  This should only be used for simple testing. At the moment there's only a single user account available for the\n  web-configurator.\n  - User: `web-configurator`\n  - Password: generated pin shown in the remote UI\n- `Bearer Token` for ever request.  \n  This is the preferred authentication method for external systems communicating with the Remote Two.\n  - See `/auth/api_keys` endpoints on how to create and manage API keys.\n  - Only the `admin` role is supported at the moment. More roles will be added in the future.\n  - Example for a curl request:  \n    `curl 'http://$IP/api/system' --header 'Authorization: Bearer $API_KEY'`\n- `Cookie` based session login with the `/api/pub/login` endpoint.  \n  This is the preferred method for web frontends like the web-configurator.\n\n## \U0001F6A7 Missing Features\n\n**This API is a preview version and does not yet contain all functionality.**\n\nThe following features will be continuously added (in no particular order):\n\n- Upload of custom certificate\n- Static network configuration\n\nPlease check the [core-api GitHub issues](https://github.com/unfoldedcircle/core-api/issues) for the current state. \n\n## API Versioning\n\nThe API is versioned according to [SemVer](https://semver.org/).  \nThe initial public release will be `1.0.0` once it is considered stable enough with some initial integration\nimplementations and developer examples.\n\n**Any major version zero (`0.y.z`) is for initial development and may change at any time!**  \nI.e. backward compatibility for minor releases is not yet established, anything MAY change at any time!\nWe try avoiding it, but it might still happen...\n"
+  description: "The Unfolded Circle REST Core-API for Remote Two/3 (_UCR REST Core-API_ in short) allows to configure the remote and\nmanage custom resource files. Furthermore, API-keys for the WebSocket & REST APIs can be created.\n\n## Overview\n\nThe Unfolded Circle Remote Core-APIs consist of:\n- this REST API\n- the [UCR WebSocket Core-API](https://github.com/unfoldedcircle/core-api/tree/main/core-api/websocket),\n  providing asynchronous events.\n\nThe focus of the Core-APIs is to provide all functionality for the UI application and the web-configurator.  \nThey allow to interact with the Unfolded Circle remote-core service and take full control of its features.\n\nThe Core-APIs may also be used by other external systems and integration drivers, if specific configuration or\ninteraction features are required, which are not present in the [UCR Integration-API](https://github.com/unfoldedcircle/core-api/tree/main/integration-api).\n\n## Authentication\n\nAll API endpoints besides `/api/pub` are secured. Available authentication methods are:\n- `Basic Auth` for every request.  \n  This should only be used for simple testing. At the moment there's only a single user account available for the\n  web-configurator.\n  - User: `web-configurator`\n  - Password: generated pin shown in the remote-UI.\n- `Bearer Token` for every request.  \n  This is the preferred authentication method for external systems communicating with the UCR REST Core-API.\n  - See `/auth/api_keys` endpoints on how to create and manage API keys.\n  - Only the `admin` role is supported at the moment. More roles will be added in the future.\n  - Example for a curl request:  \n    `curl 'http://$IP/api/system' --header 'Authorization: Bearer $API_KEY'`\n- `Cookie` based session login with the `/api/pub/login` endpoint.  \n  This is the preferred method for web frontends like the web-configurator.\n\n## \U0001F6A7 Missing Features\n\n**This API is a preview version and does not yet contain all functionality.**\n\nThe following features will be continuously added (in no particular order):\n\n- Upload of custom certificate\n- Static network configuration\n\nPlease check the [core-api GitHub issues](https://github.com/unfoldedcircle/core-api/issues) for the current state. \n\n## API Versioning\n\nThe API is versioned according to [SemVer](https://semver.org/).  \nThe initial public release will be `1.0.0` once it is considered stable enough with some initial integration\nimplementations and developer examples.\n\n**Any major version zero (`0.y.z`) is for initial development and may change at any time!**  \nI.e. backward compatibility for minor releases is not yet established, anything MAY change at any time!\nWe try avoiding it, but it might still happen...\n"
 externalDocs:
-  description: Find out more about the Remote Two
+  description: Find out more about the Remote 3
   url: 'https://www.unfoldedcircle.com/'
 servers:
   - url: /api
@@ -273,7 +273,7 @@ paths:
     post:
       tags:
         - api-keys
-      summary: Create an API key for the Remote Two APIs.
+      summary: Create an API key for the UCR APIs.
       description: |
         The returned API key in `api_key` is only visible in this response. Afterwards it cannot be retrieved anymore!
 
@@ -2234,7 +2234,7 @@ paths:
         - integrations
       summary: Configure multiple available entities.
       description: |
-        Configure multiple new Remote Two entities from available integration entities. Once configured, the entities will
+        Configure multiple new UC Remote entities from available integration entities. Once configured, the entities will
         no longer show up as an available entity (unless the `filter=ALL` query parameter is set).
 
         An empty request body array will configure all available entities.
@@ -2282,7 +2282,7 @@ paths:
         - integrations
       summary: Configure an available entity.
       description: |
-        Configure a new Remote Two entity from an available integration entity. Once configured, the entity will no longer
+        Configure a new UC Remote entity from an available integration entity. Once configured, the entity will no longer
         show up as available entity (unless the `filter=ALL` query parameter is set).
 
         The entity `name`, `icon` and `description` fields may be changed. If not specified in the request the values from
@@ -8673,7 +8673,7 @@ paths:
         - system
       summary: Create and export a device configuration backup.
       description: |
-        Export the full Remote Two device configuration. This allows to restore the configuration after a factory reset
+        Export the full UC Remote device configuration. This allows to restore the configuration after a factory reset
         or to load the configuration onto another device.
 
         - The backup archive is only returned to the client and not stored on the device. 
@@ -8731,7 +8731,7 @@ paths:
         - system
       summary: Upload and restore a device configuration backup.
       description: |
-        Restore the Remote Two device configuration from the uploaded backup archive. The backup archive is only used
+        Restore the UC Remote device configuration from the uploaded backup archive. The backup archive is only used
         to restore the system and deleted after restore.
 
         - It is highly recommended to perform the restore while the remote is in the docking station.
@@ -10346,7 +10346,7 @@ components:
               properties:
                 editable:
                   description: |
-                    - `true` / property missing: activity was created by Remote Two and can be edited.
+                    - `true` / property missing: activity was created by UC Remote and can be edited.
                     - `false`: activity was provided by an integration and cannot be edited.
                   type: boolean
                   default: true
@@ -10416,7 +10416,7 @@ components:
               properties:
                 editable:
                   description: |
-                    - `true` / property missing: activity was created by Remote Two and can be edited.
+                    - `true` / property missing: activity was created by UC Remote and can be edited.
                     - `false`: activity was provided by an integration and cannot be edited.
                   type: boolean
                   default: true
@@ -11410,7 +11410,7 @@ components:
             firmware_version:
               description: |
                 [SemVer](https://semver.org/) version requirement, describing the intersection of some version comparators to
-                match the installed Remote Two firmware.
+                match the installed UC Remote firmware.
 
                 - `>=1.0`: requires at least version 1.0.0
                 - `>=0.9.0, <0.10.0`: only works with minor version 0.9.*   
@@ -12038,7 +12038,7 @@ components:
       format: '^[a-zA-Z0-9\-_\.]+$'
       minLength: 5
       maxLength: 110
-      description: Unique UC Remote Two identifier over all entities and integrations.
+      description: Unique UC Remote identifier over all entities and integrations.
     EntityCommand:
       description: |
         Entity command object. The `entity_id` only has to be specified if it's not already included as a parameter in the URL.
@@ -13253,7 +13253,7 @@ components:
       type: string
       description: |
         The type of the IR emitter device:
-        - `DOCK`: a Remote Two docking station
+        - `DOCK`: an Unfolded Circle docking station
         - `INTERNAL`: internal IR
         - `IR_BLASTER`: a network based IR blaster
         - `OTHER`: something else
@@ -13342,7 +13342,7 @@ components:
               properties:
                 editable:
                   description: |
-                    - `true` / property missing: macro was created by Remote Two and can be edited.
+                    - `true` / property missing: macro was created by UC Remote and can be edited.
                     - `false`: macro was provided by an integration and cannot be edited.
                   type: boolean
                   default: true
@@ -13412,7 +13412,7 @@ components:
               properties:
                 editable:
                   description: |
-                    - `true` / property missing: macro was created by Remote Two and can be edited.
+                    - `true` / property missing: macro was created by UC Remote and can be edited.
                     - `false`: macro was provided by an integration and cannot be edited.
                   type: boolean
                   default: true
@@ -13643,7 +13643,7 @@ components:
               properties:
                 editable:
                   description: |
-                    - `true` / property missing: remote was created by Remote Two and can be edited.
+                    - `true` / property missing: remote was created by UC Remote and can be edited.
                     - `false`: remote was provided by an integration and cannot be edited.
                   type: boolean
                   default: true
@@ -13798,7 +13798,7 @@ components:
               properties:
                 editable:
                   description: |
-                    - `true` / property missing: remote was created by Remote Two and can be edited.
+                    - `true` / property missing: remote was created by UC Remote and can be edited.
                     - `false`: remote was provided by an integration and cannot be edited.
                   type: boolean
                   default: true

--- a/core-api/websocket/CHANGELOG.md
+++ b/core-api/websocket/CHANGELOG.md
@@ -10,6 +10,7 @@ This section contains unreleased changed which will be part of an upcoming relea
 
 ### Changed
 - Changed naming for Remote Two and Remote 3 (same API).
+- Add UCR3 specific enhancements and feature flags for charger and button backlight.
 
 ---
 

--- a/core-api/websocket/CHANGELOG.md
+++ b/core-api/websocket/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This section contains unreleased changed which will be part of an upcoming release. 
 
+### Changed
+- Changed naming for Remote Two and Remote 3 (same API).
+
 ---
 
 ## 0.26.0-beta

--- a/core-api/websocket/README.md
+++ b/core-api/websocket/README.md
@@ -5,12 +5,12 @@ It is up to the client to reconnect again.
 
 The UCR WS Core-API is defined with [AsyncAPI](https://www.asyncapi.com/).
 
-- [AsyncAPI YAML definition](UCR2-asyncapi.yaml).
+- [AsyncAPI YAML definition](UCR-core-asyncapi.yaml).
 - See [/doc folder](../../doc/README.md) for further API documentation and information.
 
 ## API HTML documentation
 
-- View with [AsyncAPI Studio online tool](https://studio.asyncapi.com/?url=https://raw.githubusercontent.com/unfoldedcircle/core-api/main/core-api/websocket/UCR2-asyncapi.yaml).  
+- View with [AsyncAPI Studio online tool](https://studio.asyncapi.com/?url=https://raw.githubusercontent.com/unfoldedcircle/core-api/main/core-api/websocket/UCR-core-asyncapi.yaml).  
   The link will directly load the yaml definition file from GitHub and display it together with the HTML documentation
   in the browser.
 

--- a/core-api/websocket/README.md
+++ b/core-api/websocket/README.md
@@ -1,9 +1,9 @@
-# Remote Two WebSocket Core-API
+# Unfolded Circle Remote WebSocket Core-API
 
-The Remote Two acts as server. Whenever the remote enters standby it may choose to disconnect open WebSocket sessions.
+The Remote device acts as server. Whenever the device enters standby, it may choose to disconnect open WebSocket sessions.
 It is up to the client to reconnect again.
 
-The Core-API is defined with [AsyncAPI](https://www.asyncapi.com/).
+The UCR WS Core-API is defined with [AsyncAPI](https://www.asyncapi.com/).
 
 - [AsyncAPI YAML definition](UCR2-asyncapi.yaml).
 - See [/doc folder](../../doc/README.md) for further API documentation and information.

--- a/core-api/websocket/UCR-core-asyncapi.yaml
+++ b/core-api/websocket/UCR-core-asyncapi.yaml
@@ -116,7 +116,7 @@ info:
       - `401`: invalid authentication and the connection will be closed.
 
 externalDocs:
-  description: Find out more about the Remote 3
+  description: Find out more about the Remotes
   url: 'https://www.unfoldedcircle.com/'
 defaultContentType: application/json
 
@@ -6991,8 +6991,9 @@ components:
     versionInfo:
       type: object
       properties:
-        model_number:
-          description: Model number of the remote (ucr2 for Remote Two, ucr3 for Remote 3).
+        model:
+          description: |
+            Short model identifier of the remote (UCR2 for Remote Two, UCR3 for Remote 3).
           type: string
         device_name:
           description: Custom name of the remote
@@ -7007,7 +7008,7 @@ components:
           description: API version
           type: string
         core:
-          description: Core app version
+          description: Core service version
           type: string
         ui:
           description: Frontend app version
@@ -7025,8 +7026,13 @@ components:
       type: object
       properties:
         model_name:
+          description: Friendly name of the device model.
           type: string
         model_number:
+          description: |
+            Full model number of the remote:
+            - `ucr2` for Remote Two
+            - `ucr3-##` for Remote 3, ## suffix indicates color variant
           type: string
         serial_number:
           type: string

--- a/core-api/websocket/UCR2-asyncapi.yaml
+++ b/core-api/websocket/UCR2-asyncapi.yaml
@@ -7,8 +7,8 @@
 asyncapi: 2.2.0
 id: 'urn:com:unfoldedcircle:core'
 info:
-  title: Remote Two WebSocket Core-API
-  version: '0.26.0-beta'
+  title: Remote Two/3 WebSocket Core-API
+  version: '0.27.0-beta'
   contact:
     name: API Support
     url: https://github.com/unfoldedcircle/core-api/issues
@@ -16,7 +16,10 @@ info:
     name: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
     url: https://creativecommons.org/licenses/by-sa/4.0/
   description: |
-    **Work in progress** API definition of the Remote Two Core WebSocket API.
+    The Unfolded Circle WebSocket Core-API for Remote Two/3 (_UCR WS Core-API_ in short) allows to interact with the
+    Unfolded Circle remote-core service and take control of most of its features. It is a subset of the
+    [UCR REST Core-API](https://github.com/unfoldedcircle/core-api/tree/main/core-api/rest), but provides additional
+    asynchronous event messages.
     
     API message status legend:
     
@@ -26,24 +29,27 @@ info:
     | 🚧   | Planned feature and most likely not (fully) implemented in the initial release. |
     | 👷   | API definition is work in progress, not ready yet for implementation.           |
     | 🔍   | API definition review & implementation.                                         |
-    | 🧪   | API has been implemented in the Remote Two and is currently being tested.       |
+    | 🧪   | API has been implemented in the UC Remote and is currently being tested.        |
     | 🚀   | Ready to use - feedback welcomed.                                               |
     
     ## Overview
 
-    The Remote Two WebSockets Core-API allows you to interact with the Unfolded Circle remote-core application and take
-    full control of its features.
+    The Unfolded Circle Remote Core-APIs consist of:
+    - this WebSocket API
+    - the [UCR REST Core-API](https://github.com/unfoldedcircle/core-api/tree/main/core-api/rest).
+
+    The remote-core service acts as WebSocket server. Whenever the remote enters standby it may choose to disconnect
+    client connections.
     
-    The remote-core application acts as server. Whenever the remote enters standby it may choose to disconnect client
-    connections.
+    The focus of the Core-APIs is to provide all functionality for the UI application and the web-configurator.  
+    They allow to interact with the Unfolded Circle remote-core service and take full control of its features.
     
-    The focus of the Core-API is to provide all functionality for the UI application and the web-configurator.  
-    It may also be used by other external systems and integration drivers, if specific configuration or interaction
-    features are required, which are not present in the Integration API.
+    The Core-APIs may also be used by other external systems and integration drivers, if specific configuration or
+    interaction features are required, which are not present in the [UCR Integration-API](https://github.com/unfoldedcircle/core-api/tree/main/integration-api).
 
     ## 🚧 Missing Features
     
-    **This API is a preview version and does not yet contain all functionality.**
+    **This API is a work-in-progress and does not yet contain all functionality of the REST API.**
     
     The following features will be continuously added (in no particular order):
     
@@ -109,7 +115,7 @@ info:
       - `401`: invalid authentication and the connection will be closed.
 
 externalDocs:
-  description: Find out more about the Remote Two
+  description: Find out more about the Remote 3
   url: 'https://www.unfoldedcircle.com/'
 defaultContentType: application/json
 
@@ -2437,7 +2443,7 @@ components:
     configure_entity_from_integration:
       summary: 🧪 Configure an available entity.
       description: |
-        Configure a new Remote Two entity from an available integration entity. Once configured, the entity will no
+        Configure a new UC Remote entity from an available integration entity. Once configured, the entity will no
         longer show up as available entity (unless the `all` filter is set).
         
         The entity `name`, `icon` and `description` fields may be changed. If not specified in the request the values from
@@ -2454,7 +2460,7 @@ components:
     configure_entities_from_integration:
       summary: 🧪 Configure multiple available entities.
       description: |
-        Configure multiple new Remote Two entities from available integration entities. Once configured, the entities will
+        Configure multiple new UC Remote entities from available integration entities. Once configured, the entities will
         no longer show up as an available entity (unless the `filter=ALL` query parameter is set).
         
         If `entity_ids` is not provided or is empty, all entities from the integration are configured.

--- a/core-api/websocket/UCR2-asyncapi.yaml
+++ b/core-api/websocket/UCR2-asyncapi.yaml
@@ -12,6 +12,7 @@ info:
   contact:
     name: API Support
     url: https://github.com/unfoldedcircle/core-api/issues
+    email: support@unfoldedcircle.com
   license:
     name: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
     url: https://creativecommons.org/licenses/by-sa/4.0/
@@ -176,10 +177,13 @@ channels:
           - $ref: '#/components/messages/get_system_update_progress'
           - $ref: '#/components/messages/get_power_mode'
           - $ref: '#/components/messages/set_power_mode'
+          - $ref: '#/components/messages/get_battery_charger'
+          - $ref: '#/components/messages/update_battery_charger'
           - $ref: '#/components/messages/get_standby_inhibitors'
           - $ref: '#/components/messages/create_standby_inhibitor'
           - $ref: '#/components/messages/del_standby_inhibitor'
           - $ref: '#/components/messages/del_all_standby_inhibitors'
+          - $ref: '#/components/messages/get_ambient_light'
 
           # --- configuration handling
           - $ref: '#/components/messages/reset_configuration'
@@ -294,8 +298,9 @@ channels:
           - $ref: '#/components/messages/factory_reset_token'
           - $ref: '#/components/messages/api_access'
           - $ref: '#/components/messages/system_update_info'
-          - $ref: '#/components/messages/get_power_mode'
-          - $ref: '#/components/messages/get_ambient_light'
+          - $ref: '#/components/messages/power_mode'
+          - $ref: '#/components/messages/battery_charger'
+          - $ref: '#/components/messages/ambient_light'
           # --- configuration handling
           - $ref: '#/components/messages/configuration'
           - $ref: '#/components/messages/button_cfg'
@@ -811,6 +816,27 @@ components:
       x-response:
         $ref: '#/components/messages/result'
 
+    get_battery_charger:
+      summary: 👷 Get battery charger information.
+      description: |
+        Device features:
+        - `DOCK_CHARGING`: device can be charged in docking station (UCR2, UCR3).
+        - `WIRELESS_CHARGING`: device has wireless charging support (UCR3).
+      payload:
+        $ref: '#/components/schemas/getBatteryChargerMsg'
+      x-response:
+        $ref: '#/components/messages/battery_charger'
+    battery_charger:
+      summary: 👷 Battery charger response.
+      payload:
+        $ref: '#/components/schemas/batteryChargerMsg'
+    update_battery_charger:
+      summary: 👷 Enable or disable wireless charging.
+      payload:
+        $ref: '#/components/schemas/updateBatteryChargerMsg'
+      x-response:
+        $ref: '#/components/messages/battery_charger'
+
     get_standby_inhibitors:
       summary: 🧪 Get standby inhibitors.
       description: |
@@ -899,6 +925,15 @@ components:
         $ref: '#/components/messages/button_cfg'
     button_cfg:
       summary: 🧪 Button settings response.
+      description: |
+        Button backlight configuration.
+
+        Device features:
+        - `BACKLIGHT`: buttons have backlight (UCR2, UCR3).  
+        - `RGB_COLOR`: RGB color backlight support (UCR3).
+        - `ZONES`: backlight can be controlled with individual zones (UCR3).
+
+        ⚠️ Individual color per zone is not yet supported.
       payload:
         $ref: '#/components/schemas/buttonCfgMsg'
 
@@ -3415,6 +3450,43 @@ components:
             - msg
             - msg_data
 
+    getBatteryChargerMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_battery_charger
+          required:
+            - msg
+    batteryChargerMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: battery_charger
+            msg_data:
+              $ref: '#/components/schemas/BatteryCharger'
+          required:
+            - msg
+            - msg_data
+    updateBatteryChargerMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: update_battery_charger
+            msg_data:
+              $ref: '#/components/schemas/BatteryChargerUpdate'
+          required:
+            - msg
+            - msg_data
+
     getStandbyInhibitorsMsg:
       type: object
       allOf:
@@ -3577,7 +3649,7 @@ components:
               type: string
               const: set_button_cfg
             msg_data:
-              $ref: '#/components/schemas/cfgButton'
+              $ref: '#/components/schemas/cfgButtonUpdate'
           required:
             - msg
             - msg_data
@@ -6919,6 +6991,9 @@ components:
     versionInfo:
       type: object
       properties:
+        model_number:
+          description: Model number of the remote (ucr2 for Remote Two, ucr3 for Remote 3).
+          type: string
         device_name:
           description: Custom name of the remote
           type: string
@@ -7330,12 +7405,58 @@ components:
           type: integer
           minimum: 0
           maximum: 100
+        static_color:
+          $ref: '#/components/schemas/staticButtonColor'
         auto_brightness:
           description: When enabled, button backlight will automatically turn on in a dark room.
           type: boolean
+        features:
+          description: Supported features by the device.
+          type: array
+          items:
+            type: string
       required:
         - brightness
         - auto_brightness
+
+    cfgButtonUpdate:
+      description: Button configuration model to update settings. Missing properties are not changed.
+      type: object
+      properties:
+        brightness:
+          description: Overall button backlight brightness. 0 = off, 100 = max.
+          type: integer
+          minimum: 0
+          maximum: 100
+        static_color:
+          $ref: '#/components/schemas/staticButtonColor'
+        auto_brightness:
+          description: When enabled, button backlight will automatically turn on in a dark room.
+          type: boolean
+
+    staticButtonColor:
+      description: Static color settings for all zones, if supported by the device.
+      type: object
+      properties:
+        rgb:
+          description: The overall rgb color value for the specified zones [int, int, int].
+          type: array
+          items:
+            type: integer
+            minimum: 0
+            maximum: 255
+          minItems: 3
+          maxItems: 3
+        zones:
+          description: The enabled backlight zones. All zones are enabled if no zones are set.
+          type: array
+          items:
+            type: string
+            minimum: 1
+            maximum: 50
+          maxItems: 32
+      required:
+        - rgb_color
 
     cfgDevice:
       type: object
@@ -9785,6 +9906,33 @@ components:
         - DISCHARGING
         - NOT_CHARGING
         - FULL
+
+    BatteryCharger:
+      type: object
+      properties:
+        features:
+          type: array
+          items:
+            type: string
+        power_supply:
+          description: A power supply is online, device doesn't run on battery.
+          type: boolean
+        wireless_charging:
+          description: Wireless charging is active. Only returned on devices with wireless charging.
+          type: boolean
+        wireless_charging_enabled:
+          description: Wireless charging is enabled. Only returned on devices with wireless charging.
+          type: boolean
+      required:
+        - features
+        - power_supply
+
+    BatteryChargerUpdate:
+      type: object
+      properties:
+        wireless_charging_enabled:
+          description: Enable or disable wireless charging. Only supported on devices with wireless charging.
+          type: boolean
 
     # --- OpenAPI AmbientLight.yaml
 

--- a/core-api/websocket/create-html-docker.sh
+++ b/core-api/websocket/create-html-docker.sh
@@ -5,6 +5,6 @@ readonly OUT_DIR=${PWD}/html
 mkdir -p "$OUT_DIR"
 docker run --rm -it \
   -v "${OUT_DIR}":/app/example \
-  -v "${PWD}/UCR2-asyncapi.yaml":/app/asyncapi.yaml \
+  -v "${PWD}/UCR-core-asyncapi.yaml":/app/asyncapi.yaml \
   asyncapi/generator:1.9.2 asyncapi.yaml @asyncapi/html-template@0.25 --force-write -o example
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -6,7 +6,7 @@
 
 ## Integration API
 
-- [Integration AsyncAPI YAML definition](../integration-api/asyncapi.yaml)
+- [Integration AsyncAPI YAML definition](../integration-api/UCR-integration-asyncapi.yaml)
 - [Remote Two entities](entities/README.md)
 - [How to write an integration driver](integration-driver/write-integration-driver.md)
 - [WebSockets handling](integration-driver/websocket.md)

--- a/doc/discovery.md
+++ b/doc/discovery.md
@@ -18,6 +18,7 @@ The `model` key specifies the physical device or the [core-simulator](https://gi
 
 | Model          | Description           |
 |----------------|-----------------------|
+| UCR3           | Remote 3              |
 | UCR2           | Remote Two            |
 | UCR2-simulator | Remote Core simulator |
 | YIO1           | YIO Remote            |

--- a/doc/entities/README.md
+++ b/doc/entities/README.md
@@ -96,7 +96,7 @@ All entities share a set of common attributes like `name` and the `UNAVAILABLE`,
 An entity implementation defines additional features, attributes, states and options which need to be handled in the
 driver implementation.
 
-Please see [Integration AsyncAPI definition](../../integration-api/asyncapi.yaml) for more information and additional options.
+Please see [Integration AsyncAPI definition](../../integration-api/UCR-integration-asyncapi.yaml) for more information and additional options.
 
 ### Common entity definition
 

--- a/doc/integration-driver/README.md
+++ b/doc/integration-driver/README.md
@@ -1,6 +1,6 @@
 # WebSocket Integration API
 
-- [AsyncAPI definition](../../integration-api/asyncapi.yaml)
+- [AsyncAPI definition](../../integration-api/UCR-integration-asyncapi.yaml)
 - [Remote Two entities](../entities/README.md)
 - [How to write an integration driver](write-integration-driver.md)
 - [WebSockets handling](websocket.md)

--- a/doc/integration-driver/write-integration-driver.md
+++ b/doc/integration-driver/write-integration-driver.md
@@ -1,6 +1,6 @@
 ## How to write an integration driver
 
-The integration API allows to develop external integration drivers in any programming language capable of running
+The Integration-API allows to develop external integration drivers in any programming language capable of running
 a WebSockets server. Custom integration drivers require Node.js or a statically linked binary.
 
 - `External integration driver`: a driver running on an external device, reachable by the Remote. 
@@ -19,7 +19,7 @@ When writing a driver from scratch without using a wrapper library:
 2. Choose a WebSockets server library or framework for your language.
 3. Choose a JSON framework for your language.
 4. Choose which [entities and features](../entities/README.md) the driver should expose.
-5. Implement the required WebSockets text messages in the [WebSocket Integration API](../../integration-api/asyncapi.yaml).
+5. Implement the required WebSockets text messages in the [WebSocket Integration API](../../integration-api/UCR-integration-asyncapi.yaml).
 
 ❗️ Using a wrapper library or one of the existing open source drivers as a start will greatly simplify driver development.
 Node.js should be preferred when developing a custom integration driver.
@@ -177,7 +177,7 @@ Example of an event message:
 ### Required Messages
 
 For a functioning integration driver not all defined messages and optional features in the integration API have to be
-implemented. The mandatory messages are tagged with a pizza 🍕 emoji in the [WebSocket Integration AsyncAPI definition](../../integration-api/asyncapi.yaml).
+implemented. The mandatory messages are tagged with a pizza 🍕 emoji in the [WebSocket Integration AsyncAPI definition](../../integration-api/UCR-integration-asyncapi.yaml).
 
 Required request messages which must be processed and answered by a driver:
 

--- a/integration-api/README.md
+++ b/integration-api/README.md
@@ -1,6 +1,6 @@
 # WebSocket Integration API
 
-- [AsyncAPI YAML definition](asyncapi.yaml).
+- [AsyncAPI YAML definition](UCR-integration-asyncapi.yaml).
 
 - See [/doc folder](../doc/README.md) for the API documentation and further information.
 

--- a/integration-api/UCR-integration-asyncapi.yaml
+++ b/integration-api/UCR-integration-asyncapi.yaml
@@ -7,8 +7,8 @@
 asyncapi: 2.2.0
 id: 'urn:com:unfoldedcircle:integration'
 info:
-  title: Remote Two WebSocket Integration API
-  version: '0.11.0-beta'
+  title: Remote Two/3 WebSocket Integration API
+  version: '0.11.1-beta'
   contact:
     name: API Support
     url: https://github.com/unfoldedcircle/core-api/issues
@@ -17,7 +17,7 @@ info:
     name: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
     url: https://creativecommons.org/licenses/by-sa/4.0/
   description: |
-    API definition of the Remote Two integration WebSocket API.
+    API definition of the Unfolded Circle WebSocket Integration-API for Remote Two/3 (_UCR Integration-API_ in short).
     
     API message status legend:
     
@@ -27,7 +27,7 @@ info:
     | 🚧   | Planned feature and most likely not (fully) implemented in the initial release. |
     | 👷   | API definition is work in progress, not ready yet for implementation.           |
     | 🔍   | Api definition review & implementation.                                         |
-    | 🧪   | API has been implemented in the Remote Two and is currently being tested.       |
+    | 🧪   | API has been implemented in the UC Remote and is currently being tested.        |
     | 🚀   | Ready to use - feedback welcomed.                                               |
   
     Simple integrations with static entities don't need to implement all messages.  
@@ -35,18 +35,18 @@ info:
     
     ## Overview
 
-    The Remote Two WebSocket integrations API allows writing device integrations for the Unfolded Circle Remote Two and
-    former YIO remote.  
-    At the moment only user integrations running on an external host are supported.
+    The UCR Integration-API allows writing device integration drivers for the Unfolded Circle Remotes.  
     
-    The integration driver acts as server and the Remote Two as client. The remote connects to the integration when an
+    ℹ️ Starting with the UCR2 firmware beta release 1.9.0, custom integration drivers can be installed on the UC Remote.
+  
+    The integration driver acts as server and the UC Remote as client. The remote connects to the integration when an
     integration instance is configured. Whenever the remote enters standby it may choose to disconnect and connect again
     after wakeup.
     
-    The goal of the integration API is to cover simple static drivers like controlling GPIOs on a Raspberry Pi, up to
+    The goal of the Integration-API is to cover simple static drivers like controlling GPIOs on a Raspberry Pi, up to
     integrating existing home automation hubs like Home Assistant, Homey, ioBroker, openHAB etc.  
-    The focus of the integration API is on entity integration, not on controlling or configuring the Remote Two. Please
-    refer to the core-API for other functionality: <https://github.com/unfoldedcircle/core-api>
+    The focus of the integration API is on entity integration, not on controlling or configuring the UC Remote. Please
+    refer to the Core-API for other functionality: <https://github.com/unfoldedcircle/core-api>
 
     ## API Versioning
     
@@ -58,7 +58,7 @@ info:
     I.e. backward compatibility for minor releases is not yet established, anything MAY change at any time!
 
 externalDocs:
-  description: Find out more about the Remote Two
+  description: Find out more about the Remotes
   url: 'https://www.unfoldedcircle.com/'
 defaultContentType: application/json
 
@@ -101,8 +101,8 @@ channels:
   /intg:
     publish:
       description: |
-        Integration API for the Remote Two to interact with custom devices.  
-        The publish channel lists all messages that the Remote Two sends to an integration driver server.
+        Integration API for the UC Remote to interact with custom devices.  
+        The publish channel lists all messages that the UC Remote sends to an integration driver server.
       operationId: pubIntegrationMessage
       message:
         oneOf:
@@ -134,8 +134,8 @@ channels:
           - $ref: '#/components/messages/runtime_info'
     subscribe:
       description: |
-        Integration API for the Remote Two to receive messages from integration drivers.  
-        The subscribe channel lists all messages that the integration driver server sends to the Remote Two.
+        Integration API for the UC Remote to receive messages from integration drivers.  
+        The subscribe channel lists all messages that the integration driver server sends to the UC Remote.
       operationId: subIntegrationMessage
       message:
         oneOf:
@@ -170,10 +170,10 @@ components:
         The API token is either provided in the `auth-token` header while upgrading to a WebSocket connection,
         or with an authentication message.
         - If the integration driver doesn't support header based authentication, it must send the `auth_required`
-          message event after the WebSocket connection is established. The Remote Two will then authenticate with the
+          message event after the WebSocket connection is established. The UC Remote will then authenticate with the
           `auth` request message.
         - If the driver doesn't support or require authentication, it still needs to send the `authentication` message
-          with `code: 200` and `req_id: 0` after the WebSocket connection has been established by the Remote Two.
+          with `code: 200` and `req_id: 0` after the WebSocket connection has been established by the UC Remote.
       type: httpApiKey
       in: header
       name: auth-token
@@ -224,7 +224,7 @@ components:
       summary: 🚀 Authentication request event after connection is established.
       description: |
         This event is only sent if the integration doesn't support header based authentication during connection setup.  
-        The Remote Two will then authenticate with the `auth` request message.
+        The UC Remote will then authenticate with the `auth` request message.
       tags:
         - name: event
       payload:
@@ -232,7 +232,7 @@ components:
     auth:
       summary: 🚀 Authenticate a connection.
       description: |
-        Sent by the Remote Two after an `auth_required` request by the integration driver.
+        Sent by the UC Remote after an `auth_required` request by the integration driver.
       payload:
         $ref: '#/components/schemas/authRequestMsg'
       x-response:
@@ -243,11 +243,11 @@ components:
         The authentication result is provided in the `code` attribute:
         - `200`: success, API can be used and message requests are accepted.
         - `401`: authentication failed, the provided token is not valid.  
-          The Remote Two will close the connection. The driver should also close the connection after sending this
+          The UC Remote will close the connection. The driver should also close the connection after sending this
           response.
         
         If the driver doesn't support or require authentication, it still needs to send the `authentication` message
-        with `code: 200` and `req_id: 0` after the WebSocket connection has been established by the Remote Two.
+        with `code: 200` and `req_id: 0` after the WebSocket connection has been established by the UC Remote.
         
         It's recommended to send the optional driver version object in the the msg_data payload to avoid eventual
         additional message exchanges.
@@ -295,9 +295,9 @@ components:
         $ref: '#/components/schemas/driverMetadataMsg'
 
     enter_standby:
-      summary: 🚀 Remote Two goes into standby event.
+      summary: 🚀 UC Remote goes into standby event.
       description: |
-        Notification event that the Remote Two goes into standby mode and won't process incoming events anymore.
+        Notification event that the UC Remote goes into standby mode and won't process incoming events anymore.
       tags:
         - name: device
         - name: entity
@@ -306,11 +306,11 @@ components:
         $ref: '#/components/schemas/enterStandbyEvent'
 
     exit_standby:
-      summary: 🚀 Remote Two leaves standby event.
+      summary: 🚀 UC Remote leaves standby event.
       description: |
-        Notification event that the Remote Two is out of standby. The integration should resume operation if it
+        Notification event that the UC Remote is out of standby. The integration should resume operation if it
         suspended it while receiving the `enter_standby` event.  
-        This allows the integration to submit any entity state changes. Otherwise the Remote Two will likely request an
+        This allows the integration to submit any entity state changes. Otherwise the UC Remote will likely request an
         entity state update.
       tags:
         - name: device
@@ -327,7 +327,7 @@ components:
         Optional: this event instructs the integration to establish the required connections to interact with the
         provided entities or devices.
         
-        The integration should send `device_state` events to inform the Remote Two about the connection state.
+        The integration should send `device_state` events to inform the UC Remote about the connection state.
       tags:
         - name: device
         - name: event
@@ -337,10 +337,10 @@ components:
       summary: 🧪 Event to stop the connection to entities or devices.
       description: |
         Optional: this event instructs the integration to stop the interactions with the provided entities or devices,
-        because the Remote Two temporarily doesn't need the entities. It's up to the integration what to do, but it
+        because the UC Remote temporarily doesn't need the entities. It's up to the integration what to do, but it
         needs to be prepared to react on a `connect` event.
         
-        The integration should send `device_state` events to inform the Remote Two about the connection state.
+        The integration should send `device_state` events to inform the UC Remote about the connection state.
       tags:
         - name: device
         - name: event
@@ -349,7 +349,7 @@ components:
     get_device_state:
       summary: 🚀 🍕 Get the current integration driver or device state.
       description: |        
-        Called by the Remote Two when it needs to synchronize the device state, e.g. after waking up from standby, or if
+        Called by the UC Remote when it needs to synchronize the device state, e.g. after waking up from standby, or if
         it doesn't receive regular `device_state` events.
         
         The `device_id` property is only required if the driver supports multiple device instances.
@@ -368,7 +368,7 @@ components:
         If there's a device communication issue or other error, this state will inform the user with a UI notification
         about the issue.
         
-        This event should be triggered by the integration driver whenever the state changes. Furthermore, the Remote Two
+        This event should be triggered by the integration driver whenever the state changes. Furthermore, the UC Remote
         can request the current state with the `get_device_state` request.
       tags:
         - name: device
@@ -379,7 +379,7 @@ components:
       summary: 🚀 Start driver setup.
       description: |
         If a driver includes a `setup_data_schema` object in its driver metadata, it enables the dynamic driver setup
-        process. The setup process can be a simple "start-confirm-done" between the Remote Two and the integration
+        process. The setup process can be a simple "start-confirm-done" between the UC Remote and the integration
         driver, or a fully dynamic, multi-step process with user interactions, where the user has to provide additional
         data or select different options.
         
@@ -391,13 +391,13 @@ components:
         After confirming the `setup_driver` request, the integration driver has to send `driver_setup_change` events:
         
         - `event_type: SETUP` with `state: SETUP` is a progress event to keep the process running, see below.
-        - `event_type: SETUP` with `state: WAIT_USER_ACTION` can be sent to the Remote Two to request a user
+        - `event_type: SETUP` with `state: WAIT_USER_ACTION` can be sent to the UC Remote to request a user
           interaction: either a confirmation to press next to continue the process, or input values.
-        - `event_type: STOP` with `event: OK` finishes the setup process and the Remote Two creates an integration instance.
+        - `event_type: STOP` with `event: OK` finishes the setup process and the UC Remote creates an integration instance.
         - `event_type: STOP` with `event: ERROR` aborts the setup process.
 
         ⚠️ If the setup process takes more than a few seconds, the integration should send `driver_setup_change` events
-        with `state: SETUP` to the Remote Two to show a setup progress to the user and prevent an inactivity timeout.  
+        with `state: SETUP` to the UC Remote to show a setup progress to the user and prevent an inactivity timeout.  
         Default setup timeouts:
         - Setup progress (watchdog): 60 seconds. If no setup message is received within that time, the setup process
           is aborted.
@@ -419,7 +419,7 @@ components:
     abort_driver_setup:
       summary: 🚀 Abort a driver setup.
       description: |
-        If the user aborts the setup process, the Remote Two sends this event. Further messages from the integration
+        If the user aborts the setup process, the UC Remote sends this event. Further messages from the integration
         from the setup process will be ignored afterwards.
       tags:
         - name: setup
@@ -479,7 +479,7 @@ components:
     available_entities:
       summary: 🚀 🍕 Available entities response.
       description: |
-        This message contains the available entities from the integration driver the Remote Two can configure.
+        This message contains the available entities from the integration driver the UC Remote can configure.
         
         If the `get_available_entities` request included a filter, it is returned in the message data with only the 
         matching entities.
@@ -493,7 +493,7 @@ components:
       description: |
         Subscribe to entity state change events to receive `entity_change` events from the integration driver.
         
-        If no entity IDs are specified then events for all available entities are sent to the Remote Two.
+        If no entity IDs are specified then events for all available entities are sent to the UC Remote.
       tags:
         - name: entity
         - name: required
@@ -506,7 +506,7 @@ components:
       description: |
         If no entity IDs are specified then all events for all available entities are stopped. 
         
-        This message is sent by the Remote Two if a previously configured entity is no longer used and therefore no
+        This message is sent by the UC Remote if a previously configured entity is no longer used and therefore no
         longer interested in entity updates. If the integration driver keeps sending events for the unsubscribed
         entities then they are simply discarded.
       tags:
@@ -516,7 +516,7 @@ components:
       x-response:
         $ref: '#/components/messages/result'
     get_version:
-      summary: 🧪  Get Remote Two version information.
+      summary: 🧪  Get UC Remote version information.
       description: |
         ℹ️️ implemented in firmware 0.9.2.
       payload:
@@ -528,11 +528,11 @@ components:
       payload:
         $ref: '#/components/schemas/versionMsg'
     get_supported_entity_types:
-      summary: 🧪 Get supported entities in the Remote Two.
+      summary: 🧪 Get supported entities in the UC Remote.
       description: |
         ℹ️️ implemented in firmware 0.9.2.
 
-        This is a metadata request for supported entities in the Remote Two and allows the client to check if it's still
+        This is a metadata request for supported entities in the UC Remote and allows the client to check if it's still
         compatible. New releases can support new entities or entities might get renamed in major updates.
       tags:
         - name: entity
@@ -553,8 +553,8 @@ components:
       description: |
         ℹ️️ implemented in firmware 0.9.2.
 
-        Request the configured entities in the Remote Two originating from this integration. These are all the entities
-        which have been configured in the Remote Two.  
+        Request the configured entities in the UC Remote originating from this integration. These are all the entities
+        which have been configured in the UC Remote.  
         ⚠️ This doesn't mean that all entities are actively being used (assigned in a profile and shown in the user
         interface).
         
@@ -575,11 +575,11 @@ components:
       payload:
         $ref: '#/components/schemas/configuredEntitiesMsg'
     get_localization_cfg:
-      summary: 🧪 Retrieve the localization settings of the Remote Two.
+      summary: 🧪 Retrieve the localization settings of the UC Remote.
       description: |
         ℹ️️ implemented in firmware 0.9.2.
 
-        The active localization settings of the Remote Two can be used if the integration driver requires localized
+        The active localization settings of the UC Remote can be used if the integration driver requires localized
         settings for texts or units of measurements. 
         
         For language texts the driver should always provide an english option in addition to any localized texts.
@@ -590,7 +590,7 @@ components:
       x-response:
         $ref: '#/components/messages/localization_cfg'
     localization_cfg:
-      summary: 🧪 Active localization settings of the Remote Two.
+      summary: 🧪 Active localization settings of the UC Remote.
       tags:
         - name: metadata
       payload:
@@ -610,7 +610,7 @@ components:
       x-response:
         $ref: '#/components/messages/runtime_info'
     runtime_info:
-      summary: 🔍 Driver runtime information from the Remote Two.
+      summary: 🔍 Driver runtime information from the UC Remote.
       tags:
         - name: metadata
       payload:
@@ -619,7 +619,7 @@ components:
     get_entity_states:
       summary: 🚀 🍕 Get the current state of the configured entities.
       description: |
-        Called by the Remote Two when it needs to synchronize the dynamic entity attributes, e.g. after connection setup
+        Called by the UC Remote when it needs to synchronize the dynamic entity attributes, e.g. after connection setup
         or waking up from standby.
         
         The integration should only send the state of the configured entities to reduce communication overhead,
@@ -659,7 +659,7 @@ components:
         The `result` response is to acknowledge the command and to return any immediate failures in case the driver
         already knows it's unable to perform the command due to invalid data, device communication issues etc.
         
-        After successfully executing a command, the Remote Two expects an `entity_change` event with the updated feature 
+        After successfully executing a command, the UC Remote expects an `entity_change` event with the updated feature 
         value(s).
       tags:
         - name: entity
@@ -752,7 +752,7 @@ components:
       summary: 🚀 🍕 Entity state change event.
       description: |
         Emitted when an attribute of an entity changes, e.g. is switched off. Either after an `entity_command` or if the
-        entity is updated manually through a user or an external system. This keeps the Remote Two in sync with the real
+        entity is updated manually through a user or an external system. This keeps the UC Remote in sync with the real
         state of the entity without the need of constant polling.
       tags:
         - name: entity
@@ -764,7 +764,7 @@ components:
     entity_available:
       summary: 🔍 New entity available event.
       description: |
-        Optional event to notify the Remote Two that new entities are available.
+        Optional event to notify the UC Remote that new entities are available.
       tags:
         - name: entity
         - name: event
@@ -774,7 +774,7 @@ components:
     entity_removed:
       summary: 🔍 Entity removed event.
       description: |
-        Optional event to notify the Remote Two that entities were removed and no longer available.
+        Optional event to notify the UC Remote that entities were removed and no longer available.
       tags:
         - name: entity
         - name: event
@@ -1430,7 +1430,7 @@ components:
     enterStandbyEvent:
       description: |
         TODO add standby type in msg_data? E.g. "screen off" & "sleep" for the integration to be notified that the
-        Remote Two is no longer reachable? While the screen is off, the remote API is still running, but might soon go
+        UC Remote is no longer reachable? While the screen is off, the remote API is still running, but might soon go
         into sleep state.
       type: object
       allOf:
@@ -1739,7 +1739,7 @@ components:
         A switch entity can turn something on or off and the current state should be readable by the integration driver.
         
         If the state can't be read, the `readable` option property can be set to `false`. This should be avoided
-        whenever possible, because the Remote Two either has to assume the current state, or the UI needs to ask the
+        whenever possible, because the UC Remote either has to assume the current state, or the UI needs to ask the
         user for the current state.
         
         If the switch controls a light source, then the 'light' entity is usually a better choice.
@@ -2450,6 +2450,10 @@ components:
     versionInfo:
       type: object
       properties:
+        model:
+          description: |
+            Short model identifier of the remote (UCR2 for Remote Two, UCR3 for Remote 3).
+          type: string
         device_name:
           description: Custom name of the remote
           type: string

--- a/integration-api/create-html-docker.sh
+++ b/integration-api/create-html-docker.sh
@@ -5,5 +5,5 @@ readonly OUT_DIR=${PWD}/html
 mkdir -p "$OUT_DIR"
 docker run --rm -it \
   -v "${OUT_DIR}":/app/example \
-  -v "${PWD}/asyncapi.yaml":/app/asyncapi.yaml \
+  -v "${PWD}/UCR-integration-asyncapi.yaml":/app/asyncapi.yaml \
   asyncapi/generator:1.9.2 asyncapi.yaml @asyncapi/html-template@0.25 --force-write -o example

--- a/integration-api/create-html.sh
+++ b/integration-api/create-html.sh
@@ -17,4 +17,4 @@ command -v ag >/dev/null 2>&1 || {
 
 readonly OUT_DIR=html
 mkdir -p $OUT_DIR
-ag asyncapi.yaml @asyncapi/html-template --force-write -o $OUT_DIR
+ag UCR-integration-asyncapi.yaml @asyncapi/html-template --force-write -o $OUT_DIR


### PR DESCRIPTION
Remote Two and Remote 3 share the same APIs. New features in Remote 3 are optional and can be retrieved with feature flags.

- change Remote Two naming to UC Remote, to include also Remote 3.
- Include model_number in public version information.
- Initial RGB button backlight configuration.
  - Static color backlight configuration for all or specific zones.
    No individual color per zone yet. This can be added later.
  - Define backlight zones in button configuration metadata.
- Wireless charging: metadata, temporarily enable & disable.
