### PR TITLE
Voice Assistant support

### DIFF
--- a/.github/workflows/asyncapi.yml
+++ b/.github/workflows/asyncapi.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Generate integration AsyncAPI HTML doc
         run: |
           ag ./integration-api/UCR-integration-asyncapi.yaml @asyncapi/html-template -o ./static/api/integration --force-write
+          cp ./integration-api/*.proto ./static/api/integration/ 
 
       - name: Generate dock AsyncAPI HTML doc
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _Changes in the next release_
   - New `sensor` widget for the activity user interface.
 - Media-player entity: new attribute `media_position_updated_at`.
 - Dock 3 external port configuration.
+- Voice Assistant support.
 
 ---
 

--- a/core-api/README.md
+++ b/core-api/README.md
@@ -25,8 +25,9 @@ in YAML format.
 
 ## API Versions
 
-| UCR2 Firmware | Core Simulator | REST API | WS API |
+| UCR Firmware  | Core Simulator | REST API | WS API |
 |---------------|----------------|----------|--------|
+| 2.8.0-beta    | 0.66.4         | 0.43.1   | 0.33.0 |
 | 2.7.2-beta    | 0.65.1         | 0.42.0   | 0.32.0 |
 | 2.6.2-beta    | 0.62.0         | 0.40.0   | 0.31.0 |
 | 2.6.0-beta    | 0.61.5         | 0.39.4   | 0.30.2 |

--- a/core-api/rest/CHANGELOG.md
+++ b/core-api/rest/CHANGELOG.md
@@ -8,11 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This section contains unreleased changes which will be part of an upcoming release.
 
+---
+
+## 0.43.1
 ### Added
 - Touch slider configuration in an activity.
 - Voice assistant configuration in an activity.
+- New entity type `voice_assistant`.
 
----
+### Changed
+- Refactored `CfgVoiceControl` data model for `/cfg/voice_control` and `/cfg/voice_control/voice_assistants` endpoints.
+- Refactored `CfgAll` model: `voice_control` -> `voice`
+- Available entity from integration can now include an icon
 
 ## 0.41.1
 ### Added

--- a/core-api/rest/UCR-core-openapi.yaml
+++ b/core-api/rest/UCR-core-openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Remote Two/3 REST Core-API
-  version: 0.42.0
+  version: 0.43.0
   contact:
     name: API Support
     url: 'https://github.com/unfoldedcircle/core-api/issues'
@@ -7816,13 +7816,15 @@ paths:
         - cfg
       summary: Modify voice control settings.
       description: |
-        Change one or multiple voice control settings.
+        Change one or multiple voice control settings. A missing field will in the request object will keep the old value.
+
+        If the specified voice control entity does not exist, the voice assistant configuration will be removed.
       operationId: updateVoiceControlSettings
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CfgVoiceControl'
+              $ref: '#/components/schemas/CfgVoiceControlUpdate'
         required: true
       responses:
         '200':
@@ -7838,10 +7840,30 @@ paths:
         '403':
           $ref: '#/components/responses/Err403Forbidden'
   /cfg/voice_control/voice_assistants:
+    head:
+      tags:
+        - cfg
+      summary: Get total number of voice assistants.
+      operationId: getVoiceAssistantCount
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            Pagination-Count:
+              description: Total number of items.
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
     get:
       tags:
         - cfg
       summary: Get available voice assistants.
+      parameters:
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
       operationId: getVoiceAssistants
       responses:
         '200':
@@ -7849,9 +7871,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: string
+                $ref: '#/components/schemas/VoiceAssistants'
         '401':
           $ref: '#/components/responses/Err401Unauthorized'
         '403':
@@ -11480,7 +11500,13 @@ components:
           type: string
           description: Status message describing the result or error. This message is intended for error analysis and should not directly shown to the end user.
     AvailableEntity:
-      description: Provided entity from an integration which can be configured to be used in the remote.
+      description: |
+        Provided entity from an integration which can be configured to be used in the remote.
+
+        See [entity documentation](https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/)
+        for more information.
+
+        If no icon identifier is specified, the default icon for the entity type is used.
       type: object
       properties:
         entity_id:
@@ -11498,6 +11524,8 @@ components:
           type: string
         name:
           $ref: '#/components/schemas/LanguageText'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
         features:
           description: |
             Supported features of the entity. See entity documentation for available features.
@@ -11689,7 +11717,7 @@ components:
           $ref: '#/components/schemas/CfgSoftwareUpdate'
         sound:
           $ref: '#/components/schemas/CfgSound'
-        voice_control:
+        voice:
           $ref: '#/components/schemas/CfgVoiceControl'
         restart_required:
           description: A configuration change requires a restart.
@@ -12080,6 +12108,9 @@ components:
         - enabled
         - volume
     CfgVoiceControl:
+      description: |
+        Voice control settings with enriched voice assistant configuration.
+        No voice assistant is enabled if the `voice_assistant.active` object is missing.
       type: object
       properties:
         microphone:
@@ -12088,15 +12119,52 @@ components:
             with the remote or integrations.
           type: boolean
         voice_assistant:
-          description: |
-            The main voice assistant to use for voice control, if no other voice assistant is configured for a specific
-            screen, for example in an activity.
-            - `None`: no voice assistant is enabled.
-          type: string
-          default: None
+          $ref: '#/components/schemas/CfgVoiceAssistant'
       required:
         - microphone
         - voice_assistant
+    CfgVoiceAssistant:
+      description: |
+        The main voice assistant to use for voice control, if no other voice assistant is configured for a specific
+        screen, for example, in an activity.
+      type: object
+      properties:
+        active:
+          $ref: '#/components/schemas/VoiceAssistant'
+        profile_id:
+          $ref: '#/components/schemas/SimpleId'
+        speech_response:
+          description: Enable speech response if supported by the voice assistant. Disabled by default.
+          type: boolean
+          default: false
+    CfgVoiceControlUpdate:
+      description: |
+        Update object for voice control settings. A missing field will keep the old value.
+      type: object
+      properties:
+        microphone:
+          description: |
+            Enable microphone. Disabling the microphone will completely turn it off. Voice control and dictation won't work
+            with the remote or integrations.
+          type: boolean
+        voice_assistant:
+          $ref: '#/components/schemas/CfgVoiceAssistantUpdate'
+    CfgVoiceAssistantUpdate:
+      description: |
+        The main voice assistant to use for voice control, if no other voice assistant is configured for a specific
+        screen, for example, in an activity.
+      type: object
+      properties:
+        entity_id:
+          description: 'Voice assistant entity id to use, empty for removing a configured voice assistant.'
+          type: string
+        profile_id:
+          $ref: '#/components/schemas/SimpleId'
+        speech_response:
+          description: Enable speech response if supported by the voice assistant. Disabled by default.
+          type: boolean
+      required:
+        - entity_id
     CommandSequence:
       description: Sequence of commands to execute.
       type: array
@@ -12917,7 +12985,10 @@ components:
         $ref: '#/components/schemas/Entity'
     Entity:
       description: |
-        Configured entity in the remote to be used in one or more profiles.
+        Configured entity in the remote to be used in one or more user profiles.
+
+        See [entity documentation](https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/)
+        for more information.
       type: object
       properties:
         entity_id:
@@ -13174,6 +13245,7 @@ components:
         - macro
         - remote
         - ir_emitter
+        - voice_assistant
     ExternalSystems:
       type: array
       items:
@@ -15861,6 +15933,88 @@ components:
           $ref: '#/components/schemas/SimpleId'
       required:
         - entity_id
+    VoiceAssistants:
+      type: array
+      items:
+        $ref: '#/components/schemas/VoiceAssistant'
+    VoiceAssistant:
+      description: |
+        Voice assistant definition.
+
+        This is a tailored representation of the voice_assistant entity, which can be used to display voice assistant
+        information to users.
+
+        - `profiles` specify optional parameters that can be used by starting a voice command.
+        - `features` are the default features supported by the voice assistant.  
+           If multiple profiles are supported, this should be the feature list of the preferred profile.
+        - `preferred_profile` is the preferred profile specified by the integration.  
+           The user can select another default profile in the voice assistant settings.
+      type: object
+      properties:
+        entity_id:
+          $ref: '#/components/schemas/EntityId'
+        name:
+          $ref: '#/components/schemas/LanguageText'
+        icon:
+          $ref: '#/components/schemas/IconIdentifier'
+        state:
+          type: string
+        features:
+          $ref: '#/components/schemas/VoiceAssistantFeatures'
+        profiles:
+          $ref: '#/components/schemas/VoiceAssistantProfiles'
+        preferred_profile:
+          $ref: '#/components/schemas/SimpleId'
+      required:
+        - entity_id
+        - name
+    VoiceAssistantFeatures:
+      type: array
+      items:
+        $ref: '#/components/schemas/VoiceAssistantFeature'
+    VoiceAssistantFeature:
+      description: |
+        Supported voice assistant or profile features.
+        - transcription: Supports voice command transcription.
+        - response_text: Supports textual response about the performed action.
+        - response_speech: Supports speech response about the performed action.
+      type: string
+      enum:
+        - transcription
+        - response_text
+        - response_speech
+    VoiceAssistantProfiles:
+      type: array
+      items:
+        $ref: '#/components/schemas/VoiceAssistantProfile'
+    VoiceAssistantProfile:
+      description: |
+        Profiles are optional and allow parameterizing voice input. A regular voice-capable device usually just accepts voice
+        input without additional parameters. Home automation systems can offer multi-language support or an option to use
+        local or cloud processing.
+
+        For example, Home Assistant allows configuring multiple Assist pipelines for voice commands.
+        These pipelines can offer different languages or speech recognition engines.
+
+        - `language` is an optional language code if the profile represents a specific language for speech recognition.
+        - `features` is optional and overwrites the voice assistant features, for example, if a profile has less or more features.
+        - An empty `features` array means "no features".
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/SimpleId'
+        name:
+          description: Friendly name to show in UI.
+          type: string
+          minLength: 1
+          maxLength: 50
+        language:
+          $ref: '#/components/schemas/LanguageCode'
+        features:
+          $ref: '#/components/schemas/VoiceAssistantFeatures'
+      required:
+        - id
+        - name
     ApScanStatus:
       type: object
       properties:

--- a/core-api/websocket/CHANGELOG.md
+++ b/core-api/websocket/CHANGELOG.md
@@ -8,10 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This section contains unreleased changes which will be part of an upcoming release. 
 
-### Changed
-- Initial voice assistant configuration refactoring.
-
 ---
+
+## 0.33.0-beta
+### Changed
+- Voice assistant configuration refactoring.
+### Added
+- New entity type `voice_assistant`.
+- New event: `assistant_event`.
 
 ## 0.31.0-beta
 ### Added

--- a/core-api/websocket/UCR-core-asyncapi.yaml
+++ b/core-api/websocket/UCR-core-asyncapi.yaml
@@ -8,7 +8,7 @@ asyncapi: 2.2.0
 id: 'urn:com:unfoldedcircle:core'
 info:
   title: Remote Two/3 WebSocket Core-API
-  version: '0.32.0-beta'
+  version: '0.33.0-beta'
   contact:
     name: API Support
     url: https://github.com/unfoldedcircle/core-api/issues
@@ -542,6 +542,7 @@ channels:
           - $ref: '#/components/messages/power_mode_change'
           - $ref: '#/components/messages/battery_status'
           - $ref: '#/components/messages/ambient_light_change'
+          - $ref: '#/components/messages/assistant_event'
 
           # TODO define all events and response messages
 #          - $ref: '#/components/messages/log_event'
@@ -874,7 +875,7 @@ components:
         $ref: '#/components/messages/result'
 
     get_battery_charger:
-      summary: 👷 Get battery charger information.
+      summary: 🔍 Get battery charger information.
       description: |
         Device features:
         - `DOCK_CHARGING`: device can be charged in docking station (UCR2, UCR3).
@@ -884,11 +885,11 @@ components:
       x-response:
         $ref: '#/components/messages/battery_charger'
     battery_charger:
-      summary: 👷 Battery charger response.
+      summary: 🔍 Battery charger response.
       payload:
         $ref: '#/components/schemas/batteryChargerMsg'
     update_battery_charger:
-      summary: 👷 Enable or disable wireless charging.
+      summary: 🔍 Enable or disable wireless charging.
       payload:
         $ref: '#/components/schemas/updateBatteryChargerMsg'
       x-response:
@@ -1267,6 +1268,10 @@ components:
         $ref: '#/components/messages/voice_control_cfg'
     set_voice_control_cfg:
       summary: 🔍 Modify voice control settings.
+      description: |
+        Change one or multiple voice control settings. A missing field will in the request object will keep the old value.
+
+        If the specified voice control entity does not exist, the voice assistant configuration will be removed.
       payload:
         $ref: '#/components/schemas/setVoiceControlCfgMsg'
       x-response:
@@ -1276,13 +1281,13 @@ components:
       payload:
         $ref: '#/components/schemas/voiceControlCfgMsg'
     get_voice_assistants:
-      summary: 🚧 Get available voice assistants.
+      summary: 🔍 Get available voice assistants.
       payload:
         $ref: '#/components/schemas/getVoiceAssistantsMsg'
       x-response:
         $ref: '#/components/messages/voice_assistants'
     voice_assistants:
-      summary: 🚧 Voice assistants response.
+      summary: 🔍 Voice assistants response.
       payload:
         $ref: '#/components/schemas/voiceAssistantsMsg'
 
@@ -3079,6 +3084,16 @@ components:
       payload:
         $ref: '#/components/schemas/ambientLightChangeEventMsg'
 
+    assistant_event:
+      summary: 🔍 Assistant event.
+      description: |
+        The `assistant_event` message must be emitted by the integration driver to start the audio
+        stream and for providing optional feedback about the voice command processing and outcome.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/assistantEventMsg'
+
   # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
   schemas:
     # =========================================================================
@@ -4289,7 +4304,7 @@ components:
               type: string
               const: set_voice_control_cfg
             msg_data:
-              $ref: '#/components/schemas/cfgVoiceControl'
+              $ref: '#/components/schemas/CfgVoiceControlUpdate'
           required:
             - msg
             - msg_data
@@ -4302,7 +4317,7 @@ components:
               type: string
               const: voice_control_cfg
             msg_data:
-              $ref: '#/components/schemas/cfgVoiceControl'
+              $ref: '#/components/schemas/CfgVoiceControl'
           required:
             - msg
     getVoiceAssistantsMsg:
@@ -4313,6 +4328,11 @@ components:
             msg:
               type: string
               const: get_voice_assistants
+            msg_data:
+              type: object
+              properties:
+                paging:
+                  $ref: '#/components/schemas/paging'
           required:
             - msg
     voiceAssistantsMsg:
@@ -4324,11 +4344,17 @@ components:
               type: string
               const: voice_assistants
             msg_data:
-              type: array
-              items:
-                type: string
+              type: object
+              properties:
+                paging:
+                  $ref: '#/components/schemas/pagination'
+                entities:
+                  $ref: '#/components/schemas/VoiceAssistants'
+              required:
+                - entities
           required:
             - msg
+            - msg_data
 
     # --- Entity handling
 
@@ -6712,6 +6738,7 @@ components:
             - software_update
             - battery_status
             - ambient_light
+            - assistant
             # TODO define all event channels. Suggestions:
             # - cfg_log
             # - cfg_ui
@@ -7024,6 +7051,23 @@ components:
             - msg
             - msg_data
 
+    assistantEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: assistant_event
+            cat:
+              type: string
+              const: ENTITY
+            msg_data:
+              $ref: '#/components/schemas/AssistantEvent'
+          required:
+            - msg
+            - msg_data
+
     # =========================================================================
     # Event message schemas
     # =========================================================================
@@ -7282,6 +7326,9 @@ components:
     entity: # YIO v1: loaded_entity
       description: |
         Configured entity in the remote to be used in one or more profiles.
+        
+        See [entity documentation](https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/)
+        for more information.
       type: object
       properties:
         entity_id:
@@ -7348,7 +7395,13 @@ components:
         - entity_id
 
     available_entity:
-      description: Provided entity from an integration which can be configured to be used in the remote.
+      description: |
+        Provided entity from an integration which can be configured to be used in the remote.
+        
+        See [entity documentation](https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/)
+        for more information.
+
+        If no icon identifier is specified, the default icon for the entity type is used.
       type: object
       properties:
         entity_id:
@@ -7357,12 +7410,21 @@ components:
           $ref: '#/components/schemas/entityType'
         integration_id:
           $ref: '#/components/schemas/integrationId'
+        device_class:
+          description: |
+            Optional device type. This can be used by the UI to represent the entity with a different
+            icon, behaviour etc. See entity documentation for available device classes.
+          type: string
         name:
           $ref: '#/components/schemas/languageText'
         icon:
           $ref: '#/components/schemas/iconIdentifier'
         features:
           $ref: '#/components/schemas/entityFeatures'
+        options:
+          description: |
+            Feature options. See entity documentation for available options.
+          type: object
         area:
           description: Optional area if supported by the integration. E.g. `Living room`
           type: string
@@ -7400,6 +7462,7 @@ components:
         - macro
         - remote
         - ir_emitter
+        - voice_assistant
 
     ActivityGroup:
       description: |
@@ -7462,8 +7525,6 @@ components:
 
     ActivityGroupOptions:
       description: |
-        👷Not yet finalized!
-
         Activity group specific options, e.g. how delays are handled when switching between activities.
       type: object
       properties:
@@ -7558,8 +7619,8 @@ components:
           $ref: '#/components/schemas/cfgSoftwareUpdate'
         sound:
           $ref: '#/components/schemas/cfgSound'
-        voice_control:
-          $ref: '#/components/schemas/cfgVoiceControl'
+        voice:
+          $ref: '#/components/schemas/CfgVoiceControl'
         restart_required:
           description: A configuration change requires a restart.
           type: boolean
@@ -7962,7 +8023,10 @@ components:
         - enabled
         - volume
 
-    cfgVoiceControl:
+    CfgVoiceControl:
+      description: |
+        Voice control settings with enriched voice assistant configuration.
+        No voice assistant is enabled if the `voice_assistant.active` object is missing.
       type: object
       properties:
         microphone:
@@ -7971,20 +8035,257 @@ components:
             with the remote or integrations.
           type: boolean
         voice_assistant:
-          $ref: '#/components/schemas/voiceAssistant'
+          $ref: '#/components/schemas/CfgVoiceAssistant'
       required:
         - microphone
         - voice_assistant
 
-    voiceAssistant:
+    CfgVoiceAssistant:
       description: |
-        🚧 Not yet finalized!
-        
         The main voice assistant to use for voice control, if no other voice assistant is configured for a specific
-        screen, for example in an activity.
-        - `None`: no voice assistant is enabled.
+        screen, for example, in an activity.
+      type: object
+      properties:
+        active:
+          $ref: '#/components/schemas/VoiceAssistant'
+        profile_id:
+          $ref: '#/components/schemas/simpleId'
+        speech_response:
+          description: Enable speech response if supported by the voice assistant. Disabled by default.
+          type: boolean
+          default: false
+
+    CfgVoiceControlUpdate:
+      description: |
+        Update object for voice control settings. A missing field will keep the old value.
+      type: object
+      properties:
+        microphone:
+          description: |
+            Enable microphone. Disabling the microphone will completely turn it off. Voice control and dictation won't work
+            with the remote or integrations.
+          type: boolean
+        voice_assistant:
+          $ref: '#/components/schemas/CfgVoiceAssistantUpdate'
+
+    CfgVoiceAssistantUpdate:
+      description: |
+        The main voice assistant to use for voice control, if no other voice assistant is configured for a specific
+        screen, for example, in an activity.
+      type: object
+      properties:
+        entity_id:
+          description: Voice assistant entity id to use, empty for removing a configured voice assistant.
+          type: string
+        profile_id:
+          $ref: '#/components/schemas/simpleId'
+        speech_response:
+          description: Enable speech response if supported by the voice assistant. Disabled by default.
+          type: boolean
+      required:
+        - entity_id
+
+    VoiceAssistants:
+      type: array
+      items:
+        $ref: '#/components/schemas/VoiceAssistant'
+
+    VoiceAssistant:
+      description: |
+        Voice assistant definition.
+
+        This is a tailored representation of the voice_assistant entity, which can be used to display voice assistant
+        information to users.
+
+        - `profiles` specify optional parameters that can be used by starting a voice command.
+        - `features` are the default features supported by the voice assistant.  
+           If multiple profiles are supported, this should be the feature list of the preferred profile.
+        - `preferred_profile` is the preferred profile specified by the integration.  
+           The user can select another default profile in the voice assistant settings.
+      type: object
+      properties:
+        entity_id:
+          $ref: '#/components/schemas/entityId'
+        name:
+          $ref: '#/components/schemas/languageText'
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
+        state:
+          type: string
+        features:
+          $ref: '#/components/schemas/VoiceAssistantFeatures'
+        profiles:
+          $ref: '#/components/schemas/VoiceAssistantProfiles'
+        preferred_profile:
+          $ref: '#/components/schemas/simpleId'
+      required:
+        - entity_id
+        - name
+
+    VoiceAssistantFeatures:
+      type: array
+      items:
+        $ref: '#/components/schemas/VoiceAssistantFeature'
+
+    VoiceAssistantFeature:
+      description: |
+        Supported voice assistant or profile features.
+        - transcription: Supports voice command transcription.
+        - response_text: Supports textual response about the performed action.
+        - response_speech: Supports speech response about the performed action.
       type: string
-      default: None
+      enum:
+        - transcription
+        - response_text
+        - response_speech
+
+    VoiceAssistantProfiles:
+      type: array
+      items:
+        $ref: '#/components/schemas/VoiceAssistantProfile'
+
+    VoiceAssistantProfile:
+      description: |
+        Profiles are optional and allow parameterizing voice input. A regular voice-capable device usually just accepts voice
+        input without additional parameters. Home automation systems can offer multi-language support or an option to use
+        local or cloud processing.
+
+        For example, Home Assistant allows configuring multiple Assist pipelines for voice commands.
+        These pipelines can offer different languages or speech recognition engines.
+
+        - `language` is an optional language code if the profile represents a specific language for speech recognition.
+        - `features` is optional and overwrites the voice assistant features, for example, if a profile has less or more features.
+        - An empty `features` array means "no features".
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/simpleId'
+        name:
+          description: Friendly name to show in UI.
+          type: string
+          minLength: 1
+          maxLength: 50
+        language:
+          $ref: '#/components/schemas/languageCode'
+        features:
+          $ref: '#/components/schemas/VoiceAssistantFeatures'
+      required:
+        - id
+        - name
+
+    AssistantEvent:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - ready
+            - stt_response
+            - text_response
+            - speech_response
+            - finished
+            - error
+        entity_id:
+          type: string
+        session_id:
+          type: integer
+          minimum: 0
+        data:
+          type: object
+      required:
+        - type
+        - entity_id
+        - session_id
+      discriminator: type
+      oneOf:
+        - title: Ready
+          properties:
+            type:
+              const: ready
+        - title: SttResponse
+          properties:
+            type:
+              const: stt_response
+            data:
+              $ref: '#/components/schemas/AssistantSttResponse'
+          required:
+            - data
+        - title: TextResponse
+          properties:
+            type:
+              const: text_response
+            data:
+              $ref: '#/components/schemas/AssistantTextResponse'
+          required:
+            - data
+        - title: SpeechResponse
+          properties:
+            type:
+              const: speech_response
+            data:
+              $ref: '#/components/schemas/AssistantSpeechResponse'
+          required:
+            - data
+        - title: Finished
+          properties:
+            type:
+              const: finished
+        - title: Error
+          properties:
+            type:
+              const: error
+            data:
+              $ref: '#/components/schemas/AssistantError'
+          required:
+            - data
+
+    AssistantSttResponse:
+      type: object
+      properties:
+        text:
+          type: string
+      required:
+        - text
+    AssistantTextResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        text:
+          type: string
+      required:
+        - success
+        - text
+    AssistantSpeechResponse:
+      type: object
+      properties:
+        url:
+          type: string
+        mime_type:
+          type: string
+      required:
+        - url
+        - mime_type
+    AssistantError:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/AssistantErrorCode'
+        message:
+          type: string
+      required:
+        - code
+        - message
+    AssistantErrorCode:
+      type: string
+      enum:
+        - SERVICE_UNAVAILABLE
+        - INVALID_AUDIO
+        - NO_TEXT_RECOGNIZED
+        - INTENT_FAILED
+        - TTS_FAILED
+        - TIMEOUT
+        - UNEXPECTED_ERROR
 
     integrationStatus:
       type: object

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -19,6 +19,7 @@
   - [Remote](entities/entity_remote.md)
   - [Sensor](entities/entity_sensor.md)
   - [IR-Emitter](entities/entity_ir_emitter.md)
+  - [Voice Assistant](entities/entity_voice_assistant.md)
 
 # Integration Drivers
 

--- a/doc/entities/README.md
+++ b/doc/entities/README.md
@@ -24,6 +24,7 @@ Supported entities:
 - [Remote](entity_remote.md)
 - [Sensor](entity_sensor.md)
 - [IR-Emitter](entity_ir_emitter.md)
+- [Voice Assistant](entity_voice_assistant.md)
 
 The 🚧 icon within the entity descriptions indicates a planned feature.
 

--- a/doc/entities/entity_voice_assistant.md
+++ b/doc/entities/entity_voice_assistant.md
@@ -1,0 +1,389 @@
+# Voice Assistant Entity
+
+> [!NOTE]
+> The [Home Assistant integration](https://github.com/unfoldedcircle/integration-home-assistant) is used as the first
+> reference implementation, followed by Android TV.
+
+A voice assistant entity interacts with a voice assistant or sends voice commands to voice-capable devices.
+It can request an audio stream from the Remote's microphone when the user pushes the voice button.
+
+This allows forwarding voice commands to the voice control feature of a device, or to a cloud-based voice assistant like
+Amazon Alexa or Google Home.
+
+Please note that an integration does not have direct access to the microphone and cannot initiate voice recording.
+This is only possible by the user pressing the voice button.
+
+## Features
+
+The features describe the capabilities of the voice assistant.
+
+Some devices only offer simple one-way voice command features, where the result of the command is shown or signaled on
+the device itself, for example, with a speech response on a smart speaker.
+The Android TV is such a device; a voice command can be sent, then the result is only shown or played on the TV.
+
+Smart home systems can offer two-way voice command features, where the result(s) of the command is also returned to the
+client.
+Home Assistant offers such functionality with the assist pipeline. The individual processing steps like speech-to-text,
+intent recognition and speech feedback are accessible.
+
+| Name            | R  | W  | Description                                              |
+|-----------------|----|----|----------------------------------------------------------|
+| transcription   | ✅  | ❌  | Speech to text response of the transcribed voice command |
+| response_text   | ✅  | ❌  | Textual response of the performed action                 |
+| response_speech | ✅  | ❌  | Voice response of the performed action                   |
+
+### Attributes
+
+| Attribute | Features  | Type | Values            | Description                     |
+|-----------|-----------|------|-------------------|---------------------------------|
+| state     |           | enum | [States](#states) | Default entity state attribute. |
+
+### States
+
+The entity `state` attribute holds the following values:
+
+| Value    | Description                                                |
+|----------|------------------------------------------------------------|
+| OFF      | The device is ready but the voice feature is not available |
+| ON       | Ready for voice commands                                   |
+
+Also includes the [common entity states](README.md#states).
+
+### Device Classes
+
+None.
+
+### Options
+
+| Name              | Type               | Default | Description                         |
+|-------------------|--------------------|---------|-------------------------------------|
+| audio_cfg         | AudioConfiguration | {}      | Audio stream format                 |
+| profiles          | Profile            | []      | List of supported profiles          |
+| preferred_profile | String             |         | Preferred profile to use as default |
+
+#### Audio Configuration
+
+The default audio stream the integration receives from the Remote is in PCM 16 kHz mono 16-bit signed format.
+Audio chunks are sent every 100–200 ms.
+
+The `audio_cfg` option can specify a different audio format to be sent to the integration.
+If an unsupported audio stream is requested, the default setting is used. For example, if a sample rate of 4 kHz is
+requested, the default sample rate of 16 kHz is used.
+
+The `AudioConfiguration` object of the `audio_stream` option has the following properties:
+
+| Property       | Type   | Default | Description                            |
+|----------------|--------|---------|----------------------------------------|
+| channels       | Number | 1       | Number of audio channels: 1 or 2       |
+| sample_rate    | Number | 16000   | Sample rate of the audio stream in Hz. |
+| sample_format  | enum   | I16     | Audio frame format.                    |
+
+The actual audio stream format is included in the `voice_start` command and in the first
+[`RemoteVoiceBegin` protobuf message](../../integration-api/ucr_integration_voice.proto) when the audio stream is
+started. See the [Integration-API](https://unfoldedcircle.github.io/core-api/integration/) for the full definition.
+
+#### Profiles
+
+The `profiles` option allows specifying a list of voice assistant profiles that can be used by starting a voice command.
+Profiles are optional and allow parameterizing voice input. A regular voice-capable device usually just accepts voice
+input without additional parameters. Home automation systems can offer multi-language support or an option to use
+local or cloud processing.
+
+For example, Home Assistant allows configuring multiple Assist pipelines for voice commands. These pipelines can offer
+different languages or speech recognition engines.
+
+The `Profile` object has the following properties:
+
+| Property        | Type   | Description                                                                                              |
+|-----------------|--------|----------------------------------------------------------------------------------------------------------|
+| id              | String | Profile identifier                                                                                       |
+| name            | String | Friendly name to show in UI                                                                              |
+| language        | String | Optional: language code for speech recognition if the profile represents a specific language             |
+| transcription   | bool   | Optional: supports voice command transcription. Entity feature is used if not specified.                 |
+| response_text   | bool   | Optional: Supports textual response about the performed action. Entity feature is used if not specified. |
+| response_speech | bool   | Optional: Supports speech response about the performed action. Entity feature is used if not specified.  |
+
+The profile identifier can be specified in the `profile_id` parameter of the `voice_start` command.
+
+## Integration API
+
+The following sequence diagram shows the happy message flow of a voice command initiated by the UI. It's a simplified
+representation of the communication between the various components, showing the relevant Core-API and Integration-API
+messages. The interaction between an integration driver and the voice assistant depends on the involved system and
+available features. 
+
+```mermaid
+sequenceDiagram
+    participant U as UI
+    participant R as Remote
+    participant I as Integration
+    participant V as Voice Assistant
+
+    U-)R: voice_start
+    activate R
+    R-->R: check microphone enabled
+    R-)I:  voice_start
+    activate I
+    I--)R: result (ok)
+    R--)U: result (ok)
+    deactivate R
+
+    I->>V: initiate voice command
+    I--)R: assistant_event (ready)
+    deactivate I
+    activate R
+    R--)U: assistant_event (ready)
+    U-->U: show ready
+
+    R-)I:  protobuf: voice_begin
+    activate I
+    I->>V: start voice command
+    loop microphone button pressed
+        R-->R:  get microphone audio chunk
+        R-)I:   protobuf: voice_data
+        I-)V:   relay audio stream
+    end
+    deactivate R
+    
+    U-)+R:  voice_end
+    R--)U: result (ok)
+    R-)-I:  protobuf: voice_end
+    I->>V: stop voice command
+    deactivate I
+    V-->V: processing
+    
+    opt stt_response feature
+        V--)I: STT response
+        I--)R: assistant_event (stt_response)
+        R--)U: assistant_event (stt_response)
+        U-->U: show response
+    end
+    opt text_response feature
+        V--)I: intent response
+        I--)R: assistant_event (text_response)
+        R--)U: assistant_event (text_response)
+        U-->U: show response
+    end
+    opt speech_response feature
+        V--)I: speech response
+        I--)R: assistant_event (speech_response)
+        R--)U: assistant_event (speech_response)
+        U-->U: play audio response
+    end
+    I--)R: assistant_event (finished)
+    R--)U: assistant_event (finished)
+```
+
+### Commands
+
+The integration driver has to implement a handler for the `entity_command` WebSocket message to process the following
+command requests in `msg_data.cmd_id`. See [Integration-API](https://unfoldedcircle.github.io/core-api/integration/)
+for the full message structure.
+
+| cmd_id      | Parameters      | Type               | Description                                                                    |
+|-------------|-----------------|--------------------|--------------------------------------------------------------------------------|
+| voice_start | session_id      | Number             | Audio session identifier that will be used in follow-up binary voice messages. |
+|             | audio_cfg       | AudioConfiguration | Audio stream format used in WS binary messages.                                |
+|             | speech_response | bool               | Optional: enable voice response of the performed action.                       |
+|             | timeout         | Number             | Optional: processing timeout in seconds.                                       |
+|             | profile_id      | String             | Optional: profile used for the voice assistant command.                        |
+
+Notes:
+- The Integration-API only defines the `voice_start` Websocket command.
+- The end-of-stream notification is sent with the Protobuf message `RemoteVoiceEnd`.
+- The Core-API defines `voice_start` and `voice_end` commands. 
+
+#### voice_start
+
+After confirming the `voice_start` command, the audio stream is started and transmitted as binary WebSocket messages
+in protocol buffer format (see [protobuf messages](../../integration-api/ucr_integration_voice.proto)).
+
+- The confirmation message must be sent within 2 seconds, or the user interface might abort the command.
+- If the integration already knows that it can't process voice commands, it needs to send a negative response.
+- The integration must send the `start` event with the provided `session_id`, when it is ready to receive the audio stream.
+- The audio stream is stopped if an `error` event is sent by the integration.
+
+Example:
+```json
+{
+  "kind": "req",
+  "id": 123,
+  "msg": "entity_command",
+  "msg_data": {
+    "entity_type": "voice_assistant",
+    "entity_id": "va-1",
+    "cmd_id": "voice_start",
+    "params": {
+      "session_id": 8,
+      "audio_cfg": {
+        "channels": 1,
+        "sample_rate": 8000,
+        "sample_format": "I16"
+      }
+    }
+  }
+}
+```
+
+### Events
+
+#### Entity change event
+
+The regular `entity_change` event must be emitted by the integration driver if the state of the voice assistant changes.
+For example, if a voice assistant becomes unavailable because a required cloud service is no longer responding.
+
+The following attributes must be included:
+
+| Attribute     | Description                   |
+|---------------|-------------------------------|
+| state         | New entity [state](#states).  |
+
+Example:
+```json
+{
+  "kind": "event",
+  "msg": "entity_change",
+  "cat": "ENTITY",
+  "msg_data": {
+    "entity_type": "voice_assistant",
+    "entity_id": "va-1",
+    "attributes": {
+      "state": "ON"
+    }
+  }
+}
+```
+
+#### Assistant event
+
+The `assistant_event` must be emitted by the integration driver to start the audio stream and for providing optional
+feedback about the voice command processing and outcome.
+
+| Event           | Data      | Type   | Description                                                    |
+|-----------------|-----------|--------|----------------------------------------------------------------|
+| ready           |           |        | Integration is ready to receive voice audio stream.            |
+| stt_response    | text      | string | Optional. Transcribed text from voice audio stream.            |
+| text_response   | text      | string | Optional. Textual response about the performed action.         |
+|                 | success   | bool   | Action result.                                                 |
+| speech_response | url       | string | Optional. Speech response about the performed action.          |
+|                 | mime_type | string |                                                                |
+| finished        |           |        | Voice processing finished.                                     |
+| error           | code      | string | Processing error while sending or processing the audio stream. |
+|                 | message   | string |                                                                |
+
+Supported audio mime types for the `speech_response` event:
+- `audio/mpeg`
+- `audio/mp3`
+- `audio/wav`
+- `audio/x-wav`
+- `audio/ogg`
+- `audio/opus`
+- `audio/webm`
+- `audio/flac`
+- `audio/aac`
+
+See the [Integration-API](https://unfoldedcircle.github.io/core-api/integration/) for the full event definitions.
+
+#### Ready event
+
+The `ready` event is emitted after the `voice_start` command has been confirmed.
+The `session_id` is used to identify the audio stream.
+
+```json
+{
+  "kind": "event",
+  "msg": "assistant_event",
+  "cat": "ENTITY",
+  "msg_data": {
+    "type": "ready",
+    "entity_id": "va-1",
+    "session_id": 8
+  }
+}
+```
+
+##### Speech to text event
+
+```json
+{
+  "kind": "event",
+  "msg": "assistant_event",
+  "cat": "ENTITY",
+  "msg_data": {
+    "type": "stt_response",
+    "entity_id": "va-1",
+    "session_id": 8,
+    "data": {
+      "text": "Switch off the living room lights"
+    }
+  }
+}
+```
+
+
+#### Text response event
+
+```json
+{
+  "kind": "event",
+  "msg": "assistant_event",
+  "cat": "ENTITY",
+  "msg_data": {
+    "type": "text_response",
+    "entity_id": "va-1",
+    "session_id": 8,
+    "data": {
+      "success": true,
+      "text": "Switched off living room lights"
+    }
+  }
+}
+```
+
+#### Speech response event
+
+```json
+{
+  "kind": "event",
+  "msg": "assistant_event",
+  "cat": "ENTITY",
+  "msg_data": {
+    "type": "speech_response",
+    "entity_id": "va-1",
+    "session_id": 8,
+    "data": {
+      "url": "https://smart.home/api/tts_proxy/6ZZGII-UgUfEEI8CbH1TNg.mp3",
+      "media_type": "audio/mpeg"
+    }
+  }
+}
+```
+
+##### Error event
+
+```json
+{
+  "kind": "event",
+  "msg": "assistant_event",
+  "cat": "ENTITY",
+  "msg_data": {
+    "type": "error",
+    "entity_id": "va-1",
+    "session_id": 8,
+    "data": {
+      "code": "NO_TEXT_RECOGNIZED",
+      "message": "I did not understand"
+    }
+  }
+}
+```
+
+Defined error codes:
+- NO_TEXT_RECOGNIZED
+- SERVICE_UNAVAILABLE
+- INVALID_AUDIO
+- NO_TEXT_RECOGNIZED
+- INTENT_FAILED
+- TTS_FAILED
+- TIMEOUT
+- UNEXPECTED_ERROR

--- a/integration-api/README.md
+++ b/integration-api/README.md
@@ -1,6 +1,7 @@
 # WebSocket Integration API
 
 - [AsyncAPI YAML definition](UCR-integration-asyncapi.yaml).
+- [Voice-related protobuf definition](ucr_integration_voice.proto).
 
 - See [/doc folder](../doc/README.md) for the API documentation and further information.
 
@@ -18,12 +19,11 @@ tool with the instructions provided from the generator tool.
 The provided Bash wrapper script [`create-html-docker.sh`](create-html-docker.sh) creates the html documentation in the
 `./html` sub folder.
 
-ℹ️ We will look into using GitHub Pages for publishing the html documentation.
-
 ## API Versions
 
-| Integration API | UCR2 Firmware | Core Simulator |
+| Integration API | UCR Firmware  | Core Simulator |
 |-----------------|---------------|----------------|
+| 0.13.0          | 2.8.0-beta    | 0.64.4         |
 | 0.12.1          | 2.2.4-beta    | 0.58.3         |
 | 0.12.0          | 1.9.3-beta    | 0.48.0         |
 | 0.11.0          | 1.9.2-beta    | 0.47.0         |

--- a/integration-api/UCR-integration-asyncapi.yaml
+++ b/integration-api/UCR-integration-asyncapi.yaml
@@ -8,7 +8,7 @@ asyncapi: 2.2.0
 id: 'urn:com:unfoldedcircle:integration'
 info:
   title: Remote Two/3 WebSocket Integration API
-  version: '0.12.1-beta'
+  version: '0.13.0-beta'
   contact:
     name: API Support
     url: https://github.com/unfoldedcircle/core-api/issues
@@ -156,6 +156,7 @@ channels:
           - $ref: '#/components/messages/entity_change'
           - $ref: '#/components/messages/entity_available'
           - $ref: '#/components/messages/entity_removed'
+          - $ref: '#/components/messages/assistant_event'
           # --- metadata & configuration requests
           - $ref: '#/components/messages/get_version'
           - $ref: '#/components/messages/get_supported_entity_types'
@@ -780,6 +781,17 @@ components:
         - name: event
       payload:
         $ref: '#/components/schemas/entityRemovedEvent'
+
+    assistant_event:
+      summary: 🔍 Assistant event.
+      description: |
+        The `assistant_event` message must be emitted by the integration driver to start the audio
+        stream and for providing optional feedback about the voice command processing and outcome.
+      tags:
+        - name: event
+      payload:
+        $ref: '#/components/schemas/assistantEventMsg'
+
 
   # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
   schemas:
@@ -1538,6 +1550,23 @@ components:
             - msg
             - msg_data
 
+    assistantEventMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonEvent'
+        - properties:
+            msg:
+              type: string
+              const: assistant_event
+            cat:
+              type: string
+              const: ENTITY
+            msg_data:
+              $ref: '#/components/schemas/AssistantEvent'
+          required:
+            - msg
+            - msg_data
+
     # =========================================================================
     # Common schemas
     # =========================================================================
@@ -1668,7 +1697,7 @@ components:
     entity:
       description: |
         Common definition of an entity. Concrete entities are: `cover`, `button`, `climate`, `ir_emitter`, `light`,
-        `media_player`, `remote`,`sensor`, `switch`. 
+        `media_player`, `remote`,`sensor`, `switch`, `voice_assistant`. 
 
         See [entity documentation](https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/)
         for more information.
@@ -1679,6 +1708,8 @@ components:
         the ability to open / close, or a venetian blind with position and tilting features.  
         See [polymorphism support in AsyncAPI specification](https://www.asyncapi.com/docs/specifications/v2.2.0#schemaComposition)
         for more information.
+        
+        If no icon identifier is specified, the default icon for the entity type is used.
       discriminator: entity_type
       type: object
       properties:
@@ -1701,6 +1732,8 @@ components:
           description: |
             Display name of the entity in the UI. An english text should always be provided as fallback option.
           $ref: '#/components/schemas/languageText'
+        icon:
+          $ref: '#/components/schemas/iconIdentifier'
         area:
           description: |
             Optional area if supported by the integration, e.g. `Living room`. This information might be used by the UI
@@ -2141,6 +2174,245 @@ components:
                     🚧 Optional maximum value of the sensor output. This can be used in the UI for graphs or gauges.
                   type: number
 
+    voice_assistant:
+      description: |
+        A voice assistant entity can be used to receive a microphone input stream suitable to send voice commands
+        to a voice assistant.
+      allOf:
+        - $ref: '#/components/schemas/entity'
+        - type: object
+          properties:
+            features:
+              $ref: '#/components/schemas/VoiceAssistantFeatures'
+            options:
+              $ref: '#/components/schemas/VoiceAssistantOptions'
+
+    VoiceAssistantFeatures:
+      type: array
+      items:
+        $ref: '#/components/schemas/VoiceAssistantFeature'
+
+    VoiceAssistantFeature:
+      description: |
+        Supported voice assistant or profile features.
+        - transcription: Supports voice command transcription.
+        - response_text: Supports textual response about the performed action.
+        - response_speech: Supports speech response about the performed action.
+      type: string
+      enum:
+        - transcription
+        - response_text
+        - response_speech
+
+    VoiceAssistantOptions:
+      type: object
+      properties:
+        audio_cfg:
+          $ref: '#/components/schemas/VaAudioConfiguration'
+        profiles:
+          $ref: '#/components/schemas/VoiceAssistantProfiles'
+        preferred_profile:
+          $ref: '#/components/schemas/simpleId'
+
+    VaAudioConfiguration:
+      description: |
+        The audio format to be sent to the integration.
+
+        If an unsupported audio stream is requested, the default setting is used. For example, if a sample rate of
+        4 kHz is requested, the default sample rate of 16 kHz is used.
+      type: object
+      properties:
+        channels:
+          description: Number of audio channels
+          type: integer
+          default: 1
+          minimum: 1
+          maximum: 2
+        sample_rate:
+          description: |
+            Sample rate of the audio stream in Hz.
+          type: integer
+          enum:
+            - 8000
+            - 11025
+            - 16000
+            - 22050
+            - 24000
+            - 44100
+            - 48000
+          default: 16000
+        sample_format:
+          description: Audio frame format.
+          type: string
+          enum:
+            - I16
+            - I32
+            - U16
+            - U32
+            - F32
+          default: I16
+
+    VoiceAssistantProfiles:
+      type: array
+      items:
+        $ref: '#/components/schemas/VoiceAssistantProfile'
+
+    VoiceAssistantProfile:
+      description: |
+        Profiles are optional and allow parameterizing voice input. A regular voice-capable device usually just accepts voice
+        input without additional parameters. Home automation systems can offer multi-language support or an option to use
+        local or cloud processing.
+
+        For example, Home Assistant allows configuring multiple Assist pipelines for voice commands.
+        These pipelines can offer different languages or speech recognition engines.
+
+        - `language` is an optional language code if the profile represents a specific language for speech recognition.
+        - `features` is optional and overwrites the voice assistant features, for example, if a profile has less or more features.
+        - An empty `features` array means "no features".
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/simpleId'
+        name:
+          description: Friendly name to show in UI.
+          type: string
+          minLength: 1
+          maxLength: 50
+        language:
+          $ref: '#/components/schemas/languageCode'
+        features:
+          $ref: '#/components/schemas/VoiceAssistantFeatures'
+      required:
+        - id
+        - name
+
+    AssistantEvent:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - ready
+            - stt_response
+            - text_response
+            - speech_response
+            - finished
+            - error
+        entity_id:
+          type: string
+        session_id:
+          type: integer
+          minimum: 0
+        data:
+          type: object
+      required:
+        - type
+        - entity_id
+        - session_id
+      discriminator: type
+      oneOf:
+        - title: Ready
+          properties:
+            type:
+              const: ready
+        - title: SttResponse
+          properties:
+            type:
+              const: stt_response
+            data:
+              $ref: '#/components/schemas/AssistantSttResponse'
+          required:
+            - data
+        - title: TextResponse
+          properties:
+            type:
+              const: text_response
+            data:
+              $ref: '#/components/schemas/AssistantTextResponse'
+          required:
+            - data
+        - title: SpeechResponse
+          properties:
+            type:
+              const: speech_response
+            data:
+              $ref: '#/components/schemas/AssistantSpeechResponse'
+          required:
+            - data
+        - title: Finished
+          properties:
+            type:
+              const: finished
+        - title: Error
+          properties:
+            type:
+              const: error
+            data:
+              $ref: '#/components/schemas/AssistantError'
+          required:
+            - data
+
+    AssistantSttResponse:
+      type: object
+      properties:
+        text:
+          type: string
+      required:
+        - text
+    AssistantTextResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        text:
+          type: string
+      required:
+        - success
+        - text
+    AssistantSpeechResponse:
+      type: object
+      properties:
+        url:
+          type: string
+          format: url
+        mime_type:
+          description: |
+            MIME type of the audio stream. Supported mime types in the UI application:
+            - `audio/mpeg`
+            - `audio/mp3`
+            - `audio/wav`
+            - `audio/x-wav`
+            - `audio/ogg`
+            - `audio/opus`
+            - `audio/webm`
+            - `audio/flac`
+            - `audio/aac`
+            Unsupported types will be ignored by the UI.
+          type: string
+      required:
+        - url
+        - mime_type
+    AssistantError:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/AssistantErrorCode'
+        message:
+          type: string
+      required:
+        - code
+        - message
+    AssistantErrorCode:
+      type: string
+      enum:
+        - SERVICE_UNAVAILABLE
+        - INVALID_AUDIO
+        - NO_TEXT_RECOGNIZED
+        - INTENT_FAILED
+        - TTS_FAILED
+        - TIMEOUT
+        - UNEXPECTED_ERROR
+
     entityType:
       description: |
         Supported entities, defined as extensible enum: already known entity types are in the enum, but other string
@@ -2157,6 +2429,7 @@ components:
             - sensor
             - remote
             - ir_emitter
+            - voice_assistant
         - {}  # extensible enum: there might be more supported entity types in a newer implementation than defined above
 
     SimpleCommand:
@@ -2579,6 +2852,13 @@ components:
       description: |
         Optional icon identifier. If specified the icon will be set. An empty identifier while updating the object
         removes the existing icon.
+
+    simpleId:
+      type: string
+      format: "^[a-zA-Z0-9\\-_\\.]+$"
+      minLength: 1
+      maxLength: 36
+      description: Simple string identifier, also usable as URL parameter or file identifier.
 
     DeviceButtonMapping:
       type: object

--- a/integration-api/ucr_integration_voice.proto
+++ b/integration-api/ucr_integration_voice.proto
@@ -1,0 +1,83 @@
+// Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
+//
+// Binary voice data definition of the Unfolded Circle WebSocket Integration-API for Remote Two/3.
+// These messages are received in binary WebSocket messages, if the integration supports the voice assistant feature.
+
+syntax = "proto3";
+
+package integration;
+option java_package = "com.unfoldedcircle.integration";
+
+// All available integration messages.
+//
+// Allows direct binary WebSocket message serialization and deserialization.
+message IntegrationMessage {
+  oneof message {
+    // Start of an audio stream session.
+    RemoteVoiceBegin voice_begin = 1;
+    // Audio chunk in an audio stream session.
+    RemoteVoiceData voice_data = 2;
+    // End of an audio stream session.
+    RemoteVoiceEnd voice_end = 3;
+  }
+}
+
+// Supported audio frame formats.
+enum SampleFormat {
+  SAMPLE_FORMAT_UNKNOWN = 0;
+  // Signed 8 bit
+  I8 = 1;
+  // Signed 16 bit
+  I16 = 2;
+  // Signed 32 bit
+  I32 = 3;
+  // Unsigned 8 bit
+  U8 = 4;
+  // Unsigned 16 bit
+  U16 = 5;
+  // Unsigned 32 bit
+  U32 = 6;
+  // Float 32 bit
+  F32 = 7;
+}
+
+// Supported audio codec formats.
+enum AudioFormat {
+  AUDIO_FORMAT_UNKNOWN = 0;
+  PCM = 1;
+}
+
+// Audio stream specification.
+message AudioConfiguration {
+  // Optional. Number of audio channels. Default: 1
+  uint32 channels = 1;
+  // Audio sample rate in Hz.
+  uint32 sample_rate = 2;
+  // Audio sample format.
+  SampleFormat sample_format = 3;
+  // Optional. Default: PCM
+  AudioFormat format = 4;
+}
+
+// Start of an audio stream session.
+// As long as the stream is active, `RemoteVoiceData` messages are sent containing audio chunks.
+message RemoteVoiceBegin {
+  // Audio session identifier that will be used in follow-up RemoteVoicePayload and RemoteVoiceEnd messages.
+  uint32 session_id = 1;
+  // Audio stream specification for data sent in the follow-up RemoteVoicePayload messages.
+  AudioConfiguration configuration = 2;
+}
+
+// Audio chunk in an audio stream session.
+message RemoteVoiceData {
+  // Audio session identifier from RemoteVoiceBegin.
+  uint32 session_id = 1;
+  // Audio chunk.
+  bytes samples = 2;
+}
+
+// End of an audio stream session.
+message RemoteVoiceEnd {
+  // Audio session identifier from RemoteVoiceBegin.
+  uint32 session_id = 1;
+}

--- a/yapp.config
+++ b/yapp.config
@@ -9,3 +9,6 @@ devices/index.html
 
 entities/README.md
 entities/index.html
+
+../../integration-api/ucr_integration_voice.proto
+https://github.com/unfoldedcircle/core-api/tree/main/integration-api/ucr_integration_voice.proto


### PR DESCRIPTION
Initial definition of the new voice_assistant entity.
This is used to start a first proof of concept implementation and for verifying the functionality.

Integration-API enhancement with streaming audio for voice-assistant feature.
The voice stream is sent over the same WebSocket connection, but using binary WebSocket messages with protocol buffers.
Protobuf allows future enhancements if other binary data needs to be exchanged.

Core-API enhancements:
- New entity type `voice_assistant`
- New event: `assistant_event`
- Data models for voice assistant functionality
- Refactored CfgVoiceControl data model for /cfg/voice_control and
  /cfg/voice_control/voice_assistants endpoints.
- Refactored CfgAll model: voice_control -> voice
- Available entity from integration can now include an icon

Integration-API enhancements:
- New entity type `voice_assistant`
- New event: `assistant_event`
- Data models for voice assistant functionality

Supported in firmware v2.8.0 with a reference implementation of Home Assistant Assist in the [Home Assistant integration](https://github.com/unfoldedcircle/integration-home-assistant) v0.14.1