### PR TITLE
Enhance media-player entity with media_position_updated_at attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _Changes in the next release_
   - Control the [Logdy](https://logdy.dev/) web-app.
   - New custom TV icon resource identifier: `ctv:`
   - Add query parameter to resource type endpoint to filter items.
+- Media-player entity: new attribute `media_position_updated_at`.
 
 ---
 

--- a/doc/entities/entity_media_player.md
+++ b/doc/entities/entity_media_player.md
@@ -102,39 +102,39 @@ of the media-player UI on the Remote Two.
 Entity attributes are enabled by features and hold the current value of a feature or provide available options.
 Multiple features can act on the same attribute.
 
-| Attribute                  | Features                   | Type    | Values              | Description                                                                 |
-|----------------------------|----------------------------|---------|---------------------|-----------------------------------------------------------------------------|
-| state                      | on_off                     | enum    | [States](#states)   | State of the media player, influenced by the play and power commands.       |
-|                            | toggle                     |         |                     |                                                                             |
-|                            | play_pause, stop           |         |                     |                                                                             |
-| volume                     | volume                     | number  | 0..100              | Current volume level.                                                       |
-|                            | volume_up_down             |         |                     |                                                                             |
-| muted                      | mute_toggle                | boolean |                     | Flag if the volume is muted.                                                |
-|                            | mute, unmute               |         |                     |                                                                             |
-| media_duration             | media_duration             | number  |                     | Media duration in seconds.                                                  |
-| media_position             | media_position             | number  |                     | Current media position in seconds.                                          |
-|                            | play_pause, stop           |         |                     |                                                                             |
-|                            | fast_forward, rewind, seek |         |                     |                                                                             |
-| media_position_updated_at  | media_position             | string  | datetime (ISO 8601) | Optional timestamp when `media_position` was last updated.                  |
-| media_type                 | media_type                 | enum    | _platform specific_ | The type of media being played.                                             |
-| media_image_url            | media_image_url            | string  |                     | URL to retrieve the album art or an image representing what's being played. |
-|                            | play_pause                 |         |                     |                                                                             |
-|                            | next, previous             |         |                     |                                                                             |
-| media_title                | media_title                | string  |                     | Currently playing media information.                                        |
-|                            | play_pause                 |         |                     |                                                                             |
-|                            | next, previous             |         |                     |                                                                             |
-| media_artist               | media_artist               | string  |                     | Currently playing media information.                                        |
-|                            | play_pause                 |         |                     |                                                                             |
-|                            | next, previous             |         |                     |                                                                             |
-| media_album                | media_album                | string  |                     | Currently playing media information.                                        |
-|                            | play_pause                 |         |                     |                                                                             |
-|                            | next, previous             |         |                     |                                                                             |
-| repeat                     | repeat                     | enum    | `OFF`, `ALL`, `ONE` | Current repeat mode.                                                        |
-| shuffle                    | shuffle                    | boolean |                     | Shuffle mode on or off.                                                     |
-| source                     | select_source              | string  |                     | Currently selected media or input source.                                   |
-| source_list                | select_source              | list    | _text items_        | Available media or input sources.                                           |
-| sound_mode                 | select_sound_mode          | string  |                     | Currently selected sound mode.                                              |
-| sound_mode_list            | select_sound_mode          | list    | _text items_        | Available sound modes.                                                      |
+| Attribute                  | Features                   | Type    | Values              | Description                                                                              |
+|----------------------------|----------------------------|---------|---------------------|------------------------------------------------------------------------------------------|
+| state                      | on_off                     | enum    | [States](#states)   | State of the media player, influenced by the play and power commands.                    |
+|                            | toggle                     |         |                     |                                                                                          |
+|                            | play_pause, stop           |         |                     |                                                                                          |
+| volume                     | volume                     | number  | 0..100              | Current volume level.                                                                    |
+|                            | volume_up_down             |         |                     |                                                                                          |
+| muted                      | mute_toggle                | boolean |                     | Flag if the volume is muted.                                                             |
+|                            | mute, unmute               |         |                     |                                                                                          |
+| media_duration             | media_duration             | number  |                     | Media duration in seconds.                                                               |
+| media_position             | media_position             | number  |                     | Current media position in seconds.                                                       |
+|                            | play_pause, stop           |         |                     |                                                                                          |
+|                            | fast_forward, rewind, seek |         |                     |                                                                                          |
+| media_position_updated_at  | media_position             | string  | datetime (ISO 8601) | Optional timestamp when `media_position` was last updated. Requires integration support. |
+| media_type                 | media_type                 | enum    | _platform specific_ | The type of media being played.                                                          |
+| media_image_url            | media_image_url            | string  |                     | URL to retrieve the album art or an image representing what's being played.              |
+|                            | play_pause                 |         |                     |                                                                                          |
+|                            | next, previous             |         |                     |                                                                                          |
+| media_title                | media_title                | string  |                     | Currently playing media information.                                                     |
+|                            | play_pause                 |         |                     |                                                                                          |
+|                            | next, previous             |         |                     |                                                                                          |
+| media_artist               | media_artist               | string  |                     | Currently playing media information.                                                     |
+|                            | play_pause                 |         |                     |                                                                                          |
+|                            | next, previous             |         |                     |                                                                                          |
+| media_album                | media_album                | string  |                     | Currently playing media information.                                                     |
+|                            | play_pause                 |         |                     |                                                                                          |
+|                            | next, previous             |         |                     |                                                                                          |
+| repeat                     | repeat                     | enum    | `OFF`, `ALL`, `ONE` | Current repeat mode.                                                                     |
+| shuffle                    | shuffle                    | boolean |                     | Shuffle mode on or off.                                                                  |
+| source                     | select_source              | string  |                     | Currently selected media or input source.                                                |
+| source_list                | select_source              | list    | _text items_        | Available media or input sources.                                                        |
+| sound_mode                 | select_sound_mode          | string  |                     | Currently selected sound mode.                                                           |
+| sound_mode_list            | select_sound_mode          | list    | _text items_        | Available sound modes.                                                                   |
 
 ### States
 

--- a/doc/entities/entity_media_player.md
+++ b/doc/entities/entity_media_player.md
@@ -102,38 +102,39 @@ of the media-player UI on the Remote Two.
 Entity attributes are enabled by features and hold the current value of a feature or provide available options.
 Multiple features can act on the same attribute.
 
-| Attribute       | Features                   | Type    | Values              | Description                                                                 |
-|-----------------|----------------------------|---------|---------------------|-----------------------------------------------------------------------------|
-| state           | on_off                     | enum    | [States](#states)   | State of the media player, influenced by the play and power commands.       |
-|                 | toggle                     |         |                     |                                                                             |
-|                 | play_pause, stop           |         |                     |                                                                             |
-| volume          | volume                     | number  | 0..100              | Current volume level.                                                       |
-|                 | volume_up_down             |         |                     |                                                                             |
-| muted           | mute_toggle                | boolean |                     | Flag if the volume is muted.                                                |
-|                 | mute, unmute               |         |                     |                                                                             |
-| media_duration  | media_duration             | number  |                     | Media duration in seconds.                                                  |
-| media_position  | media_position             | number  |                     | Current media position in seconds.                                          |
-|                 | play_pause, stop           |         |                     |                                                                             |
-|                 | fast_forward, rewind, seek |         |                     |                                                                             |
-| media_type      | media_type                 | enum    | _platform specific_ | The type of media being played.                                             |
-| media_image_url | media_image_url            | string  |                     | URL to retrieve the album art or an image representing what's being played. |
-|                 | play_pause                 |         |                     |                                                                             |
-|                 | next, previous             |         |                     |                                                                             |
-| media_title     | media_title                | string  |                     | Currently playing media information.                                        |
-|                 | play_pause                 |         |                     |                                                                             |
-|                 | next, previous             |         |                     |                                                                             |
-| media_artist    | media_artist               | string  |                     | Currently playing media information.                                        |
-|                 | play_pause                 |         |                     |                                                                             |
-|                 | next, previous             |         |                     |                                                                             |
-| media_album     | media_album                | string  |                     | Currently playing media information.                                        |
-|                 | play_pause                 |         |                     |                                                                             |
-|                 | next, previous             |         |                     |                                                                             |
-| repeat          | repeat                     | enum    | `OFF`, `ALL`, `ONE` | Current repeat mode.                                                        |
-| shuffle         | shuffle                    | boolean |                     | Shuffle mode on or off.                                                     |
-| source          | select_source              | string  |                     | Currently selected media or input source.                                   |
-| source_list     | select_source              | list    | _text items_        | Available media or input sources.                                           |
-| sound_mode      | select_sound_mode          | string  |                     | Currently selected sound mode.                                              |
-| sound_mode_list | select_sound_mode          | list    | _text items_        | Available sound modes.                                                      |
+| Attribute                  | Features                   | Type    | Values              | Description                                                                 |
+|----------------------------|----------------------------|---------|---------------------|-----------------------------------------------------------------------------|
+| state                      | on_off                     | enum    | [States](#states)   | State of the media player, influenced by the play and power commands.       |
+|                            | toggle                     |         |                     |                                                                             |
+|                            | play_pause, stop           |         |                     |                                                                             |
+| volume                     | volume                     | number  | 0..100              | Current volume level.                                                       |
+|                            | volume_up_down             |         |                     |                                                                             |
+| muted                      | mute_toggle                | boolean |                     | Flag if the volume is muted.                                                |
+|                            | mute, unmute               |         |                     |                                                                             |
+| media_duration             | media_duration             | number  |                     | Media duration in seconds.                                                  |
+| media_position             | media_position             | number  |                     | Current media position in seconds.                                          |
+|                            | play_pause, stop           |         |                     |                                                                             |
+|                            | fast_forward, rewind, seek |         |                     |                                                                             |
+| media_position_updated_at  | media_position             | string  | datetime (ISO 8601) | Optional timestamp when `media_position` was last updated.                  |
+| media_type                 | media_type                 | enum    | _platform specific_ | The type of media being played.                                             |
+| media_image_url            | media_image_url            | string  |                     | URL to retrieve the album art or an image representing what's being played. |
+|                            | play_pause                 |         |                     |                                                                             |
+|                            | next, previous             |         |                     |                                                                             |
+| media_title                | media_title                | string  |                     | Currently playing media information.                                        |
+|                            | play_pause                 |         |                     |                                                                             |
+|                            | next, previous             |         |                     |                                                                             |
+| media_artist               | media_artist               | string  |                     | Currently playing media information.                                        |
+|                            | play_pause                 |         |                     |                                                                             |
+|                            | next, previous             |         |                     |                                                                             |
+| media_album                | media_album                | string  |                     | Currently playing media information.                                        |
+|                            | play_pause                 |         |                     |                                                                             |
+|                            | next, previous             |         |                     |                                                                             |
+| repeat                     | repeat                     | enum    | `OFF`, `ALL`, `ONE` | Current repeat mode.                                                        |
+| shuffle                    | shuffle                    | boolean |                     | Shuffle mode on or off.                                                     |
+| source                     | select_source              | string  |                     | Currently selected media or input source.                                   |
+| source_list                | select_source              | list    | _text items_        | Available media or input sources.                                           |
+| sound_mode                 | select_sound_mode          | string  |                     | Currently selected sound mode.                                              |
+| sound_mode_list            | select_sound_mode          | list    | _text items_        | Available sound modes.                                                      |
 
 ### States
 
@@ -465,8 +466,9 @@ Specify a sound mode value contained in the `sound_mode_list` attribute array.
     "entity_id": "media-1",
     "attributes": {
       "state": "PLAYING",
-      "media_position": 1,
       "media_duration": 245,
+      "media_position": 1,
+      "media_position_updated_at": "2025-03-18T07:30:00.000Z",
       "media_title": "Some title",
       "media_artist": "My artist",
       "media_album": "Best of",

--- a/integration-api/README.md
+++ b/integration-api/README.md
@@ -24,7 +24,7 @@ The provided Bash wrapper script [`create-html-docker.sh`](create-html-docker.sh
 
 | Integration API | UCR2 Firmware | Core Simulator |
 |-----------------|---------------|----------------|
-| 0.12.1          |               |                |
+| 0.12.1          |               | 0.58.3         |
 | 0.12.0          | 1.9.3-beta    | 0.48.0         |
 | 0.11.0          | 1.9.2-beta    | 0.47.0         |
 | 0.10.0          | 1.7.12        | 0.43.0         |

--- a/integration-api/README.md
+++ b/integration-api/README.md
@@ -24,6 +24,7 @@ The provided Bash wrapper script [`create-html-docker.sh`](create-html-docker.sh
 
 | Integration API | UCR2 Firmware | Core Simulator |
 |-----------------|---------------|----------------|
+| 0.12.1          |               |                |
 | 0.12.0          | 1.9.3-beta    | 0.48.0         |
 | 0.11.0          | 1.9.2-beta    | 0.47.0         |
 | 0.10.0          | 1.7.12        | 0.43.0         |

--- a/integration-api/UCR-integration-asyncapi.yaml
+++ b/integration-api/UCR-integration-asyncapi.yaml
@@ -8,7 +8,7 @@ asyncapi: 2.2.0
 id: 'urn:com:unfoldedcircle:integration'
 info:
   title: Remote Two/3 WebSocket Integration API
-  version: '0.12.0-beta'
+  version: '0.12.1-beta'
   contact:
     name: API Support
     url: https://github.com/unfoldedcircle/core-api/issues
@@ -1990,6 +1990,7 @@ components:
                   - seek
                   - media_duration
                   - media_position
+                  - media_position_updated_at
                   - media_title
                   - media_artist
                   - media_album


### PR DESCRIPTION
The core service now propagates the `media_position_updated_at` attribute from integration drivers.
- This attribute is optional and not modified by the core.
- Timezone information is required, UTC is preferred.

Relates to: unfoldedcircle/feature-and-bug-tracker#443