### PR TITLE
docs: Remove an already implemented "missing feature"

### DIFF
--- a/doc/integration-driver/driver-installation.md
+++ b/doc/integration-driver/driver-installation.md
@@ -155,8 +155,6 @@ Example of a Node.js based integration driver archive (contents of bin/node_modu
   - Workaround: remove and re-install.
 - [ ] Resource usage: provide memory and CPU usage per integration.
   - Only the overall resource usage can be monitored with `GET /api/pub/status`.
-- [ ] Web-Configurator support: install custom integration drivers.
-  - Custom integration drivers can already be deleted in the web-configurator.
 
 ### Runtime environment
 


### PR DESCRIPTION
Installing custom integration drivers via the Web Configurator is already possible.

I opted for removing this "missing feature", instead of checking it.

Please let me know, if the sections "install driver" and "delete driver" should be extended with 1 or 2 sentences, that custom integration drivers can be added/deleted via the Web Configurator, too. :)