### PR TITLE
feat: add media-player stable_id_support option

### DIFF
--- a/doc/entities/entity_media_player.md
+++ b/doc/entities/entity_media_player.md
@@ -190,10 +190,23 @@ the media player with a different icon, behaviour etc.
 
 Optional features of the media-player entity.
 
-| Name            | Type   | Values | Default | Description                                                                                                                                                                                                                                                                                                           |
-|-----------------|--------|--------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| simple_commands | array  | string | []      | Additional commands the media-player supports, which are not covered in the feature list. See [simple commands](#simple-commands).<br/>Example: `["EXIT", "THUMBS_UP", "THUMBS_DOWN"]`                                                                                                                                |
-| volume_steps    | number | 2..100 | 100     | Number of available volume steps for the set volume command and UI controls.<br/>Examples: 100 = any value between 0..100, 50 = only odd numbers, 3 = \[33, 67, 100] etc. Value 0 = mute.<br/>Note: if the integration receives an "unexpected" number it is required to round up or down to the next matching value. |
+| Name              | Type      | Values | Default     | Description                                                                                                                                                                                                                                                                                                           |
+|-------------------|-----------|--------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| simple_commands   | array     | string | []          | Additional commands the media-player supports, which are not covered in the feature list. See [simple commands](#simple-commands).<br/>Example: `["EXIT", "THUMBS_UP", "THUMBS_DOWN"]`                                                                                                                                |
+| volume_steps      | number    | 2..100 | 100         | Number of available volume steps for the set volume command and UI controls.<br/>Examples: 100 = any value between 0..100, 50 = only odd numbers, 3 = \[33, 67, 100] etc. Value 0 = mute.<br/>Note: if the integration receives an "unexpected" number it is required to round up or down to the next matching value. |
+| stable_id_support | bit field | 0..15  | 5 (bit 0+2) | Stable media-ID support in the `browse` and `search` commands. Default if missing: `5` (Bit 0 and 2) - `browse` and `search` always return stable IDs.                                                                                                                                                                |
+
+#### stable_id_support
+
+The numeric `stable_id_support` value is a bit field that defines which stable IDs are supported by the integration:
+
+- Bit 0: `browse` always returns stable ids.
+- Bit 1: `browse` supports stable ids with the `stable_ids` parameter.
+- Bit 2: `search` always returns stable ids.
+- Bit 3: `search` returns stable ids with the `stable_ids` parameter.
+
+Using the `stable_ids` parameter for `browse` and `search` might incur a runtime cost and should only be used where
+stable ids are persisted, like in the `play_media` command.
 
 ## Integration API
 

--- a/integration-api/README.md
+++ b/integration-api/README.md
@@ -23,7 +23,8 @@ The provided Bash wrapper script [`create-html-docker.sh`](create-html-docker.sh
 
 | Integration API | UCR Firmware | Core Simulator |
 |-----------------|--------------|----------------|
-| 0.15.1          |              | 0.70.4         |
+| 0.15.3          |              | 0.70.7         |
+| 0.15.1          | 2.9.0-beta   | 0.70.4         |
 | 0.13.0          | 2.8.0-beta   | 0.64.4         |
 | 0.12.1          | 2.2.4-beta   | 0.58.3         |
 | 0.12.0          | 1.9.3-beta   | 0.48.0         |

--- a/integration-api/UCR-integration-asyncapi.yaml
+++ b/integration-api/UCR-integration-asyncapi.yaml
@@ -8,7 +8,7 @@ asyncapi: 2.2.0
 id: 'urn:com:unfoldedcircle:integration'
 info:
   title: Remote Two/3 WebSocket Integration API
-  version: '0.15.2-beta'
+  version: '0.15.3-beta'
   contact:
     name: API Support
     url: https://github.com/unfoldedcircle/core-api/issues
@@ -2268,7 +2268,17 @@ components:
                   default: 100
                   minimum: 2
                   maximum: 100
-
+                stable_id_support:
+                  description: |
+                    Bit-field indicating if the `browse` and `search` commands support stable media IDs:
+                    
+                    - Bit 0: `browse` always returns stable ids.
+                    - Bit 1: `browse` supports stable ids with the `stable_ids` parameter.
+                    - Bit 2: `search` always returns stable ids.
+                    - Bit 3: `search` returns stable ids with the `stable_ids` parameter.
+                  type: integer
+                  minimum: 0
+                  default: 5
     MediaSearchFilter:
       description: Media search filter
       type: object


### PR DESCRIPTION
The reason for this option is for integrations like Roon that support stable media IDs with a costly workaround for browsing but not for searching. When using media browsing or searching for selecting a media for immediate playback, then it doesn't matter and stable IDs are not required. But when using it for a play-command in a sequence or as a UI command, a stable media-ID is required.
This new option allows disabling the search feature in the play-media command selection.